### PR TITLE
refactor: use `async_nats` in websocket tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,7 +2728,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "shared",
- "tungstenite",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/tools/websocket/Cargo.toml
+++ b/tools/websocket/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
-tungstenite = "0.27.0"
+tokio-tungstenite = "0.27.0"
 serde_json = "1.0.142"
 
 [features]


### PR DESCRIPTION
As part of #192, use async_nats instead of the nats create in the websocket tool.