### PR TITLE
Add more metrics based on data from the `getpeerinfo` RPC

### DIFF
--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -106,6 +106,7 @@ fn main() {
                 let mut min_pings = vec![];
 
                 let mut peers_by_transport_protocol_type: BTreeMap<&str, i64> = BTreeMap::new();
+                let mut peers_by_network: BTreeMap<&str, i64> = BTreeMap::new();
 
                 for peer in info.infos.iter() {
                     let ip = util::ip_from_ipport(peer.address.clone());
@@ -159,6 +160,11 @@ fn main() {
                         .entry(&peer.transport_protocol_type)
                         .and_modify(|e| *e += 1)
                         .or_insert(1);
+
+                    peers_by_network
+                        .entry(&peer.network)
+                        .and_modify(|e| *e += 1)
+                        .or_insert(1);
                 }
 
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_GMAX_BAN.set(on_gmax_banlist);
@@ -187,6 +193,13 @@ fn main() {
                 metrics::RPC_PEER_INFO_TRANSPORT_PROTOCOL_TYPE_PEERS.reset();
                 for (k, v) in peers_by_transport_protocol_type.iter() {
                     metrics::RPC_PEER_INFO_TRANSPORT_PROTOCOL_TYPE_PEERS
+                        .with_label_values(&[k])
+                        .set(*v);
+                }
+
+                metrics::RPC_PEER_INFO_NETWORK_PEERS.reset();
+                for (k, v) in peers_by_network.iter() {
+                    metrics::RPC_PEER_INFO_NETWORK_PEERS
                         .with_label_values(&[k])
                         .set(*v);
                 }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -167,6 +167,8 @@ fn main() {
 
                 metrics::RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_TO.set(bip152_highbandwidth_to);
                 metrics::RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_FROM.set(bip152_highbandwidth_from);
+
+                metrics::RPC_PEER_INFO_NUM_PEERS.set(info.infos.len() as i64);
             }
         }
     }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -91,6 +91,11 @@ fn main() {
                 let mut timeoffset_plus10s = 0;
                 let mut timeoffset_minus10s = 0;
 
+                // track how many peers we consider high bandwidth compact block peers
+                // and how many consider us to be a high bandwidth peer
+                let mut bip152_highbandwidth_to = 0;
+                let mut bip152_highbandwidth_from = 0;
+
                 let mut addr_rate_limited_peers = 0; // number of peers that had at least one address rate limited.
                 let mut addr_rate_limited_total: u64 = 0; // total number of rate-limited addresses
                 let mut addr_processed_total: u64 = 0; // total number of processed addresses
@@ -134,6 +139,14 @@ fn main() {
                     if peer.minimum_ping > 0.0 {
                         min_pings.push(peer.minimum_ping * 1000.0);
                     }
+
+                    if peer.bip152_hb_to {
+                        bip152_highbandwidth_to += 1;
+                    }
+
+                    if peer.bip152_hb_from {
+                        bip152_highbandwidth_from += 1;
+                    }
                 }
 
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_GMAX_BAN.set(on_gmax_banlist);
@@ -151,6 +164,9 @@ fn main() {
 
                 metrics::RPC_PEER_INFO_TIMEOFFSET_PLUS10S.set(timeoffset_plus10s);
                 metrics::RPC_PEER_INFO_TIMEOFFSET_MINUS10S.set(timeoffset_minus10s);
+
+                metrics::RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_TO.set(bip152_highbandwidth_to);
+                metrics::RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_FROM.set(bip152_highbandwidth_from);
             }
         }
     }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -105,6 +105,9 @@ fn main() {
 
                 let mut pings = vec![];
                 let mut min_pings = vec![];
+                // Count the number of peers that have a ping_wait larger than 5 seconds.
+                // These are good candidates for dropping connections due to network issues.
+                let mut ping_wait_larger_5s = 0;
 
                 let mut peers_by_transport_protocol_type: BTreeMap<&str, i64> = BTreeMap::new();
                 let mut peers_by_network: BTreeMap<&str, i64> = BTreeMap::new();
@@ -157,6 +160,9 @@ fn main() {
                     }
                     if peer.minimum_ping > 0.0 {
                         min_pings.push(peer.minimum_ping * 1000.0);
+                    }
+                    if peer.ping_wait > 5.0 {
+                        ping_wait_larger_5s += 1;
                     }
 
                     if peer.bip152_hb_to {
@@ -217,6 +223,7 @@ fn main() {
                 metrics::RPC_PEER_INFO_PING_MEDIAN.set(stat_util::median_f64(&pings));
                 metrics::RPC_PEER_INFO_MINPING_MEAN.set(stat_util::mean_f64(&min_pings));
                 metrics::RPC_PEER_INFO_MINPING_MEDIAN.set(stat_util::median_f64(&min_pings));
+                metrics::RPC_PEER_INFO_PING_WAIT_LARGER_5_SECONDS_PEERS.set(ping_wait_larger_5s);
 
                 metrics::RPC_PEER_INFO_TIMEOFFSET_PLUS10S.set(timeoffset_plus10s);
                 metrics::RPC_PEER_INFO_TIMEOFFSET_MINUS10S.set(timeoffset_minus10s);

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -111,13 +111,13 @@ fn main() {
                     addr_processed_total += peer.addr_processed;
                 }
 
-                metrics::PEER_INFO_LIST_CONNECTIONS_GMAX_BAN.set(on_gmax_banlist);
-                metrics::PEER_INFO_LIST_CONNECTIONS_MONERO_BAN.set(on_monero_banlist);
-                metrics::PEER_INFO_LIST_CONNECTIONS_TOR_EXIT.set(on_tor_exit_list);
-                metrics::PEER_INFO_LIST_CONNECTIONS_LINKINGLION.set(on_linkinglion_list);
-                metrics::PEER_INFO_ADDR_RATELIMITED_PEERS.set(addr_rate_limited_peers);
-                metrics::PEER_INFO_ADDR_RATELIMITED_TOTAL.set(addr_rate_limited_total as i64);
-                metrics::PEER_INFO_ADDR_PROCESSED_TOTAL.set(addr_processed_total as i64);
+                metrics::RPC_PEER_INFO_LIST_CONNECTIONS_GMAX_BAN.set(on_gmax_banlist);
+                metrics::RPC_PEER_INFO_LIST_CONNECTIONS_MONERO_BAN.set(on_monero_banlist);
+                metrics::RPC_PEER_INFO_LIST_CONNECTIONS_TOR_EXIT.set(on_tor_exit_list);
+                metrics::RPC_PEER_INFO_LIST_CONNECTIONS_LINKINGLION.set(on_linkinglion_list);
+                metrics::RPC_PEER_INFO_ADDR_RATELIMITED_PEERS.set(addr_rate_limited_peers);
+                metrics::RPC_PEER_INFO_ADDR_RATELIMITED_TOTAL.set(addr_rate_limited_total as i64);
+                metrics::RPC_PEER_INFO_ADDR_PROCESSED_TOTAL.set(addr_processed_total as i64);
             }
         }
     }

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -99,6 +99,7 @@ fn main() {
                 let mut addr_rate_limited_peers = 0; // number of peers that had at least one address rate limited.
                 let mut addr_rate_limited_total: u64 = 0; // total number of rate-limited addresses
                 let mut addr_processed_total: u64 = 0; // total number of processed addresses
+                let mut addr_relay_enabled_peers = 0; // nmber of peers we participate in address relay with
 
                 let mut pings = vec![];
                 let mut min_pings = vec![];
@@ -124,6 +125,10 @@ fn main() {
 
                     addr_rate_limited_total += peer.addr_rate_limited;
                     addr_processed_total += peer.addr_processed;
+
+                    if peer.addr_relay_enabled {
+                        addr_relay_enabled_peers += 1;
+                    }
 
                     if peer.time_offset < -10 {
                         timeoffset_minus10s += 1;
@@ -153,9 +158,11 @@ fn main() {
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_MONERO_BAN.set(on_monero_banlist);
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_TOR_EXIT.set(on_tor_exit_list);
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_LINKINGLION.set(on_linkinglion_list);
+
                 metrics::RPC_PEER_INFO_ADDR_RATELIMITED_PEERS.set(addr_rate_limited_peers);
                 metrics::RPC_PEER_INFO_ADDR_RATELIMITED_TOTAL.set(addr_rate_limited_total as i64);
                 metrics::RPC_PEER_INFO_ADDR_PROCESSED_TOTAL.set(addr_processed_total as i64);
+                metrics::RPC_PEER_INFO_ADDR_RELAY_ENABLED_PEERS.set(addr_relay_enabled_peers);
 
                 metrics::RPC_PEER_INFO_PING_MEAN.set(stat_util::mean_f64(&pings));
                 metrics::RPC_PEER_INFO_PING_MEDIAN.set(stat_util::median_f64(&pings));

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -109,6 +109,7 @@ fn main() {
                 let mut peers_by_transport_protocol_type: BTreeMap<&str, i64> = BTreeMap::new();
                 let mut peers_by_network: BTreeMap<&str, i64> = BTreeMap::new();
                 let mut peers_by_connection_type: BTreeMap<&str, i64> = BTreeMap::new();
+                let mut peers_by_protocol_version: BTreeMap<u32, i64> = BTreeMap::new();
 
                 // When we requested a block, but a peer hasn't yet sent us the block,
                 // the block is considered inflight. If a peer doesn't send us a block at all,
@@ -185,6 +186,11 @@ fn main() {
                         .entry(&peer.connection_type)
                         .and_modify(|e| *e += 1)
                         .or_insert(1);
+
+                    peers_by_protocol_version
+                        .entry(peer.version)
+                        .and_modify(|e| *e += 1)
+                        .or_insert(1);
                 }
 
                 metrics::RPC_PEER_INFO_LIST_CONNECTIONS_GMAX_BAN.set(on_gmax_banlist);
@@ -232,6 +238,13 @@ fn main() {
                 for (k, v) in peers_by_connection_type.iter() {
                     metrics::RPC_PEER_INFO_CONNECTION_TYPE_PEERS
                         .with_label_values(&[k])
+                        .set(*v);
+                }
+
+                metrics::RPC_PEER_INFO_PROTOCOL_VERSION_PEERS.reset();
+                for (k, v) in peers_by_protocol_version.iter() {
+                    metrics::RPC_PEER_INFO_PROTOCOL_VERSION_PEERS
+                        .with_label_values(&[k.to_string()])
                         .set(*v);
                 }
             }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -1,9 +1,9 @@
 use shared::lazy_static::lazy_static;
 use shared::prometheus::{
-    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
-    HistogramOpts, Opts,
+    register_gauge, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, HistogramOpts, Opts,
 };
-use shared::prometheus::{HistogramVec, IntCounter, IntCounterVec, IntGauge};
+use shared::prometheus::{Gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge};
 
 // Prometheus Metrics
 
@@ -690,6 +690,38 @@ lazy_static! {
     pub static ref RPC_PEER_INFO_ADDR_PROCESSED_TOTAL: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_addr_processed_total", "Number of addressed processed across all connected peers (see bitcoin/bitcoin #22387).")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Median ping of all connected peers.
+    pub static ref RPC_PEER_INFO_PING_MEDIAN: Gauge =
+    register_gauge!(
+        Opts::new("peer_info_ping_median", "Median ping (in milliseconds) of all connected peers.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Mean ping of all connected peers.
+    pub static ref RPC_PEER_INFO_PING_MEAN: Gauge =
+    register_gauge!(
+        Opts::new("peer_info_ping_mean", "Mean ping (in milliseconds) of all connected peers.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Median min_ping of all connected peers.
+    pub static ref RPC_PEER_INFO_MINPING_MEDIAN: Gauge =
+    register_gauge!(
+        Opts::new("peer_info_minping_median", "Median min_ping (in milliseconds) of all connected peers.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Mean min_ping of all connected peers.
+    pub static ref RPC_PEER_INFO_MINPING_MEAN: Gauge =
+    register_gauge!(
+        Opts::new("peer_info_minping_mean", "Mean min_ping (in milliseconds) of all connected peers.")
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -41,6 +41,7 @@ pub const LABEL_MEMPOOL_REASON: &str = "reason";
 pub const LABEL_RPC_TRANSPORT_PROTOCOL_TYPE: &str = "transport_protocol_type";
 pub const LABEL_RPC_NETWORK_TYPE: &str = "network";
 pub const LABEL_RPC_CONNECTION_TYPE: &str = "connection_type";
+pub const LABEL_RPC_PROTOCOL_VERSION: &str = "protocol_version";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -803,6 +804,15 @@ lazy_static! {
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC),
         &[LABEL_RPC_CONNECTION_TYPE]
+    ).unwrap();
+
+    /// Number of peers by protocol_version
+    pub static ref RPC_PEER_INFO_PROTOCOL_VERSION_PEERS: IntGaugeVec =
+    register_int_gauge_vec!(
+        Opts::new("peer_info_protocol_version_peers", "Number of peers by protocol_version")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC),
+        &[LABEL_RPC_PROTOCOL_VERSION]
     ).unwrap();
 
     /// Number of peers that have inflight blocks for us

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -742,4 +742,20 @@ lazy_static! {
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
 
+    /// Number of peers we selected peer as (compact blocks) high-bandwidth peer
+    pub static ref RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_TO: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_bip152_highbandwidth_to", "Number of peers we selected peer as (compact blocks) high-bandwidth peer.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers that selected us as (compact blocks) high-bandwidth peer
+    pub static ref RPC_PEER_INFO_BIP152_HIGHBANDWIDTH_FROM: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_bip152_highbandwidth_from", "Number of peers that selected us as (compact blocks) high-bandwidth peer.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -1,9 +1,9 @@
 use shared::lazy_static::lazy_static;
 use shared::prometheus::{
     register_gauge, register_histogram_vec, register_int_counter, register_int_counter_vec,
-    register_int_gauge, HistogramOpts, Opts,
+    register_int_gauge, register_int_gauge_vec, HistogramOpts, Opts,
 };
-use shared::prometheus::{Gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge};
+use shared::prometheus::{Gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 // Prometheus Metrics
 
@@ -37,6 +37,8 @@ pub const LABEL_CONN_MISBEHAVING_MESSAGE: &str = "misbehavingmessage";
 pub const LABEL_CONN_MISBEHAVING_ID: &str = "id";
 pub const LABEL_ADDRMAN_NEW_INSERT_SUCCESS: &str = "inserted";
 pub const LABEL_MEMPOOL_REASON: &str = "reason";
+
+pub const LABEL_RPC_TRANSPORT_PROTOCOL_TYPE: &str = "transport_protocol_type";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -772,6 +774,15 @@ lazy_static! {
         Opts::new("peer_info_addr_relay_enabled_peers", "Number of peers we particiate in addr relay with (addr_relay_enabled).")
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers by transport_protocol_type (usually v1 and v2)
+    pub static ref RPC_PEER_INFO_TRANSPORT_PROTOCOL_TYPE_PEERS: IntGaugeVec =
+    register_int_gauge_vec!(
+        Opts::new("peer_info_transport_protocol_type_peers", "Number of peers by transport_protocol_type (usually v1 and v2).")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC),
+        &[LABEL_RPC_TRANSPORT_PROTOCOL_TYPE]
     ).unwrap();
 
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -766,4 +766,12 @@ lazy_static! {
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
 
+    /// Number of peers we particiate in addr relay with (addr_relay_enabled)
+    pub static ref RPC_PEER_INFO_ADDR_RELAY_ENABLED_PEERS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_addr_relay_enabled_peers", "Number of peers we particiate in addr relay with (addr_relay_enabled).")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -42,6 +42,7 @@ pub const LABEL_RPC_TRANSPORT_PROTOCOL_TYPE: &str = "transport_protocol_type";
 pub const LABEL_RPC_NETWORK_TYPE: &str = "network";
 pub const LABEL_RPC_CONNECTION_TYPE: &str = "connection_type";
 pub const LABEL_RPC_PROTOCOL_VERSION: &str = "protocol_version";
+pub const LABEL_RPC_ASN: &str = "ASN";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -813,6 +814,15 @@ lazy_static! {
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC),
         &[LABEL_RPC_PROTOCOL_VERSION]
+    ).unwrap();
+
+    /// Number of peers by AS number
+    pub static ref RPC_PEER_INFO_ASN_PEERS: IntGaugeVec =
+    register_int_gauge_vec!(
+        Opts::new("peer_info_asn_peers", "Number of peers by AS number")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC),
+        &[LABEL_RPC_ASN]
     ).unwrap();
 
     /// Number of peers that have inflight blocks for us

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -638,7 +638,7 @@ lazy_static! {
     // -------------------- RPC
 
     /// Number of peers connected that are on the 2018 ban list by gmax.
-    pub static ref PEER_INFO_LIST_CONNECTIONS_GMAX_BAN: IntGauge =
+    pub static ref RPC_PEER_INFO_LIST_CONNECTIONS_GMAX_BAN: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_list_peers_gmax_ban", "Number of peers connected to us that are on the 2018 ban list by gmax.")
             .namespace(NAMESPACE)
@@ -646,7 +646,7 @@ lazy_static! {
     ).unwrap();
 
     /// Number of peers connected to us that are on the monero banlist.
-    pub static ref PEER_INFO_LIST_CONNECTIONS_MONERO_BAN: IntGauge =
+    pub static ref RPC_PEER_INFO_LIST_CONNECTIONS_MONERO_BAN: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_list_peers_monero_ban", "Number of peers connected to us that are on the monero banlist.")
             .namespace(NAMESPACE)
@@ -654,7 +654,7 @@ lazy_static! {
     ).unwrap();
 
     /// Number of peers connected to us that are on the list of tor exit nodes.
-    pub static ref PEER_INFO_LIST_CONNECTIONS_TOR_EXIT: IntGauge =
+    pub static ref RPC_PEER_INFO_LIST_CONNECTIONS_TOR_EXIT: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_list_peers_tor_exit", "Number of peers connected to us that are on the list of tor exit nodes.")
             .namespace(NAMESPACE)
@@ -663,7 +663,7 @@ lazy_static! {
 
 
     /// Number of peers connected to us that are known LinkingLion nodes.
-    pub static ref PEER_INFO_LIST_CONNECTIONS_LINKINGLION: IntGauge =
+    pub static ref RPC_PEER_INFO_LIST_CONNECTIONS_LINKINGLION: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_list_peers_linkinglion", "Number of peers connected to us that are known LinkingLion nodes.")
             .namespace(NAMESPACE)
@@ -671,7 +671,7 @@ lazy_static! {
     ).unwrap();
 
     /// Number of peers connected to us that had at least one address rate-limited from being processed (see bitcoin/bitcoin #22387).
-    pub static ref PEER_INFO_ADDR_RATELIMITED_PEERS: IntGauge =
+    pub static ref RPC_PEER_INFO_ADDR_RATELIMITED_PEERS: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_addr_ratelimited_peers", "Number of peers connected to us that had at least one address rate-limited from being processed (see bitcoin/bitcoin #22387)")
             .namespace(NAMESPACE)
@@ -679,7 +679,7 @@ lazy_static! {
     ).unwrap();
 
     /// Number of addressed rate-limited across all connected peers (see bitcoin/bitcoin #22387).
-    pub static ref PEER_INFO_ADDR_RATELIMITED_TOTAL: IntGauge =
+    pub static ref RPC_PEER_INFO_ADDR_RATELIMITED_TOTAL: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_addr_ratelimited_total", "Number of addressed rate-limited across all connected peers (see bitcoin/bitcoin #22387).")
             .namespace(NAMESPACE)
@@ -687,7 +687,7 @@ lazy_static! {
     ).unwrap();
 
     /// Number of addressed processed across all connected peers (see bitcoin/bitcoin #22387).
-    pub static ref PEER_INFO_ADDR_PROCESSED_TOTAL: IntGauge =
+    pub static ref RPC_PEER_INFO_ADDR_PROCESSED_TOTAL: IntGauge =
     register_int_gauge!(
         Opts::new("peer_info_addr_processed_total", "Number of addressed processed across all connected peers (see bitcoin/bitcoin #22387).")
             .namespace(NAMESPACE)

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -758,4 +758,12 @@ lazy_static! {
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
 
+    /// Number of peers we are connected to
+    pub static ref RPC_PEER_INFO_NUM_PEERS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_num_peers", "Number of peers we are connected to.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -39,6 +39,7 @@ pub const LABEL_ADDRMAN_NEW_INSERT_SUCCESS: &str = "inserted";
 pub const LABEL_MEMPOOL_REASON: &str = "reason";
 
 pub const LABEL_RPC_TRANSPORT_PROTOCOL_TYPE: &str = "transport_protocol_type";
+pub const LABEL_RPC_NETWORK_TYPE: &str = "network";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -783,6 +784,15 @@ lazy_static! {
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC),
         &[LABEL_RPC_TRANSPORT_PROTOCOL_TYPE]
+    ).unwrap();
+
+    /// Number of peers by network
+    pub static ref RPC_PEER_INFO_NETWORK_PEERS: IntGaugeVec =
+    register_int_gauge_vec!(
+        Opts::new("peer_info_network_peers", "Number of peers by network.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC),
+        &[LABEL_RPC_NETWORK_TYPE]
     ).unwrap();
 
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -841,6 +841,12 @@ lazy_static! {
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
 
-
+    /// Number of peers that have a ping_wait larger than 5 seconds.
+    pub static ref RPC_PEER_INFO_PING_WAIT_LARGER_5_SECONDS_PEERS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_ping_wait_larger_5_seconds_block_peers", "Number of peers that have a ping_wait larger than 5 seconds.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
 
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -40,6 +40,7 @@ pub const LABEL_MEMPOOL_REASON: &str = "reason";
 
 pub const LABEL_RPC_TRANSPORT_PROTOCOL_TYPE: &str = "transport_protocol_type";
 pub const LABEL_RPC_NETWORK_TYPE: &str = "network";
+pub const LABEL_RPC_CONNECTION_TYPE: &str = "connection_type";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -795,6 +796,15 @@ lazy_static! {
         &[LABEL_RPC_NETWORK_TYPE]
     ).unwrap();
 
+    /// Number of peers by connection_type
+    pub static ref RPC_PEER_INFO_CONNECTION_TYPE_PEERS: IntGaugeVec =
+    register_int_gauge_vec!(
+        Opts::new("peer_info_connection_type_peers", "Number of peers by connection_type")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC),
+        &[LABEL_RPC_CONNECTION_TYPE]
+    ).unwrap();
+
     /// Number of peers that have inflight blocks for us
     pub static ref RPC_PEER_INFO_INFLIGHT_BLOCK_PEERS: IntGauge =
     register_int_gauge!(
@@ -810,6 +820,7 @@ lazy_static! {
             .namespace(NAMESPACE)
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
+
 
 
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -795,4 +795,21 @@ lazy_static! {
         &[LABEL_RPC_NETWORK_TYPE]
     ).unwrap();
 
+    /// Number of peers that have inflight blocks for us
+    pub static ref RPC_PEER_INFO_INFLIGHT_BLOCK_PEERS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_inflight_block_peers", "Number of peers that have inflight blocks for us.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of distinct inflight blocks heights that peers are sending us
+    pub static ref RPC_PEER_INFO_INFLIGHT_DISTINCT_BLOCK_HEIGHTS: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_inflight_distinct_blocks_heights", "Number of distinct inflight blocks heights that peers are sending us.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -726,4 +726,20 @@ lazy_static! {
             .subsystem(SUBSYSTEM_RPC)
     ).unwrap();
 
+    /// Number of peers with a time offset greater than 10s.
+    pub static ref RPC_PEER_INFO_TIMEOFFSET_PLUS10S: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_timeoffset_plus10s", "Number of peers with a time offset greater than 10s.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
+    /// Number of peers with a time offset smaller than -10s.
+    pub static ref RPC_PEER_INFO_TIMEOFFSET_MINUS10S: IntGauge =
+    register_int_gauge!(
+        Opts::new("peer_info_timeoffset_minus10s", "Number of peers with a time offset smaller than -10s.")
+            .namespace(NAMESPACE)
+            .subsystem(SUBSYSTEM_RPC)
+    ).unwrap();
+
 }

--- a/tools/metrics/src/stat_util.rs
+++ b/tools/metrics/src/stat_util.rs
@@ -1,0 +1,95 @@
+pub fn median_f64(l: &[f64]) -> f64 {
+    // Filter out NaNs
+    let mut a: Vec<f64> = l.iter().cloned().filter(|x| !x.is_nan()).collect();
+
+    if a.is_empty() {
+        return 0.0;
+    }
+
+    a.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let len = a.len();
+    if len % 2 == 1 {
+        a[len / 2]
+    } else {
+        (a[len / 2 - 1] + a[len / 2]) / 2.0
+    }
+}
+
+pub fn mean_f64(l: &[f64]) -> f64 {
+    let filtered: Vec<f64> = l.iter().cloned().filter(|x| !x.is_nan()).collect();
+
+    if filtered.is_empty() {
+        return 0.0;
+    }
+
+    filtered.iter().sum::<f64>() / filtered.len() as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_median_empty() {
+        let v: &[f64] = &[];
+        assert_eq!(median_f64(v), 0.0);
+    }
+
+    #[test]
+    fn test_median_single() {
+        let v = &[42.0];
+        assert_eq!(median_f64(v), 42.0);
+    }
+
+    #[test]
+    fn test_median_odd() {
+        let v = &[3.0, 1.0, 2.0];
+        // Sorted: [1.0, 2.0, 3.0], median = 2.0
+        assert_eq!(median_f64(v), 2.0);
+    }
+
+    #[test]
+    fn test_median_even() {
+        let v = &[3.0, 1.0, 4.0, 2.0];
+        // Sorted: [1.0, 2.0, 3.0, 4.0], median = (2.0 + 3.0) / 2 = 2.5
+        assert_eq!(median_f64(v), 2.5);
+    }
+
+    #[test]
+    fn test_median_nan_multi() {
+        let v = &[1.0, f64::NAN, 2.0];
+        // Sorted: [1.0, 2.0], median = (1.0 + 2.0) / 2 = 1.5
+        assert_eq!(median_f64(v), 1.5);
+    }
+
+    #[test]
+    fn test_median_nan_single() {
+        let v = &[f64::NAN];
+        assert_eq!(median_f64(v), 0.0);
+    }
+
+    #[test]
+    fn test_mean_empty() {
+        let v: &[f64] = &[];
+        assert_eq!(mean_f64(v), 0.0);
+    }
+
+    #[test]
+    fn test_mean_single() {
+        let v = &[42.0];
+        assert_eq!(mean_f64(v), 42.0);
+    }
+
+    #[test]
+    fn test_mean_multiple() {
+        let v = &[1.0, 2.0, 3.0, 4.0];
+        assert_eq!(mean_f64(v), 2.5);
+    }
+
+    #[test]
+    fn test_mean_negative() {
+        let v = &[-1.0, 1.0];
+        assert_eq!(mean_f64(v), 0.0);
+    }
+}


### PR DESCRIPTION
Addresses #198:
- [x] median ping time across all connected peers
- [x] average ping time across all connected peers
- [x] median min_ping time across all connected peers
- [x] average min_ping time across all connected peers
- [x] count of peers with a time_offset (their clock compared to our clock) larger than 10s into the future or 10s into the past
- [x] count of peers we consider to be BIP152 high bandwidth ``bip152_hb_to``, and count of peers that consider us to be BIP152 high bandwidth `bip152_hb_from`
- [x] count of peers (while we have this via the connection tracepoints already, good to have this metric alone here too if someone isn't using the tracepoints)
- [x] count of `addr_relay_enabled` peers
- [x] count of `v1` peers (`transport_protocol_type`)
- [x] count of `v2` peers (`transport_protocol_type`)
- [x] count of peers by network
- [x] count of peers that have inflight blocks, and count of distinct inflight blocks
- [x] count of peers by connection_type
- [x] count by version (not subversion, version like 70001)
- [x] for non-zero AS fields, count the number of connections per AS
- [x] count of peers with a ping_await higher than 5s