### PR TITLE
add: prometheus metric for LinkingLion traffic

### DIFF
--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -264,6 +264,18 @@ fn main() {
             .with(&labels)
             .inc_by(msg.meta.size);
 
+        if util::is_on_linkinglion_banlist(&ip) {
+            let mut labels_ll = HashMap::<&str, &str>::new();
+            labels_ll.insert(metrics::LABEL_P2P_MSG_TYPE, &msg.meta.command);
+            labels_ll.insert(metrics::LABEL_P2P_DIRECTION, &direction);
+            metrics::P2P_MESSAGE_COUNT_LINKINGLION
+                .with(&labels_ll)
+                .inc();
+            metrics::P2P_MESSAGE_BYTES_LINKINGLION
+                .with(&labels_ll)
+                .inc_by(msg.meta.size);
+        }
+
         metrics::P2P_MESSAGE_BYTES_BY_SUBNET
             .with_label_values(&[&direction, &subnet])
             .inc_by(msg.meta.size);

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -149,6 +149,24 @@ lazy_static! {
         &[LABEL_P2P_DIRECTION, LABEL_P2P_SUBNET]
     ).unwrap();
 
+    /// Number of P2P network messages bytes send or received by LinkingLion peers.
+    pub static ref P2P_MESSAGE_BYTES_LINKINGLION: IntCounterVec =
+        register_int_counter_vec!(
+            Opts::new("message_bytes_linkinglion", "Number of P2P network messages bytes send or received by LinkingLion peers.")
+                .namespace(NAMESPACE)
+                .subsystem(SUBSYSTEM_P2P),
+            &[LABEL_P2P_MSG_TYPE, LABEL_P2P_DIRECTION]
+        ).unwrap();
+
+    /// Number of P2P network messages send or received by LinkingLion peers.
+    pub static ref P2P_MESSAGE_COUNT_LINKINGLION: IntCounterVec =
+        register_int_counter_vec!(
+            Opts::new("message_count_linkinglion", "Number of P2P network messages send or received by LinkingLion peers.")
+                .namespace(NAMESPACE)
+                .subsystem(SUBSYSTEM_P2P),
+            &[LABEL_P2P_MSG_TYPE, LABEL_P2P_DIRECTION]
+        ).unwrap();
+
     // -------------------- Addr
 
     /// Histogram of the number of addresses contained in an "addr" message.


### PR DESCRIPTION
Instead of having an extra tool as discussed in #142, do it in the `metrics` tool.

closes #142

Needs some dashboards..