### PR TITLE
add: tool to log linking lion traffic

### DIFF
--- a/tools/linkinglion-traffic/linkinglion-traffic.py
+++ b/tools/linkinglion-traffic/linkinglion-traffic.py
@@ -1,0 +1,91 @@
+import asyncio
+from nats.aio.client import Client as NATS
+import json
+import sys
+from datetime import datetime
+from random import randrange
+sys.path.append("../../protobuf/python-types")
+
+import event_msg_pb2
+
+def format_traffic(b):
+    if b > 1_000_000_000:
+        return "{:.2f}GB".format(b/1_000_000_000).rjust(10)
+    elif b > 1_000_000:
+        return "{:.2f}MB".format(b/1_000_000).rjust(10)
+    elif b > 1_000:
+        return "{:.2f}kB".format(b/1_000).rjust(10)
+    else:
+        return f"{b}b".rjust(10)
+
+
+def print_traffic_detailed():
+    print("---")
+    print(datetime.utcnow())
+    print(json.dumps(traffic, sort_keys=True, indent=4))
+
+def print_traffic_short():
+    down_o = traffic["other"]["download"]["total"]
+    up_o = traffic["other"]["upload"]["total"]
+    total_o = down_o + up_o
+    print("other download:", format_traffic(down_o), "\tupload:", format_traffic(up_o), "\ttotal:", format_traffic(total_o))
+
+    down_l = traffic["linking-lion"]["download"]["total"]
+    up_l = traffic["linking-lion"]["upload"]["total"]
+    total_l = down_l + up_l
+    down_percentage = "down: {:.2f}%".format(down_l * 100 / (down_o + down_l))
+    up_percentage = "up: {:.2f}%".format(up_l * 100 / (up_o + up_l))
+    total_percentage = "t: {:.2f}%".format(total_l * 100 / (total_o + total_l))
+    print("llion download:", format_traffic(down_l), "\tupload:", format_traffic(up_l), "\ttotal:", format_traffic(total_l), down_percentage, up_percentage, total_percentage)
+
+traffic = {
+    "linking-lion": {
+        "download": {"total": 0},
+        "upload": {"total": 0},
+    },
+    "other": {
+        "download": {"total": 0},
+        "upload": {"total": 0},
+    },
+}
+
+def is_linking_lion(meta):
+    for subnet in ["91.198.115", "162.218.65", "209.222.252", "2604:d500:"]:
+        if subnet in meta.addr:
+            return True
+    return False
+
+async def main():
+    nc = NATS()
+    await nc.connect("nats://127.0.0.1:4222")
+
+    async def message_handler(msg):
+        subject = msg.subject
+        data = msg.data
+
+        event = event_msg_pb2.EventMsg()
+        event.ParseFromString(data)
+
+        p2pmsg = event.msg
+        dir = "download" if p2pmsg.meta.inbound else "upload"
+        actor = "linking-lion" if is_linking_lion(p2pmsg.meta) else "other"
+        command = p2pmsg.meta.command
+        if command not in traffic[actor][dir]:
+            traffic[actor][dir][command] = 0
+        traffic[actor][dir][command] += p2pmsg.meta.size
+        traffic[actor][dir]["total"] += p2pmsg.meta.size
+
+        if randrange(100) == 0:
+            print_traffic_short()
+            print()
+        if randrange(10000) == 0:
+            print_traffic_detailed()
+
+
+    await nc.subscribe("netmsg", cb=message_handler)
+    print("Subscribed to 'netmsg' topic...")
+
+    await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/linkinglion-traffic/shell.nix
+++ b/tools/linkinglion-traffic/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = [
+      pkgs.python39Packages.nats-py
+      pkgs.python39Packages.protobuf
+    ];
+}


### PR DESCRIPTION
closes https://github.com/0xB10C/peer-observer/issues/142

prints something like the following every few seconds

```
other download:     9.58MB 	upload:    25.25MB 	total:    34.83MB
llion download:   119.95kB 	upload:     1.10MB 	total:     1.22MB down: 1.24% up: 4.18% t: 3.39%

other download:     9.58MB 	upload:    25.26MB 	total:    34.85MB
llion download:   119.95kB 	upload:     1.10MB 	total:     1.22MB down: 1.24% up: 4.18% t: 3.39%
---
2025-04-11 10:15:30.343964
{
    "linking-lion": {
        "download": {
            "addr": 19716,
            "pong": 3880,
            "total": 119948,
            "verack": 0,
            "version": 96352
        },
        "upload": {
            "addr": 524,
            "feefilter": 5944,
            "getheaders": 764547,
            "inv": 231382,
            "ping": 6000,
            "sendaddrv2": 0,
            "sendcmpct": 6714,
            "total": 1102321,
            "verack": 0,
            "version": 87210,
            "wtxidrelay": 0
        }
    },
    "other": {
        "download": {
            "addr": 1576,
            "addrv2": 17832,
            "cmpctblock": 72594,
            "feefilter": 8,
            "getaddr": 0,
            "getblocktxn": 4657,
            "getdata": 1478109,
            "getheaders": 5214,
            "headers": 1063,
            "inv": 6444073,
            "notfound": 4250,
            "ping": 5696,
            "pong": 3608,
            "sendaddrv2": 0,
            "sendcmpct": 27,
            "sendheaders": 0,
            "total": 9579199,
            "tx": 1538441,
            "verack": 0,
            "version": 2051,
            "wtxidrelay": 0
        },
        "upload": {
            "addr": 1753,
            "addrv2": 47497,
            "alert": 336,
            "blocktxn": 1954216,
            "cmpctblock": 919524,
            "feefilter": 96,
            "getdata": 127997,
            "getheaders": 14406,
            "headers": 6067,
            "inv": 5699304,
            "notfound": 1737,
            "ping": 3688,
            "pong": 5696,
            "sendaddrv2": 0,
            "sendcmpct": 108,
            "sendheaders": 0,
            "total": 25251566,
            "tx": 16467101,
            "verack": 0,
            "version": 2040,
            "wtxidrelay": 0
        }
    }
}
```