### PR TITLE
dependabot: only open PRs for direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     allow:
-      - dependency-type: "all"
+      - dependency-type: "direct"


### PR DESCRIPTION
Previously, for all transative packages PRs were opened and I've been closing them all manually.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow