### PR TITLE
update: rename bpftool -> bpftools in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@ pkgs.mkShell {
 
       pkgs.rustfmt
 
-      pkgs.bpftool
+      pkgs.bpftools
 
       # libbpf CO-RE pkgs
       pkgs.clang_14


### PR DESCRIPTION
fixes:
```
error: 'bpftool' has been renamed to/replaced by 'bpftools'
```