### PR TITLE
a few clap and logging fixups

### DIFF
--- a/extractor/src/main.rs
+++ b/extractor/src/main.rs
@@ -145,8 +145,8 @@ struct Args {
     #[arg(long)]
     addrman_tracepoints: bool,
 
-    // The log level the extractor should run with. Valid log levels are "trace",
-    // "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
+    /// The log level the extractor should run with. Valid log levels are "trace",
+    /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = log::Level::Debug)]
     log_level: log::Level,
 }

--- a/tools/connectivity-check/src/main.rs
+++ b/tools/connectivity-check/src/main.rs
@@ -42,21 +42,20 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const READ_TIMEOUT: Duration = Duration::from_secs(5);
 const RECENT_CONNECTION_DURATION: Duration = Duration::from_secs(60 * 60);
 
-/// Simple peer-observer tool that checks the connectivity of received addr message entries
+/// A peer-observer tool that checks the connectivity of received addr message entries
 /// and offers stats as prometheus metrics
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // The extractor address the tool should connect to.
+    /// The extractor address the tool should connect to.
     #[arg(short, long, default_value = "tcp://127.0.0.1:8883")]
     address: String,
-    // The metrics server address the tool should listen on.
+    /// The metrics server address the tool should listen on.
     #[arg(short, long, default_value = "127.0.0.1:18282")]
     metrics_address: String,
-
-    // The log level the tool should run with.
-    // Valid log levels are "trace", "debug", "info", "warn",
-    // "error". See https://docs.rs/log/latest/log/enum.Level.html
+    /// The log level the tool should run with.
+    /// Valid log levels are "trace", "debug", "info", "warn",
+    /// "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = log::Level::Debug)]
     log_level: log::Level,
 }

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -11,16 +11,16 @@ use shared::nng::{Protocol, Socket};
 use shared::prost::Message;
 use shared::simple_logger;
 
-/// Simple peer-observer tool that logs all received event messages
+/// A peer-observer tool that logs all received event messages
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // The extractor address the tool should connect to.
+    /// The extractor address the tool should connect to.
     #[arg(short, long, default_value = "tcp://127.0.0.1:8883")]
     address: String,
-    // The log level the tool should run on. Events are logged with
-    // the INFO log level. Valid log levels are "trace", "debug",
-    // "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
+    /// The log level the tool should run on. Events are logged with
+    /// the INFO log level. Valid log levels are "trace", "debug",
+    /// "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = log::Level::Debug)]
     log_level: log::Level,
 }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -25,14 +25,14 @@ mod metricserver;
 
 const LOG_TARGET: &str = "main";
 
-/// Simple peer-observer tool that produces Prometheus metrics for received event messages
+/// A peer-observer tool that produces Prometheus metrics for received events
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    // The extractor address the tool should connect to.
+    /// The extractor address the tool should connect to.
     #[arg(short, long, default_value = "tcp://127.0.0.1:8883")]
     address: String,
-    // The metrics server address the tool should listen on.
+    /// The metrics server address the tool should listen on.
     #[arg(short, long, default_value = "127.0.0.1:8282")]
     metrics_address: String,
 }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -14,7 +14,7 @@ use shared::nng::options::protocol::pubsub::Subscribe;
 use shared::nng::options::Options;
 use shared::nng::{Protocol, Socket};
 use shared::prost::Message;
-use shared::simple_logger::SimpleLogger;
+use shared::simple_logger;
 use shared::util;
 use shared::validation::validation_event;
 use std::collections::HashMap;
@@ -35,14 +35,16 @@ struct Args {
     /// The metrics server address the tool should listen on.
     #[arg(short, long, default_value = "127.0.0.1:8282")]
     metrics_address: String,
+    /// The log level the tool should run with. Valid log levels
+    /// are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    log_level: log::Level,
 }
 
 fn main() {
     let args = Args::parse();
 
-    SimpleLogger::new()
-        .init()
-        .expect("Could not setup logging.");
+    simple_logger::init_with_level(args.log_level).unwrap();
 
     log::info!(target: LOG_TARGET, "Starting metrics-server...",);
 


### PR DESCRIPTION
- the arg struct comments have to be `///` to show up in the --help output of the binary
- the metrics tool didn't have a log level argument