### PR TITLE
add: closed connection age counter metric

### DIFF
--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
                     handle_p2p_message(&msg, unwrapped.timestamp);
                 }
                 Event::Conn(c) => {
-                    handle_connection_event(c.event.unwrap());
+                    handle_connection_event(c.event.unwrap(), unwrapped.timestamp);
                 }
                 Event::Addrman(a) => {
                     handle_addrman_event(&a.event.unwrap());
@@ -121,7 +121,7 @@ fn main() {
         }
     }
 
-    fn handle_connection_event(cevent: connection_event::Event) {
+    fn handle_connection_event(cevent: connection_event::Event, timestamp: u64) {
         match cevent {
             connection_event::Event::Inbound(i) => {
                 let ip = util::ip_from_ipport(i.conn.addr);
@@ -161,6 +161,7 @@ fn main() {
             connection_event::Event::Closed(c) => {
                 let ip = util::ip_from_ipport(c.conn.addr);
                 metrics::CONN_CLOSED.inc();
+                metrics::CONN_CLOSED_AGE.inc_by(timestamp - c.time_established);
                 metrics::CONN_CLOSED_NETWORK
                     .with_label_values(&[&c.conn.network.to_string()])
                     .inc();

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -341,6 +341,14 @@ lazy_static! {
             .subsystem(SUBSYSTEM_CONN),
     ).unwrap();
 
+    /// Age (in seconds) of closed connections.
+    pub static ref CONN_CLOSED_AGE: IntCounter =
+    register_int_counter!(
+        Opts::new("closed_age_seconds", "Age (in seconds) of closed connections. The age of each closed connection is added to the metric.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_CONN),
+    ).unwrap();
+
     /// Number of closed connections by network.
     pub static ref CONN_CLOSED_NETWORK: IntCounterVec =
     register_int_counter_vec!(


### PR DESCRIPTION
```
# HELP peerobserver_conn_closed_age_seconds Age (in seconds) of closed connections. The age of each closed connection is added to the metric.
# TYPE peerobserver_conn_closed_age_seconds counter
peerobserver_conn_closed_age_seconds 67
```

closes https://github.com/0xB10C/peer-observer/issues/35