### PR TITLE
remove rlimit bumping in extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,6 @@ version = "0.1.0"
 dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
- "libc",
  "nng",
  "prost",
  "shared",

--- a/extractor/Cargo.toml
+++ b/extractor/Cargo.toml
@@ -11,7 +11,6 @@ shared = { path = "../shared" }
 prost = "0.10"
 nng = "1.0.1"
 libbpf-rs = "0.23"
-libc = "0.2"
 
 [build-dependencies]
 libbpf-cargo = "0.23"

--- a/extractor/src/main.rs
+++ b/extractor/src/main.rs
@@ -4,8 +4,6 @@ use std::env;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use libc;
-
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::RingBufferBuilder;
 
@@ -113,17 +111,6 @@ const TRACEPOINTS_VALIDATION: [Tracepoint; 1] = [Tracepoint {
     function: "handle_validation_block_connected",
 }];
 
-fn bump_memlock_rlimit() {
-    let rlimit = libc::rlimit {
-        rlim_cur: 128 << 20,
-        rlim_max: 128 << 20,
-    };
-
-    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
-        panic!("Failed to increase rlimit");
-    }
-}
-
 #[path = "tracing.gen.rs"]
 mod tracing;
 
@@ -134,8 +121,6 @@ fn main() -> Result<(), libbpf_rs::Error> {
 
     let mut skel_builder = tracing::TracingSkelBuilder::default();
     skel_builder.obj_builder.debug(true);
-
-    bump_memlock_rlimit();
 
     let open_skel: OpenTracingSkel = skel_builder.open().unwrap();
     let mut obj: libbpf_rs::Object = match open_skel.obj.load() {


### PR DESCRIPTION
As noticed by @i-am-yuvi recently, bumping the rlimit is not required (anymore).

It turns out that, since libbpf commit https://github.com/libbpf/libbpf/commit/216eaa760edf06f3521d5d49a419515607c1f38e, the rlimit bump in downstream applications isn't needed anymore as libbpf handles it, if needed.