### PR TITLE
add: spy-detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,20 +609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,7 +1673,6 @@ dependencies = [
 name = "spy-detector"
 version = "0.1.0"
 dependencies = [
- "dashmap",
  "shared",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,20 +415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets 0.52.4",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,12 +500,6 @@ dependencies = [
  "serde",
  "shared",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -952,29 +917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,15 +1163,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "num_cpus"
@@ -1754,10 +1687,7 @@ dependencies = [
 name = "spy-detector"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "dashmap",
- "log",
- "nng",
  "shared",
 ]
 
@@ -2139,15 +2069,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.4",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +192,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.4.0",
- "rustix 0.38.13",
+ "rustix 0.38.38",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -415,6 +430,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +529,12 @@ dependencies = [
  "serde",
  "shared",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -609,6 +644,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,23 +696,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -914,6 +952,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1055,9 +1116,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1071,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
@@ -1160,6 +1221,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1306,7 +1376,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.13",
+ "rustix 0.38.38",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1511,15 +1581,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1681,6 +1751,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spy-detector"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "log",
+ "nng",
+ "shared",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,7 +1811,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall",
- "rustix 0.38.13",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -2034,7 +2115,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -2058,6 +2139,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
   "tools/logger",
   "tools/websocket",
   "tools/metrics",
-  "tools/connectivity-check",
+  "tools/connectivity-check", "tools/spy-detector",
 ]

--- a/tools/spy-detector/Cargo.toml
+++ b/tools/spy-detector/Cargo.toml
@@ -4,8 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nng = "1.0.1"
 dashmap = "6.1.0"
-chrono = "0.4.38"
 shared = { path = "../../shared" }
-log = "0.4.22"

--- a/tools/spy-detector/Cargo.toml
+++ b/tools/spy-detector/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spy-detector"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nng = "1.0.1"
+dashmap = "6.1.0"
+chrono = "0.4.38"
+shared = { path = "../../shared" }
+log = "0.4.22"

--- a/tools/spy-detector/Cargo.toml
+++ b/tools/spy-detector/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dashmap = "6.1.0"
 shared = { path = "../../shared" }

--- a/tools/spy-detector/src/main.rs
+++ b/tools/spy-detector/src/main.rs
@@ -1,0 +1,262 @@
+use dashmap::DashMap;
+use nng::options::protocol::pubsub::Subscribe;
+use nng::options::Options;
+use nng::{Protocol, Socket};
+use shared::clap;
+use shared::clap::Parser;
+use shared::event_msg;
+use shared::event_msg::event_msg::Event;
+use shared::net_msg;
+use shared::prost::Message;
+use shared::simple_logger;
+use std::sync::atomic;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+const ADDRESS: &str = "tcp://127.0.0.1:8883";
+const STATS_INTERVAL: Duration = Duration::from_secs(10); // Duration(seconds) to print stats of peers
+
+const LOG_TARGET: &str = "main";
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about=None)]
+struct Args {
+    /// set the threshold for spy detection (default value is 5)
+    #[arg(short, long, default_value = "5")]
+    threshold: u32,
+
+    /// The log level the tool should run with. Valid log levels
+    /// are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    log_level: log::Level,
+}
+
+#[derive(Debug, Default)]
+struct PeerStats {
+    inv_tx_received: AtomicU32,            // TX(INV) received by the peer
+    inv_tx_sent: AtomicU32,                // TX(INV) sent by the peer
+    inv_wtx_sent: AtomicU32,               // WTX(INV) received by the peer
+    inv_wtx_received: AtomicU32,           // WTX(INV) received by the peer
+    inv_witnesstx_received: AtomicU32,     // WitnessTX(INV) received by the peer
+    inv_witnesstx_sent: AtomicU32,         // WitnessTX(INV) sent by the peer
+    getdata_witnesstx_sent: AtomicU32,     // WitnessTX(GETDATA) sent by the peer
+    getdata_witnesstx_received: AtomicU32, // WitnessTX(GETDATA) received by the peer
+    tx_sent: AtomicU32,                    // TX sent by the peer
+    tx_received: AtomicU32,                // TX received by the peer
+    last_activity: Option<Instant>,        // Last activity time of the peer
+}
+
+type PeerMap = Arc<DashMap<String, PeerStats>>;
+
+fn main() {
+    let args = Args::parse();
+
+    //to-do: use threshold at appropriate location
+    let threshold = &args.threshold;
+
+    simple_logger::init_with_level(args.log_level).unwrap();
+
+    log::info!(target: LOG_TARGET, "Starting spy-detector...",);
+
+    log::info!(target: LOG_TARGET, "Starting spy-detector...",);
+
+    let sub = Socket::new(Protocol::Sub0).unwrap();
+    sub.dial(ADDRESS).unwrap();
+
+    let all_topics = vec![];
+    sub.set_opt::<Subscribe>(all_topics).unwrap();
+
+    let peer_map: PeerMap = Arc::new(DashMap::new());
+
+    // Spawn a thread for periodic stats display - 2 mins
+    let display_peer_map = peer_map.clone();
+    std::thread::spawn(move || {
+        let mut last_display = Instant::now();
+        loop {
+            let now = Instant::now();
+            if now.duration_since(last_display) >= STATS_INTERVAL {
+                display_all_stats(&display_peer_map);
+                last_display = now;
+            }
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    log::info!(target: LOG_TARGET, "Spy-detector started",);
+
+    loop {
+        let msg = sub.recv().unwrap();
+        let message = event_msg::EventMsg::decode(msg.as_slice()).unwrap().event;
+
+        if let Some(event) = message {
+            match event {
+                Event::Msg(msg) => {
+                    let msg_type: u32;
+
+                    if msg.meta.inbound {
+                        msg_type = 0;
+                    } else {
+                        msg_type = 1;
+                    };
+
+                    let peer_id = msg.meta.peer_id;
+
+                    if let Some(p2p_msg) = msg.msg {
+                        match p2p_msg {
+                            net_msg::message::Msg::Inv(_) => {
+                                process_inv_msg(&peer_map, &p2p_msg, msg_type, peer_id);
+                            }
+
+                            net_msg::message::Msg::Getdata(_) => {
+                                process_getdata_msg(&peer_map, &p2p_msg, msg_type, peer_id);
+                            }
+
+                            net_msg::message::Msg::Tx(_) => {
+                                process_tx_msg(&peer_map, msg_type, peer_id);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Event::Conn(c) => {
+                    if let Some(event) = c.event {
+                        process_connection_event(&peer_map, &event.to_string());
+                        //println!("{}", event);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn process_inv_msg(peer_map: &PeerMap, msg: &net_msg::message::Msg, msg_type: u32, peer_id: u64) {
+    let stats = peer_map
+        .entry(peer_id.to_string())
+        .or_insert_with(PeerStats::default);
+
+    if let net_msg::message::Msg::Inv(inv) = msg {
+        for inv_item in &inv.items {
+            match inv_item.inv_type() {
+                "Tx" => {
+                    if msg_type == 0 {
+                        stats
+                            .inv_tx_received
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    } else {
+                        stats.inv_tx_sent.fetch_add(1, atomic::Ordering::Relaxed);
+                    }
+                }
+                "WTx" => {
+                    if msg_type == 0 {
+                        stats
+                            .inv_wtx_received
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    } else {
+                        stats.inv_wtx_sent.fetch_add(1, atomic::Ordering::Relaxed);
+                    }
+                }
+                "WitnessTx" => {
+                    if msg_type == 0 {
+                        stats
+                            .inv_witnesstx_received
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    } else {
+                        stats
+                            .inv_witnesstx_sent
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    }
+                }
+                _ => {} // Ignore other types
+            }
+        }
+    }
+}
+
+fn process_getdata_msg(
+    peer_map: &PeerMap,
+    msg: &net_msg::message::Msg,
+    msg_type: u32,
+    peer_id: u64,
+) {
+    let stats = peer_map
+        .entry(peer_id.to_string())
+        .or_insert_with(PeerStats::default);
+
+    if let net_msg::message::Msg::Inv(inv) = msg {
+        for inv_item in &inv.items {
+            match inv_item.inv_type() {
+                "WitnessTx" => {
+                    if msg_type == 0 {
+                        stats
+                            .getdata_witnesstx_received
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    } else {
+                        stats
+                            .getdata_witnesstx_sent
+                            .fetch_add(1, atomic::Ordering::Relaxed);
+                    }
+                }
+                _ => {} // Ignore other types
+            }
+        }
+    }
+}
+
+fn process_tx_msg(peer_map: &PeerMap, msg_type: u32, peer_id: u64) {
+    let stats = peer_map
+        .entry(peer_id.to_string())
+        .or_insert_with(PeerStats::default);
+
+    if msg_type == 0 {
+        stats.tx_received.fetch_add(1, atomic::Ordering::Relaxed);
+    } else {
+        stats.tx_sent.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+}
+
+fn process_connection_event(peer_map: &PeerMap, event: &str) {
+    if event.starts_with("closed") {
+        let peer_id = event.split(' ').nth(1).unwrap_or("");
+        if let Some(stats) = peer_map.remove(peer_id) {
+            println!("Connection closed for peer: {}", peer_id);
+            print_peer_stats(peer_id, &stats.1);
+        }
+    }
+}
+
+fn print_peer_stats(peer_addr: &str, stats: &PeerStats) {
+    println!(
+        "[{}] Peer ID {} stats:\n  INV TX sent: {:?}\n  INV TX received: {:?}\n  INV WTX received: {:?}\n INV WitnessTX received: {:?}\n GetDATA WitnessTX received: {:?}\n  GETDATA WitnessTX received: {:?}\n  Tx sent: {:?}\n  Tx received: {:?}\n Last Activity: {:?}",
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+        peer_addr,
+        stats.inv_tx_sent,
+        stats.inv_tx_received,
+        stats.inv_wtx_received,
+        stats.inv_witnesstx_received,
+        stats.getdata_witnesstx_sent,
+        stats.getdata_witnesstx_received,
+        stats.tx_sent,
+        stats.tx_received,
+        stats.last_activity
+    );
+}
+
+fn display_all_stats(peer_map: &PeerMap) {
+    let map = peer_map;
+    println!(
+        "\n===== Stats for all peers ({}): =====",
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+    );
+    for item in map.iter() {
+        let peer_id = item.key();
+        let stats = item.value();
+
+        //println!("Key: {}\n", peer_id);
+        print_peer_stats(&peer_id, &stats);
+        println!("----------------------------------------");
+    }
+    println!("=====================================\n");
+}


### PR DESCRIPTION
Fixes #43 

This creates a tool, Spy-Detector that:
- prints stats of every peer(inv, tx, getdata) at every 10 secs
- for the connection being closed their stats are printed and removed from the shared state