### PR TITLE
Fix: Add filters to logger tool

### DIFF
--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -8,7 +8,11 @@ use shared::prost::Message;
 use shared::simple_logger;
 use shared::{clap, nats};
 
-/// A peer-observer tool that logs all received event messages
+/// A peer-observer tool that logs all received event messages.
+/// By default, all events are shown. This can be a lot. Events can be
+/// filtered by type. For example, --messages only shows P2P messages.
+/// Using `--messages --connections` together showns both P2P messages
+/// and connections.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -20,52 +24,84 @@ struct Args {
     /// "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = log::Level::Debug)]
     log_level: log::Level,
+
+    /// If passed, show P2P message events
+    #[arg(long)]
+    messages: bool,
+
+    /// If passed, show P2P connection events
+    #[arg(long)]
+    connections: bool,
+
+    /// If passed, show addrman events
+    #[arg(long)]
+    addrman: bool,
+
+    /// If passed, show mempool events
+    #[arg(long)]
+    mempool: bool,
+
+    /// If passed, show validation events
+    #[arg(long)]
+    validation: bool,
+}
+
+impl Args {
+    fn should_show_all(&self) -> bool {
+        !(self.messages || self.connections || self.addrman || self.mempool || self.validation)
+    }
 }
 
 fn main() {
+    //Add early binding of filter flags
     let args = Args::parse();
-
+    let should_show_all = args.should_show_all();
+    let messages = args.messages;
+    let conn = args.connections;
+    let addrman = args.addrman;
+    let mempool = args.mempool;
+    let validation = args.validation;
     simple_logger::init_with_level(args.log_level).unwrap();
 
     // TODO: handle unwraps
     let nc = nats::connect(args.nats_address).unwrap();
     let sub = nc.subscribe("*").unwrap();
     for msg in sub.messages() {
-        let unwrapped = event_msg::EventMsg::decode(msg.data.as_slice())
-            .unwrap()
-            .event;
-
-        if let Some(event) = unwrapped {
-            match event {
-                Event::Msg(msg) => {
-                    log::info! {
-                        "{} {} id={} (conn_type={:?}): {}",
-                        if msg.meta.inbound { "<--"} else { "-->" },
-                        if msg.meta.inbound { "from"} else { "to" },
-                        msg.meta.peer_id,
-                        msg.meta.conn_type,
-                        msg.msg.unwrap(),
-                    };
-                }
-                Event::Conn(c) => {
-                    log::info! {
-                        "# CONN {}", c.event.unwrap()
-                    };
-                }
-                Event::Addrman(a) => {
-                    log::info! {
-                        "@Addrman {}", a.event.unwrap()
-                    };
-                }
-                Event::Mempool(m) => {
-                    log::info! {
-                        "$Mempool {}", m.event.unwrap()
-                    };
-                }
-                Event::Validation(v) => {
-                    log::info! {
-                        "+Validation {}", v.event.unwrap()
-                    };
+        if let Ok(event_msg) = event_msg::EventMsg::decode(msg.data.as_slice()) {
+            if let Some(event) = event_msg.event {
+                match event {
+                    Event::Msg(msg) => {
+                        if should_show_all || messages {
+                            log::info!(
+                                "{} {} id={} (conn_type={:?}): {}",
+                                if msg.meta.inbound { "<--" } else { "-->" },
+                                if msg.meta.inbound { "from" } else { "to" },
+                                msg.meta.peer_id,
+                                msg.meta.conn_type,
+                                msg.msg.unwrap()
+                            );
+                        }
+                    }
+                    Event::Conn(c) => {
+                        if should_show_all || conn {
+                            log::info!("# CONN {}", c.event.unwrap());
+                        }
+                    }
+                    Event::Addrman(a) => {
+                        if should_show_all || addrman {
+                            log::info!("@Addrman {}", a.event.unwrap());
+                        }
+                    }
+                    Event::Mempool(m) => {
+                        if should_show_all || mempool {
+                            log::info!("$Mempool {}", m.event.unwrap());
+                        }
+                    }
+                    Event::Validation(v) => {
+                        if should_show_all || validation {
+                            log::info!("+Validation {}", v.event.unwrap());
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #48

The logger tool is quite spammy currently as it prints all events
 (p2p message, connections, addrman (if enabled), validation, and mempool).
This PR adds a filter where we can pass a command line argument to enable only the desired event types. For example, passing --filter mempool or -f mempool would only log $Mempool messages.