### PR TITLE
Use clap for command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
@@ -449,11 +449,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
@@ -880,6 +880,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1421,7 +1427,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -1678,6 +1684,7 @@ version = "0.1.0"
 dependencies = [
  "base32",
  "bitcoin",
+ "clap",
  "hex",
  "prost",
  "prost-build",
@@ -1736,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
@@ -1746,7 +1753,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,6 +10,7 @@ prost = "0.10.4"
 bitcoin = "0.32"
 base32 = "0.4.0" # for encoding Tor/Onion addresses
 serde = { version = "1.0.203", features = ["derive"] }
+clap = { version = "4.5.13", features = ["derive"] }
 
 [build-dependencies]
 prost-build = "0.10"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 pub extern crate bitcoin;
+pub extern crate clap;
 pub extern crate prost;
 
 pub mod addrman;

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -3,16 +3,26 @@
 use nng::options::protocol::pubsub::Subscribe;
 use nng::options::Options;
 use nng::{Protocol, Socket};
-
+use shared::clap;
+use shared::clap::Parser;
 use shared::event_msg;
 use shared::event_msg::event_msg::Event;
 use shared::prost::Message;
 
-const ADDRESS: &'static str = "tcp://127.0.0.1:8883";
+/// Simple peer-observer tool that logs all received event messages
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    // The extractor address the tool should connect to.
+    #[arg(short, long, default_value = "tcp://127.0.0.1:8883")]
+    address: String,
+}
 
 fn main() {
+    let args = Args::parse();
+
     let sub = Socket::new(Protocol::Sub0).unwrap();
-    sub.dial(ADDRESS).unwrap();
+    sub.dial(&args.address).unwrap();
 
     let all_topics = vec![];
     sub.set_opt::<Subscribe>(all_topics).unwrap();


### PR DESCRIPTION
Fixes #28.

The clap-based command line arguments not provide a `--help`, `--version`, and usage hints. It's also explicit what's needed and what's used as default.

For example, the extractor help now shows:

```
$ extractor --help
The peer-observer extractor Hooks into a Bitcoin Core binary with tracepoints and extracts events from it into a nanomsg PUB-SUB queue

Usage: extractor [OPTIONS] --bitcoind-path <BITCOIND_PATH>

Options:
  -a, --address <ADDRESS>              TCP socket the nanomsg publisher binds on [default: tcp://127.0.0.1:8883]
  -b, --bitcoind-path <BITCOIND_PATH>  Path to the Bitcoin Core (bitcoind) binary that should be hooked into
      --no-p2pmsg-tracepoints          Controls if the p2p message tracepoints should be hooked into
      --no-connection-tracepoints      Controls if the connection tracepoints should be hooked into
      --no-mempool-tracepoints         Controls if the mempool tracepoints should be hooked into
      --no-validation-tracepoints      Controls if the validation tracepoints should be hooked into
      --addrman-tracepoints            Controls if the addrman tracepoints should be hooked into. These may not have been PRed to Bitcoin Core yet
  -h, --help                           Print help
  -V, --version                        Print version
```   