### PR TITLE
refactor: extract nng crate to shared module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,11 +471,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -496,7 +495,6 @@ dependencies = [
  "crossbeam",
  "csv",
  "lazy_static",
- "nng",
  "prometheus",
  "rand",
  "serde",
@@ -722,7 +720,6 @@ version = "0.1.0"
 dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
- "nng",
  "prost",
  "shared",
 ]
@@ -957,17 +954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.13",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1082,6 @@ dependencies = [
 name = "logger"
 version = "0.1.0"
 dependencies = [
- "nng",
  "shared",
 ]
 
@@ -1129,7 +1114,6 @@ name = "metrics"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
- "nng",
  "prometheus",
  "shared",
 ]
@@ -1210,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
@@ -1652,6 +1636,7 @@ dependencies = [
  "clap",
  "hex",
  "log",
+ "nng",
  "prost",
  "prost-build",
  "serde",
@@ -2035,7 +2020,6 @@ version = "0.1.0"
 dependencies = [
  "async-broadcast",
  "async-std",
- "nng",
  "serde_json",
  "shared",
  "tungstenite",

--- a/extractor/Cargo.toml
+++ b/extractor/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 shared = { path = "../shared" }
 
 prost = "0.10"
-nng = "1.0.1"
 libbpf-rs = "0.23"
 
 [build-dependencies]

--- a/extractor/src/main.rs
+++ b/extractor/src/main.rs
@@ -2,7 +2,6 @@
 
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::RingBufferBuilder;
-use nng::{Protocol, Socket};
 use prost::Message;
 use shared::clap;
 use shared::clap::Parser;
@@ -14,6 +13,7 @@ use shared::ctypes::{
 use shared::event_msg::event_msg::Event;
 use shared::event_msg::EventMsg;
 use shared::log;
+use shared::nng::{Protocol, Socket};
 use shared::simple_logger;
 use shared::{addrman, mempool, net_conn, net_msg, validation};
 use std::time::Duration;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 clap = { version = "4.5.13", features = ["derive"] }
 simple_logger = "5.0.0"
 log = "0.4"
+nng = "1.0.1"
 
 [build-dependencies]
 prost-build = "0.10"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,6 +3,7 @@
 pub extern crate bitcoin;
 pub extern crate clap;
 pub extern crate log;
+pub extern crate nng;
 pub extern crate prost;
 pub extern crate simple_logger;
 

--- a/tools/connectivity-check/Cargo.toml
+++ b/tools/connectivity-check/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 shared = { path = "../../shared" }
 
-nng = "1.0.1"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 rand = "0.8.5"
 prometheus = "0.13.3"

--- a/tools/connectivity-check/src/main.rs
+++ b/tools/connectivity-check/src/main.rs
@@ -2,9 +2,6 @@
 
 use crossbeam;
 use crossbeam::channel::{unbounded, Receiver, Sender};
-use nng::options::protocol::pubsub::Subscribe;
-use nng::options::Options;
-use nng::{Protocol, Socket};
 use rand::Rng;
 use shared::bitcoin::consensus::{encode, Decodable};
 use shared::bitcoin::p2p::message::NetworkMessage;
@@ -18,6 +15,9 @@ use shared::event_msg::event_msg::Event;
 use shared::log;
 use shared::net_msg::message::Msg;
 use shared::net_msg::Message as NetMessage;
+use shared::nng::options::protocol::pubsub::Subscribe;
+use shared::nng::options::Options;
+use shared::nng::{Protocol, Socket};
 use shared::primitive::address::Address as AddressType;
 use shared::primitive::Address;
 use shared::prost::Message as ProstMessage;

--- a/tools/logger/Cargo.toml
+++ b/tools/logger/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 [dependencies]
 shared = { path = "../../shared" }
 
-nng = "1.0.1"
-
 [features]
 # Treat warnings as a build error.
 strict = []

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
-use nng::options::protocol::pubsub::Subscribe;
-use nng::options::Options;
-use nng::{Protocol, Socket};
 use shared::clap;
 use shared::clap::Parser;
 use shared::event_msg;
 use shared::event_msg::event_msg::Event;
 use shared::log;
+use shared::nng::options::protocol::pubsub::Subscribe;
+use shared::nng::options::Options;
+use shared::nng::{Protocol, Socket};
 use shared::prost::Message;
 use shared::simple_logger;
 

--- a/tools/metrics/Cargo.toml
+++ b/tools/metrics/Cargo.toml
@@ -8,7 +8,6 @@ shared = { path = "../../shared" }
 
 prometheus = "0.13.0"
 lazy_static = "1.4.0"
-nng = "1.0.1"
 
 [features]
 # Treat warnings as a build error.

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
-use nng::options::protocol::pubsub::Subscribe;
-use nng::options::Options;
-use nng::{Protocol, Socket};
 use shared::addrman::addrman_event;
 use shared::clap;
 use shared::clap::Parser;
@@ -13,6 +10,9 @@ use shared::mempool::mempool_event;
 use shared::net_conn::connection_event;
 use shared::net_msg;
 use shared::net_msg::{message::Msg, reject::RejectReason};
+use shared::nng::options::protocol::pubsub::Subscribe;
+use shared::nng::options::Options;
+use shared::nng::{Protocol, Socket};
 use shared::prost::Message;
 use shared::simple_logger::SimpleLogger;
 use shared::util;

--- a/tools/websocket/Cargo.toml
+++ b/tools/websocket/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
-nng = "1.0.1"
 tungstenite = "0.21.0"
 async-std = { version = "1.12.0", features = ["attributes"] }
 async-broadcast = "0.7.0"

--- a/tools/websocket/src/main.rs
+++ b/tools/websocket/src/main.rs
@@ -2,12 +2,12 @@
 
 use async_broadcast::broadcast;
 use async_std::task;
-use nng::options::protocol::pubsub::Subscribe;
-use nng::options::Options;
-use nng::{Protocol, Socket};
 use shared::event_msg;
 use shared::event_msg::event_msg::Event;
 use shared::log;
+use shared::nng::options::protocol::pubsub::Subscribe;
+use shared::nng::options::Options;
+use shared::nng::{Protocol, Socket};
 use shared::prost::Message;
 use shared::simple_logger;
 use std::net::TcpListener;


### PR DESCRIPTION
Allows us to update everything in one place and makes sure the extractor and all tools always have the same version.

closes https://github.com/0xB10C/peer-observer/issues/47