### PR TITLE
Improve logging of tools and extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,6 @@ dependencies = [
  "crossbeam",
  "csv",
  "lazy_static",
- "log",
  "nng",
  "prometheus",
  "rand",
@@ -1130,7 +1129,6 @@ name = "metrics"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
- "log",
  "nng",
  "prometheus",
  "shared",
@@ -1653,6 +1651,7 @@ dependencies = [
  "bitcoin",
  "clap",
  "hex",
+ "log",
  "prost",
  "prost-build",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,6 @@ dependencies = [
  "rand",
  "serde",
  "shared",
- "simple_logger 4.2.0",
 ]
 
 [[package]]
@@ -1135,7 +1134,6 @@ dependencies = [
  "nng",
  "prometheus",
  "shared",
- "simple_logger 5.0.0",
 ]
 
 [[package]]
@@ -1658,18 +1656,7 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
-]
-
-[[package]]
-name = "simple_logger"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230cd5c29b815c9b699fb610b49a5ed65588f3509d9f0108be3a885da629333"
-dependencies = [
- "colored",
- "log",
- "time",
- "windows-sys 0.42.0",
+ "simple_logger",
 ]
 
 [[package]]
@@ -2091,21 +2078,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2154,12 +2126,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -2169,12 +2135,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2190,12 +2150,6 @@ checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -2205,12 +2159,6 @@ name = "windows_i686_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2226,12 +2174,6 @@ checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -2244,12 +2186,6 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -2259,12 +2195,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,6 +11,7 @@ bitcoin = "0.32"
 base32 = "0.4.0" # for encoding Tor/Onion addresses
 serde = { version = "1.0.203", features = ["derive"] }
 clap = { version = "4.5.13", features = ["derive"] }
+simple_logger = "5.0.0"
 
 [build-dependencies]
 prost-build = "0.10"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,6 +12,7 @@ base32 = "0.4.0" # for encoding Tor/Onion addresses
 serde = { version = "1.0.203", features = ["derive"] }
 clap = { version = "4.5.13", features = ["derive"] }
 simple_logger = "5.0.0"
+log = "0.4"
 
 [build-dependencies]
 prost-build = "0.10"

--- a/shared/src/ctypes.rs
+++ b/shared/src/ctypes.rs
@@ -468,19 +468,19 @@ fn decode_weird_network_message(
         "addrv2" => {
             if meta.msg_size == 0 {
                 // case: empty addrv2 message.
-                println!("emtpy addrv2: {}", meta);
+                log::debug!("emtpy addrv2: {}", meta);
                 return Some(net_msg::message::Msg::Emptyaddrv2(true));
             }
         }
         "ping" => {
             if meta.msg_size == 0 {
                 // case: old ping message with no nonce.
-                println!("no-value ping: {}", meta);
+                log::debug!("no-value ping: {}", meta);
                 return Some(net_msg::message::Msg::Oldping(true));
             }
         }
         "tx" => {
-            println!(
+            log::debug!(
                 "invalid (?) tx with {} byte: {}",
                 meta.msg_size,
                 payload.to_lower_hex_string(),

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub extern crate bitcoin;
 pub extern crate clap;
+pub extern crate log;
 pub extern crate prost;
 pub extern crate simple_logger;
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,6 +3,7 @@
 pub extern crate bitcoin;
 pub extern crate clap;
 pub extern crate prost;
+pub extern crate simple_logger;
 
 pub mod addrman;
 pub mod ctypes;

--- a/tools/connectivity-check/Cargo.toml
+++ b/tools/connectivity-check/Cargo.toml
@@ -14,7 +14,6 @@ rand = "0.8.5"
 prometheus = "0.13.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
-simple_logger = "4.0.0"
 csv = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/tools/connectivity-check/Cargo.toml
+++ b/tools/connectivity-check/Cargo.toml
@@ -13,7 +13,6 @@ crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rand = "0.8.5"
 prometheus = "0.13.3"
 lazy_static = "1.4.0"
-log = "0.4.17"
 csv = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/tools/connectivity-check/src/metricserver.rs
+++ b/tools/connectivity-check/src/metricserver.rs
@@ -1,3 +1,5 @@
+use prometheus::Encoder;
+use shared::log;
 use std::error;
 use std::fmt;
 use std::io;
@@ -6,8 +8,6 @@ use std::net::TcpListener;
 use std::net::TcpStream;
 use std::string::FromUtf8Error;
 use std::thread;
-
-use prometheus::Encoder;
 
 const LOG_TARGET: &str = "metricserver";
 

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -7,7 +7,9 @@ use shared::clap;
 use shared::clap::Parser;
 use shared::event_msg;
 use shared::event_msg::event_msg::Event;
+use shared::log;
 use shared::prost::Message;
+use shared::simple_logger;
 
 /// Simple peer-observer tool that logs all received event messages
 #[derive(Parser, Debug)]
@@ -16,10 +18,17 @@ struct Args {
     // The extractor address the tool should connect to.
     #[arg(short, long, default_value = "tcp://127.0.0.1:8883")]
     address: String,
+    // The log level the tool should run on. Events are logged with
+    // the INFO log level. Valid log levels are "trace", "debug",
+    // "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    log_level: log::Level,
 }
 
 fn main() {
     let args = Args::parse();
+
+    simple_logger::init_with_level(args.log_level).unwrap();
 
     let sub = Socket::new(Protocol::Sub0).unwrap();
     sub.dial(&args.address).unwrap();
@@ -34,7 +43,7 @@ fn main() {
         if let Some(event) = unwrapped {
             match event {
                 Event::Msg(msg) => {
-                    println! {
+                    log::info! {
                         "{} {} id={} (conn_type={:?}): {}",
                         if msg.meta.inbound { "<--"} else { "-->" },
                         if msg.meta.inbound { "from"} else { "to" },
@@ -44,22 +53,22 @@ fn main() {
                     };
                 }
                 Event::Conn(c) => {
-                    println! {
+                    log::info! {
                         "# CONN {}", c.event.unwrap()
                     };
                 }
                 Event::Addrman(a) => {
-                    println! {
+                    log::info! {
                         "@Addrman {}", a.event.unwrap()
                     };
                 }
                 Event::Mempool(m) => {
-                    println! {
+                    log::info! {
                         "$Mempool {}", m.event.unwrap()
                     };
                 }
                 Event::Validation(v) => {
-                    println! {
+                    log::info! {
                         "+Validation {}", v.event.unwrap()
                     };
                 }

--- a/tools/metrics/Cargo.toml
+++ b/tools/metrics/Cargo.toml
@@ -8,10 +8,7 @@ shared = { path = "../../shared" }
 
 prometheus = "0.13.0"
 lazy_static = "1.4.0"
-
 log = "0.4.14"
-simple_logger = "5.0.0"
-
 nng = "1.0.1"
 
 [features]

--- a/tools/metrics/Cargo.toml
+++ b/tools/metrics/Cargo.toml
@@ -8,7 +8,6 @@ shared = { path = "../../shared" }
 
 prometheus = "0.13.0"
 lazy_static = "1.4.0"
-log = "0.4.14"
 nng = "1.0.1"
 
 [features]

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -8,6 +8,7 @@ use shared::clap;
 use shared::clap::Parser;
 use shared::event_msg;
 use shared::event_msg::event_msg::Event;
+use shared::log;
 use shared::mempool::mempool_event;
 use shared::net_conn::connection_event;
 use shared::net_msg;

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -13,9 +13,9 @@ use shared::net_conn::connection_event;
 use shared::net_msg;
 use shared::net_msg::{message::Msg, reject::RejectReason};
 use shared::prost::Message;
+use shared::simple_logger::SimpleLogger;
 use shared::util;
 use shared::validation::validation_event;
-use simple_logger::SimpleLogger;
 use std::collections::HashMap;
 use std::time;
 

--- a/tools/metrics/src/metricserver.rs
+++ b/tools/metrics/src/metricserver.rs
@@ -1,3 +1,5 @@
+use prometheus::Encoder;
+use shared::log;
 use std::error;
 use std::fmt;
 use std::io;
@@ -6,8 +8,6 @@ use std::net::TcpListener;
 use std::net::TcpStream;
 use std::string::FromUtf8Error;
 use std::thread;
-
-use prometheus::Encoder;
 
 const LOG_TARGET: &str = "metricserver";
 


### PR DESCRIPTION
flowing up on https://github.com/0xB10C/peer-observer/pull/42

from #46: 

- [x] move the `simple_logger` dependency into `shared` to have only one place to upgrade and to be sure we're only using one version across all tools
- [x] replace all `println!` macros with their respective `log:<level>!` macros
- [x] insert `SimpleLogger::new().init()` at startup
- [x]  make logging levels configurable through clap

Closes https://github.com/0xB10C/peer-observer/issues/46
