### PR TITLE
update: ubuntu ci checkout v3 -> v4

### DIFF
--- a/.github/workflows/rust-ubuntu.yml
+++ b/.github/workflows/rust-ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
           binutils-dev \
           elfutils \
           gcc-multilib
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose --all-features
     - name: Run tests


### PR DESCRIPTION
Also renames `rust.yml` to `rust-ubuntu.yml`.