### PR TITLE
Add basic RPC extractor with getpeerinfo support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f6da6d49a956424ca4e28fe93656f790d748b469eaccbc7488fec545315180"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid 0.5.0",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.48",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +166,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "base32"
@@ -139,12 +205,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-url"
 version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -166,6 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32",
  "bitcoin-internals",
  "bitcoin-io",
@@ -174,6 +253,7 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -181,6 +261,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -195,6 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
+ "serde",
 ]
 
 [[package]]
@@ -205,6 +289,7 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
+ "serde",
 ]
 
 [[package]]
@@ -252,6 +337,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -415,6 +503,29 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "corepc-client"
+version = "0.8.0"
+source = "git+https://github.com/0xb10c/corepc.git?branch=2025-07-peer-observer-rpc-extractor#5e1b6091ec8aeeba9a9db20ee63141e09f40da25"
+dependencies = [
+ "bitcoin",
+ "corepc-types",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.8.0"
+source = "git+https://github.com/0xb10c/corepc.git?branch=2025-07-peer-observer-rpc-extractor#5e1b6091ec8aeeba9a9db20ee63141e09f40da25"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -636,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -703,6 +814,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +857,35 @@ checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -756,6 +920,12 @@ dependencies = [
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
@@ -990,6 +1160,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1200,18 @@ name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
+name = "jsonrpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
+dependencies = [
+ "base64 0.13.1",
+ "minreq",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1070,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1132,6 +1325,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "minreq"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,7 +1367,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19090dd06e27eb59adfd16f332b85818a3e7dbbdbc13c448676c9bb69f964208"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "base64-url",
  "blocking",
  "crossbeam-channel",
@@ -1155,13 +1379,13 @@ dependencies = [
  "log",
  "memchr",
  "nkeys",
- "nuid",
+ "nuid 0.3.2",
  "once_cell",
  "parking_lot",
  "portable-atomic",
  "regex",
  "ring",
- "rustls",
+ "rustls 0.22.4",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki",
@@ -1222,6 +1446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1318,10 +1560,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -1601,6 +1869,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpc"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,7 +1900,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1629,6 +1910,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+dependencies = [
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1710,6 +2005,7 @@ checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes",
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -1840,9 +2136,11 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
+ "async-nats",
  "base32",
  "bitcoin",
  "clap",
+ "corepc-client",
  "hex",
  "lazy_static",
  "log",
@@ -1852,6 +2150,7 @@ dependencies = [
  "prost-build",
  "serde",
  "simple_logger",
+ "tokio",
 ]
 
 [[package]]
@@ -1895,10 +2194,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "spki"
@@ -2056,13 +2371,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.23",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2085,6 +2485,16 @@ dependencies = [
  "sharded-slab",
  "thread_local",
  "tracing-core",
+]
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2247,6 +2657,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "websocket"
 version = "0.1.0"
 dependencies = [
@@ -2351,7 +2779,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2371,17 +2808,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2392,9 +2830,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2404,9 +2842,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2416,9 +2854,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2428,9 +2872,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2440,9 +2884,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2452,9 +2896,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2464,9 +2908,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,6 @@ version = "0.1.0"
 dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
- "prost",
  "shared",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
   "shared",
   "extractors/ebpf",
+  "extractors/rpc",
   "tools/logger",
   "tools/websocket",
   "tools/metrics",

--- a/extractors/ebpf/Cargo.toml
+++ b/extractors/ebpf/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 shared = { path = "../../shared" }
 
-prost = "0.14"
 libbpf-rs = "0.25"
 
 [build-dependencies]

--- a/extractors/ebpf/src/main.rs
+++ b/extractors/ebpf/src/main.rs
@@ -3,7 +3,6 @@
 use error::RuntimeError;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 use libbpf_rs::{Map, MapCore, Object, ProgramMut, RingBufferBuilder};
-use shared::prost::Message;
 use shared::clap::Parser;
 use shared::ctypes::{
     AddrmanInsertNew, AddrmanInsertTried, ClosedConnection, InboundConnection, MempoolAdded,
@@ -13,6 +12,7 @@ use shared::ctypes::{
 use shared::event_msg::event_msg::Event;
 use shared::event_msg::EventMsg;
 use shared::log::{self, error};
+use shared::prost::Message;
 use shared::simple_logger;
 use shared::{addrman, mempool, nats_subjects::Subject, net_conn, net_msg, validation};
 use shared::{clap, nats};

--- a/extractors/ebpf/src/main.rs
+++ b/extractors/ebpf/src/main.rs
@@ -3,7 +3,7 @@
 use error::RuntimeError;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 use libbpf_rs::{Map, MapCore, Object, ProgramMut, RingBufferBuilder};
-use prost::Message;
+use shared::prost::Message;
 use shared::clap::Parser;
 use shared::ctypes::{
     AddrmanInsertNew, AddrmanInsertTried, ClosedConnection, InboundConnection, MempoolAdded,

--- a/extractors/rpc/Cargo.toml
+++ b/extractors/rpc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rpc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../../shared" }
+
+[features]
+# Treat warnings as a build error.
+strict = []

--- a/extractors/rpc/src/main.rs
+++ b/extractors/rpc/src/main.rs
@@ -1,0 +1,134 @@
+use shared::clap::{ArgGroup, Parser};
+use shared::corepc_client::client_sync::Auth;
+use shared::corepc_client::client_sync::v29::Client;
+use shared::event_msg::EventMsg;
+use shared::event_msg::event_msg::Event;
+use shared::log::{self, error};
+use shared::nats_subjects::Subject;
+use shared::prost::Message;
+use shared::tokio::{
+    self,
+    time::{self, Duration},
+};
+use shared::{async_nats, clap};
+use shared::{rpc, simple_logger};
+
+/// The peer-observer rpc-extractor periodically queries data from the
+/// Bitcoin Core RPC endpoint and publishes the results as events into
+/// a NATS pub-sub queue.
+#[derive(Parser, Debug)]
+#[clap(group(
+    ArgGroup::new("auth")
+        .required(true)
+        .multiple(false)
+        .args(&["rpc_cookie_file", "rpc_user"])
+))]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Address of the NATS server where the extractor will publish messages to.
+    #[arg(short, long, default_value = "127.0.0.1:4222")]
+    nats_address: String,
+
+    /// The log level the extractor should run with. Valid log levels are "trace",
+    /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html.
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    log_level: log::Level,
+
+    /// Address of the Bitcoin Core RPC endpoint the RPC extractor will query.
+    #[arg(long, default_value = "127.0.0.1:8332")]
+    rpc_host: String,
+
+    /// RPC username for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(short, long)]
+    rpc_user: Option<String>,
+
+    /// RPC password for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(requires = "rpc_user", long)]
+    rpc_password: Option<String>,
+
+    /// An RPC cookie file for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(long)]
+    rpc_cookie_file: Option<String>,
+
+    /// Interval (in seconds) in which to query from the Bitcoin Core RPC endpoint.
+    #[arg(long, default_value_t = 10)]
+    query_interval: u64,
+}
+
+#[tokio::main]
+async fn main() -> () {
+    let args = Args::parse();
+
+    simple_logger::init_with_level(args.log_level).expect("can't set up logger");
+
+    let auth: Auth = match args.rpc_cookie_file {
+        Some(path) => Auth::CookieFile(path.into()),
+        None => Auth::UserPass(
+            args.rpc_user.expect("need an RPC user"),
+            args.rpc_password.expect("need an RPC password"),
+        ),
+    };
+    let client = match Client::new_with_auth(&format!("http://{}", args.rpc_host), auth) {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Could not create RPC client: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    log::debug!("Connecting to NATS server at {}..", args.nats_address);
+    let nats_client = match async_nats::connect(&args.nats_address).await {
+        Ok(nats_client) => nats_client,
+        Err(e) => {
+            error!(
+                "Could not connect to NATS server at {}: {}",
+                args.nats_address, e
+            );
+            std::process::exit(1);
+        }
+    };
+    log::info!("Connected to NATS server at {}", &args.nats_address);
+
+    let duration_sec = Duration::from_secs(args.query_interval);
+    let mut interval = time::interval(duration_sec);
+    log::info!(
+        "Querying the Bitcoin Core RPC interface every {:?}.",
+        duration_sec
+    );
+
+    loop {
+        interval.tick().await;
+
+        match client.get_peer_info() {
+            Ok(peerinfo) => {
+                match EventMsg::new(Event::Rpc(rpc::RpcEvent {
+                    event: Some(rpc::rpc_event::Event::PeerInfos(peerinfo.into())),
+                })) {
+                    Ok(proto) => {
+                        if let Err(e) = nats_client
+                            .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
+                            .await
+                        {
+                            error!(
+                                "could not publish message in 'handle_validation_block_connected': {}",
+                                e
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        error!(
+                            "Could not create new EventMsg due to SystemTimeError: {}",
+                            e
+                        );
+                    }
+                };
+            }
+            Err(e) => {
+                error!(
+                    "Could not query getpeerinfo from the Bitcoin Core RPC server: {}",
+                    e
+                );
+            }
+        }
+    }
+}

--- a/protobuf/proto-types/event_msg.proto
+++ b/protobuf/proto-types/event_msg.proto
@@ -2,11 +2,15 @@ syntax = "proto2";
 
 package event_msg;
 
+// ebpf extractor
 import "net_msg.proto";
 import "net_conn.proto";
 import "addrman.proto";
 import "mempool.proto";
 import "validation.proto";
+
+// rpc extractor
+import "rpc.proto";
 
 message EventMsg {
   required uint64  timestamp = 10;  // Timestamp (seconds since UNIX epoch) when the message was received.
@@ -17,6 +21,6 @@ message EventMsg {
     addrman.AddrmanEvent addrman = 3;
     mempool.MempoolEvent mempool = 4;
     validation.ValidationEvent validation = 5;
+    rpc.RPCEvent rpc = 6;
   }
 }
-

--- a/protobuf/proto-types/rpc.proto
+++ b/protobuf/proto-types/rpc.proto
@@ -1,0 +1,56 @@
+syntax = "proto2";
+
+package rpc;
+
+message RPCEvent {
+  oneof event {
+    PeerInfos peer_infos = 1;
+  }
+}
+
+// A getpeerinfo RPC response from Bitcoin Core.
+message PeerInfos {
+  repeated PeerInfo infos = 1;
+}
+
+// Information about a single peer.
+message PeerInfo {
+  required uint32   id                      = 1;  // The peer_id of this peer.
+  required string   address                 = 2;  // The address of this peer (host:port).
+  required string   address_bind            = 3;  // The bind address of the connection to the peer (ip:port).
+  required string   address_local           = 4;  // Local address as reported by the peer (ip:port)
+  required string   network                 = 5;  // Network (ipv4, ipv6, onion, i2p, cjdns, not_publicly_routable, or empty)
+  required uint32   mapped_as               = 6;  // Mapped AS (Autonomous System) number
+  required string   services                = 7;  // The services offered
+  required bool     relay_transactions      = 8;  // Whether we relay transactions to this peer
+  required int64    last_send               = 9;  // The UNIX epoch time of the last send
+  required int64    last_received           = 10; // The UNIX epoch time of the last receive
+  required int64    last_transaction        = 11; // The UNIX epoch time of the last valid transaction received from this peer
+  required int64    last_block              = 12; // The UNIX epoch time of the last block received from this peer
+  required uint64   bytes_sent              = 13; // The total bytes sent
+  required uint64   bytes_received          = 14; // The total bytes received
+  required int64    connection_time         = 15; // The UNIX epoch time of the connection
+  required int64    time_offset             = 16; // The time offset in seconds
+  required double   ping_time               = 17; // The last ping time in milliseconds (ms), if any
+  required double   minimum_ping            = 18; // The minimum observed ping time in milliseconds (ms), if any
+  required double   ping_wait               = 19; // The duration in milliseconds (ms) of an outstanding ping (if non-zero)
+  required uint32   version                 = 20; // The peer version, such as 70001
+  required string   subversion              = 21; // The string version
+  required bool     inbound                 = 22; // Inbound (true) or Outbound (false)
+  required bool     bip152_hb_to            = 23; // Whether we selected peer as (compact blocks) high-bandwidth peer
+  required bool     bip152_hb_from          = 24; // Whether peer selected us as (compact blocks) high-bandwidth peer
+  required int64    starting_height         = 25; // The starting height (block) of the peer
+  required int64    synced_headers          = 26; // The last header we have in common with this peer
+  required int64    synced_blocks           = 27; // The last block we have in common with this peer
+  repeated uint64   inflight                = 28; // The heights of blocks we're currently asking from this peer
+  required bool     addr_relay_enabled      = 29; // Whether we participate in address relay with this peer
+  required uint64   addr_processed          = 30; // The total number of addresses processed, excluding those dropped due to rate limiting
+  required uint64   addr_rate_limited       = 31; // The total number of addresses dropped due to rate limiting
+  repeated string   permissions             = 32; // Any special permissions that have been granted to this peer
+  required double   minfeefilter            = 33; // The minimum fee rate for transactions this peer accepts
+  map<string, uint64> bytes_sent_per_message = 34; // The total bytes sent aggregated by message type.
+  map<string, uint64> bytes_received_per_message = 35; // The total bytes received aggregated by message type.
+  required string   connection_type         = 36; // The services offered
+  required string   transport_protocol_type = 37; // Type of transport protocol (v1, v2)
+  // session ID is not implemented, since I'm not sure we need them?
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,9 +13,15 @@ serde = { version = "1.0.219", features = ["derive"] }
 clap = { version = "4.5.41", features = ["derive"] }
 simple_logger = "5.0.0"
 log = "0.4"
+# The non-async NATS crate is deprecated. New tools should use async_nats.
 nats = "0.25.0"
+async-nats = "0.42.0"
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
+# for the rpc exporter
+# TODO: when #310 is merged and 0.9.0 is release, switch to that.
+corepc-client = { git = "https://github.com/0xb10c/corepc.git", branch = "2025-07-peer-observer-rpc-extractor",  features = ["client-sync"]}
+tokio = { version = "1.47.0", features = ["rt-multi-thread"] }
 
 [build-dependencies]
 prost-build = "0.14"

--- a/shared/ip-lists/README.md
+++ b/shared/ip-lists/README.md
@@ -32,3 +32,14 @@ wget https://gui.xmr.pm/files/block.txt
 python3 preprocess-monero-block-list.py
 
 ```
+
+## LinkingLion banlist
+
+A banlist of IP addresses for LinkingLion.
+
+```
+162.218.65.0/24
+209.222.252.0/24
+91.198.115.0/24
+2604:d500:4:1::/64
+```

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,13 +1,16 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
+pub extern crate async_nats;
 pub extern crate bitcoin;
 pub extern crate clap;
+pub extern crate corepc_client;
 pub extern crate lazy_static;
 pub extern crate log;
 pub extern crate nats;
 pub extern crate prometheus;
 pub extern crate prost;
 pub extern crate simple_logger;
+pub extern crate tokio;
 
 pub mod addrman;
 pub mod ctypes;
@@ -17,6 +20,7 @@ pub mod nats_subjects;
 pub mod net_conn;
 pub mod net_msg;
 pub mod primitive;
+pub mod rpc;
 pub mod validation;
 
 /// A minimal HTTP webserver (but not spec compliant) used to serve prometheus metrics via HTTP.

--- a/shared/src/nats_subjects.rs
+++ b/shared/src/nats_subjects.rs
@@ -5,6 +5,7 @@ const NATS_SUBJECT_MEMPOOL: &str = "mempool";
 const NATS_SUBJECT_NETMSG: &str = "netmsg";
 const NATS_SUBJECT_NETCONN: &str = "netconn";
 const NATS_SUBJECT_VALIDATION: &str = "validation";
+const NATS_SUBJECT_RPC: &str = "rpc";
 
 pub enum Subject {
     Addrman,
@@ -12,6 +13,7 @@ pub enum Subject {
     NetMsg,
     NetConn,
     Validation,
+    Rpc,
 }
 
 impl fmt::Display for Subject {
@@ -22,6 +24,7 @@ impl fmt::Display for Subject {
             Subject::NetConn => write!(f, "{}", NATS_SUBJECT_NETCONN),
             Subject::NetMsg => write!(f, "{}", NATS_SUBJECT_NETMSG),
             Subject::Validation => write!(f, "{}", NATS_SUBJECT_VALIDATION),
+            Subject::Rpc => write!(f, "{}", NATS_SUBJECT_RPC),
         }
     }
 }

--- a/shared/src/rpc.rs
+++ b/shared/src/rpc.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+
+use corepc_client::types::v26::{GetPeerInfo as RPCGetPeerInfo, PeerInfo as RPCPeerInfo};
+
+// structs are generated via the rpc.proto file
+include!(concat!(env!("OUT_DIR"), "/rpc.rs"));
+
+impl fmt::Display for PeerInfos {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let info_strs: Vec<String> = self.infos.iter().map(|i| i.to_string()).collect();
+        write!(f, "PeerInfos([{}])", info_strs.join(", "))
+    }
+}
+
+impl From<RPCGetPeerInfo> for PeerInfos {
+    fn from(infos: RPCGetPeerInfo) -> Self {
+        PeerInfos {
+            infos: infos.0.iter().map(|i| i.clone().into()).collect(),
+        }
+    }
+}
+
+impl fmt::Display for PeerInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PeerInfo(id={})", self.id,)
+    }
+}
+
+impl fmt::Display for rpc_event::Event {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            rpc_event::Event::PeerInfos(infos) => write!(f, "{}", infos),
+        }
+    }
+}
+
+impl From<RPCPeerInfo> for PeerInfo {
+    fn from(info: RPCPeerInfo) -> Self {
+        PeerInfo {
+            address: info.address,
+            address_bind: info.address_bind.unwrap_or_default(),
+            address_local: info.address_local.unwrap_or_default(),
+            addr_rate_limited: info.addresses_rate_limited.unwrap_or_default() as u64,
+            addr_relay_enabled: info.addresses_relay_enabled.unwrap_or_default(),
+            addr_processed: info.addresses_processed.unwrap_or_default() as u64,
+            bip152_hb_from: info.bip152_hb_from,
+            bip152_hb_to: info.bip152_hb_to,
+            bytes_received: info.bytes_received,
+            bytes_received_per_message: info.bytes_received_per_message.into_iter().collect(),
+            bytes_sent: info.bytes_sent,
+            bytes_sent_per_message: info.bytes_sent_per_message.into_iter().collect(),
+            connection_time: info.connection_time,
+            connection_type: info.connection_type.unwrap_or_default(),
+            id: info.id,
+            inbound: info.inbound,
+            inflight: info.inflight.unwrap_or_default(),
+            last_block: info.last_block,
+            last_received: info.last_received,
+            last_send: info.last_send,
+            last_transaction: info.last_transaction,
+            mapped_as: info.mapped_as.unwrap_or_default(),
+            minfeefilter: info.minimum_fee_filter,
+            minimum_ping: info.minimum_ping.unwrap_or_default(),
+            network: info.network,
+            ping_time: info.ping_time.unwrap_or_default(),
+            ping_wait: info.ping_wait.unwrap_or_default(),
+            permissions: info.permissions,
+            relay_transactions: info.relay_transactions,
+            services: info.services,
+            starting_height: info.starting_height.unwrap_or_default(),
+            subversion: info.subversion,
+            synced_blocks: info.synced_blocks.unwrap_or_default(),
+            synced_headers: info.synced_headers.unwrap_or_default(),
+            time_offset: info.time_offset,
+            transport_protocol_type: info.transport_protocol_type,
+            version: info.version,
+        }
+    }
+}

--- a/shared/src/util.rs
+++ b/shared/src/util.rs
@@ -49,6 +49,13 @@ pub fn current_timestamp() -> u64 {
         .as_secs()
 }
 
+pub fn is_on_linkinglion_banlist(ip: &str) -> bool {
+    ip.starts_with("162.218.65")
+        || ip.starts_with("209.222.252")
+        || ip.starts_with("91.198.115")
+        || ip.starts_with("2604:d500:4:")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,5 +147,25 @@ mod tests {
         assert!(is_tor_exit_node("185.220.100.253")); // tor-exit-2.zbau.f3netze.de
         assert!(is_tor_exit_node("204.8.96.150")); // tor61.quintex.com
         assert!(is_tor_exit_node("185.129.61.5")); // tor-project-exit5.dotsrc.org
+    }
+
+    #[test]
+    fn test_linkinglion() {
+        assert!(!is_on_linkinglion_banlist(
+            "this is probably not an ip of a tor exit node"
+        ));
+
+        // The IP addresses defined in RFC5737 for use in documentation are not on a LinkingLion banlist.
+        //
+        // https://www.rfc-editor.org/rfc/rfc5737
+        assert!(!is_on_linkinglion_banlist("192.0.2.222")); // TEST-NET-1
+        assert!(!is_on_linkinglion_banlist("198.51.100.111")); // TEST-NET-2
+        assert!(!is_on_linkinglion_banlist("203.0.113.123")); // TEST-NET-3
+
+        // These are actual IP addresses LinkingLion uses.
+        assert!(is_on_linkinglion_banlist("162.218.65.254"));
+        assert!(is_on_linkinglion_banlist("209.222.252.254"));
+        assert!(is_on_linkinglion_banlist("91.198.115.62"));
+        assert!(is_on_linkinglion_banlist("2604:d500:4:1::3:fe"));
     }
 }

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -45,11 +45,20 @@ struct Args {
     /// If passed, show validation events
     #[arg(long)]
     validation: bool,
+
+    /// If passed, show RPC events
+    #[arg(long)]
+    rpc: bool,
 }
 
 impl Args {
     fn should_show_all(&self) -> bool {
-        !(self.messages || self.connections || self.addrman || self.mempool || self.validation)
+        !(self.messages
+            || self.connections
+            || self.addrman
+            || self.mempool
+            || self.validation
+            || self.rpc)
     }
 }
 
@@ -62,6 +71,7 @@ fn main() {
     let addrman = args.addrman;
     let mempool = args.mempool;
     let validation = args.validation;
+    let rpc = args.rpc;
     simple_logger::init_with_level(args.log_level).unwrap();
 
     // TODO: handle unwraps
@@ -101,6 +111,11 @@ fn main() {
                     Event::Validation(v) => {
                         if should_show_all || validation {
                             log::info!("+Validation {}", v.event.unwrap());
+                        }
+                    }
+                    Event::Rpc(r) => {
+                        if should_show_all || rpc {
+                            log::info!("!RPC {}", r.event.unwrap());
                         }
                     }
                 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -15,6 +15,7 @@ const SUBSYSTEM_CONN: &str = "conn";
 const SUBSYSTEM_ADDRMAN: &str = "addrman";
 const SUBSYSTEM_MEMPOOL: &str = "mempool";
 const SUBSYSTEM_VALIDATION: &str = "validation";
+const SUBSYSTEM_RPC: &str = "rpc";
 
 pub const LABEL_P2P_MSG_TYPE: &str = "message";
 pub const LABEL_P2P_CONNECTION_TYPE: &str = "connection_type";
@@ -633,4 +634,64 @@ lazy_static! {
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_VALIDATION)
     ).unwrap();
+
+    // -------------------- RPC
+
+    /// Number of peers connected that are on the 2018 ban list by gmax.
+    pub static ref PEER_INFO_LIST_CONNECTIONS_GMAX_BAN: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_list_peers_gmax_ban", "Number of peers connected to us that are on the 2018 ban list by gmax.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers connected to us that are on the monero banlist.
+    pub static ref PEER_INFO_LIST_CONNECTIONS_MONERO_BAN: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_list_peers_monero_ban", "Number of peers connected to us that are on the monero banlist.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers connected to us that are on the list of tor exit nodes.
+    pub static ref PEER_INFO_LIST_CONNECTIONS_TOR_EXIT: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_list_peers_tor_exit", "Number of peers connected to us that are on the list of tor exit nodes.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+
+    /// Number of peers connected to us that are known LinkingLion nodes.
+    pub static ref PEER_INFO_LIST_CONNECTIONS_LINKINGLION: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_list_peers_linkinglion", "Number of peers connected to us that are known LinkingLion nodes.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers connected to us that had at least one address rate-limited from being processed (see bitcoin/bitcoin #22387).
+    pub static ref PEER_INFO_ADDR_RATELIMITED_PEERS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_addr_ratelimited_peers", "Number of peers connected to us that had at least one address rate-limited from being processed (see bitcoin/bitcoin #22387)")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of addressed rate-limited across all connected peers (see bitcoin/bitcoin #22387).
+    pub static ref PEER_INFO_ADDR_RATELIMITED_TOTAL: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_addr_ratelimited_total", "Number of addressed rate-limited across all connected peers (see bitcoin/bitcoin #22387).")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of addressed processed across all connected peers (see bitcoin/bitcoin #22387).
+    pub static ref PEER_INFO_ADDR_PROCESSED_TOTAL: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_addr_processed_total", "Number of addressed processed across all connected peers (see bitcoin/bitcoin #22387).")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
 }


### PR DESCRIPTION
This adds an RPC extractor that connects to a Bitcoin Core node and queries RPCs for data in an interval (currently 10s). The data is then send into NATS and can be consumed by tools. As a start, the `getpeerinfo` RPC is implemented.

It uses rust-bitcoin/corepc and their non-production, sync RPC client. A custom RPC client can be implemented in the future, if needed. It requires https://github.com/rust-bitcoin/corepc/pull/310 to be merged and released. Until then, a custom branch is being used.

Basic logger, websocket, and metrics tool support has been implemented. The websocket web pages can be updated to use data the and the metric tool can be built out to allow for more metrics.

Required before merge:

- [ ] usage docs for the RPC exporter

To be done as followups:
- [ ] Issue to upgrade to corepc v0.9.0 once released
- [ ] Use the getpeerinfo RPC data in the websocket pages
- [ ] Add more getpeerinfo RPC metrics to `metrics`
- [ ] ...