### PR TITLE
integration tests for RPC extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "ring",
  "rustls-native-certs",
  "rustls-pemfile",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -287,12 +287,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -452,12 +478,56 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corepc-client"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565724b3d7556c06827b27c468333bbf97e2173097aaed576b5da73faf7a1e04"
+dependencies = [
+ "bitcoin",
+ "corepc-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-client"
+version = "0.8.0"
 source = "git+https://github.com/0xb10c/corepc.git?branch=2025-07-peer-observer-rpc-extractor#5e1b6091ec8aeeba9a9db20ee63141e09f40da25"
 dependencies = [
  "bitcoin",
- "corepc-types",
+ "corepc-types 0.8.0 (git+https://github.com/0xb10c/corepc.git?branch=2025-07-peer-observer-rpc-extractor)",
  "jsonrpc",
  "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-node"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "596e4ee1ff3616ae3f36e89e0b847604034ba689243cc5e7dd08da395b88ec58"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes",
+ "corepc-client 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2",
+ "log",
+ "minreq",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "which",
+ "zip",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7f2faedffc7c654e348e2da6c6416090525c6072979fee9681d620d1d398a4"
+dependencies = [
+ "bitcoin",
  "serde",
  "serde_json",
 ]
@@ -479,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -708,10 +787,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1182,10 +1283,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
+ "redox_syscall 0.5.17",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1254,8 +1372,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678"
 dependencies = [
  "log",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -1383,7 +1504,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -1669,6 +1790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.4.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,8 +1872,33 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -1755,7 +1910,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -1787,6 +1942,16 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1825,6 +1990,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secp256k1"
@@ -1969,7 +2144,8 @@ dependencies = [
  "base32",
  "bitcoin",
  "clap",
- "corepc-client",
+ "corepc-client 0.8.0 (git+https://github.com/0xb10c/corepc.git?branch=2025-07-peer-observer-rpc-extractor)",
+ "corepc-node",
  "futures",
  "hex",
  "lazy_static",
@@ -2105,6 +2281,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,8 +2299,8 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
+ "redox_syscall 0.3.5",
+ "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
 
@@ -2245,7 +2432,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -2510,6 +2697,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -2533,6 +2726,15 @@ dependencies = [
  "serde_json",
  "shared",
  "tokio-tungstenite",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2622,6 +2824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,11 +2856,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2665,6 +2893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,6 +2909,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2689,10 +2929,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2707,6 +2959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2975,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2731,6 +2995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +3011,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -2762,6 +3038,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+dependencies = [
+ "libc",
+ "rustix 1.0.8",
+]
 
 [[package]]
 name = "yoke"
@@ -2834,4 +3120,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/extractors/rpc/Cargo.toml
+++ b/extractors/rpc/Cargo.toml
@@ -9,3 +9,9 @@ shared = { path = "../../shared" }
 [features]
 # Treat warnings as a build error.
 strict = []
+
+# Run integration tests needing a NATS server.
+nats_integration_tests = []
+
+# Run integration tests needing a Bitcoin Core node.
+node_integration_tests = []

--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -37,6 +37,8 @@ Options:
           An RPC cookie file for authentication with the Bitcoin Core RPC endpoint
       --query-interval <QUERY_INTERVAL>
           Interval (in seconds) in which to query from the Bitcoin Core RPC endpoint [default: 10]
+      --disable-getpeerinfo
+          Disable quering and publishing of `getpeerinfo` data
   -h, --help
           Print help
   -V, --version

--- a/extractors/rpc/src/error.rs
+++ b/extractors/rpc/src/error.rs
@@ -1,7 +1,10 @@
 use shared::async_nats;
+use shared::async_nats::ConnectErrorKind;
 use shared::corepc_client::client_sync::Error as RPCError;
+use shared::log::SetLoggerError;
 use std::error;
 use std::fmt;
+use std::io;
 use std::time::SystemTimeError;
 
 #[derive(Debug)]
@@ -46,5 +49,59 @@ impl From<SystemTimeError> for FetchOrPublishError {
 impl From<async_nats::error::Error<async_nats::client::PublishErrorKind>> for FetchOrPublishError {
     fn from(e: async_nats::error::Error<async_nats::client::PublishErrorKind>) -> Self {
         FetchOrPublishError::NatsPublish(e)
+    }
+}
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    SetLogger(SetLoggerError),
+    Io(io::Error),
+    Corepc(shared::corepc_client::client_sync::Error),
+    NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::SetLogger(e) => write!(f, "set logger error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+            RuntimeError::Corepc(e) => write!(f, "RPC client error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::SetLogger(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+            RuntimeError::Corepc(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<SetLoggerError> for RuntimeError {
+    fn from(e: SetLoggerError) -> Self {
+        RuntimeError::SetLogger(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}
+
+impl From<shared::corepc_client::client_sync::Error> for RuntimeError {
+    fn from(e: shared::corepc_client::client_sync::Error) -> Self {
+        RuntimeError::Corepc(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
+        RuntimeError::NatsConnect(e)
     }
 }

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -57,6 +57,26 @@ pub struct Args {
     pub query_interval: u64,
 }
 
+impl Args {
+    pub fn new(
+        nats_address: String,
+        log_level: log::Level,
+        rpc_host: String,
+        rpc_cookie_file: String,
+        query_interval: u64,
+    ) -> Args {
+        Self {
+            nats_address,
+            log_level,
+            rpc_host,
+            rpc_password: None,
+            rpc_user: None,
+            rpc_cookie_file: Some(rpc_cookie_file),
+            query_interval,
+        }
+    }
+}
+
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
     let auth: Auth = match args.rpc_cookie_file {
         Some(path) => Auth::CookieFile(path.into()),

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,0 +1,118 @@
+use shared::clap::{ArgGroup, Parser};
+use shared::corepc_client::client_sync::Auth;
+use shared::corepc_client::client_sync::v29::Client;
+use shared::event_msg::EventMsg;
+use shared::event_msg::event_msg::Event;
+use shared::log::{self, error};
+use shared::nats_subjects::Subject;
+use shared::prost::Message;
+use shared::rpc;
+use shared::tokio::time::{self, Duration};
+use shared::{async_nats, clap};
+
+mod error;
+
+use error::FetchOrPublishError;
+
+/// The peer-observer rpc-extractor periodically queries data from the
+/// Bitcoin Core RPC endpoint and publishes the results as events into
+/// a NATS pub-sub queue.
+#[derive(Parser, Debug)]
+#[clap(group(
+    ArgGroup::new("auth")
+        .required(true)
+        .multiple(false)
+        .args(&["rpc_cookie_file", "rpc_user"])
+))]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Address of the NATS server where the extractor will publish messages to.
+    #[arg(short, long, default_value = "127.0.0.1:4222")]
+    pub nats_address: String,
+
+    /// The log level the extractor should run with. Valid log levels are "trace",
+    /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html.
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    pub log_level: log::Level,
+
+    /// Address of the Bitcoin Core RPC endpoint the RPC extractor will query.
+    #[arg(long, default_value = "127.0.0.1:8332")]
+    pub rpc_host: String,
+
+    /// RPC username for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(long)]
+    pub rpc_user: Option<String>,
+
+    /// RPC password for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(requires = "rpc_user", long)]
+    pub rpc_password: Option<String>,
+
+    /// An RPC cookie file for authentication with the Bitcoin Core RPC endpoint.
+    #[arg(long)]
+    pub rpc_cookie_file: Option<String>,
+
+    /// Interval (in seconds) in which to query from the Bitcoin Core RPC endpoint.
+    #[arg(long, default_value_t = 10)]
+    pub query_interval: u64,
+}
+
+pub async fn run(args: Args) -> () {
+    let auth: Auth = match args.rpc_cookie_file {
+        Some(path) => Auth::CookieFile(path.into()),
+        None => Auth::UserPass(
+            args.rpc_user.expect("need an RPC user"),
+            args.rpc_password.expect("need an RPC password"),
+        ),
+    };
+    let rpc_client = match Client::new_with_auth(&format!("http://{}", args.rpc_host), auth) {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Could not create RPC client: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    log::debug!("Connecting to NATS server at {}..", args.nats_address);
+    let nats_client = match async_nats::connect(&args.nats_address).await {
+        Ok(nats_client) => nats_client,
+        Err(e) => {
+            error!(
+                "Could not connect to NATS server at {}: {}",
+                args.nats_address, e
+            );
+            std::process::exit(1);
+        }
+    };
+    log::info!("Connected to NATS server at {}", &args.nats_address);
+
+    let duration_sec = Duration::from_secs(args.query_interval);
+    let mut interval = time::interval(duration_sec);
+    log::info!(
+        "Querying the Bitcoin Core RPC interface every {:?}.",
+        duration_sec
+    );
+
+    loop {
+        interval.tick().await;
+
+        if let Err(e) = getpeerinfo(&rpc_client, &nats_client).await {
+            log::error!("Could not fetch and publish 'getpeerinfo': {}", e)
+        }
+    }
+}
+
+async fn getpeerinfo(
+    rpc_client: &Client,
+    nats_client: &async_nats::Client,
+) -> Result<(), FetchOrPublishError> {
+    let peer_info = rpc_client.get_peer_info()?;
+
+    let proto = EventMsg::new(Event::Rpc(rpc::RpcEvent {
+        event: Some(rpc::rpc_event::Event::PeerInfos(peer_info.into())),
+    }))?;
+
+    nats_client
+        .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
+        .await?;
+    Ok(())
+}

--- a/extractors/rpc/src/main.rs
+++ b/extractors/rpc/src/main.rs
@@ -1,4 +1,5 @@
 use rpc_extractor::Args;
+use shared::log::error;
 use shared::tokio;
 use shared::{clap::Parser, simple_logger};
 
@@ -10,5 +11,7 @@ async fn main() {
         eprintln!("rpc extractor error: {}", e);
     }
 
-    rpc_extractor::run(args).await;
+    if let Err(e) = rpc_extractor::run(args).await {
+        error!("rpc extractor error: {}", e);
+    }
 }

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+use shared::{
+    async_nats,
+    corepc_node,
+    event_msg::{EventMsg, event_msg::Event},
+    futures::StreamExt,
+    log::{self, info},
+    nats_server_for_testing::NatsServerForTesting,
+    prost::Message,
+    rand::{self, Rng},
+    rpc::rpc_event::Event::PeerInfos,
+    simple_logger::SimpleLogger,
+    tokio::{self, sync::watch},
+};
+
+use std::{
+    sync::{
+        Once, OnceLock,
+        atomic::{AtomicU16, Ordering},
+    },
+};
+
+use rpc_extractor::Args;
+
+static INIT: Once = Once::new();
+static NEXT_NATS_PORT: OnceLock<AtomicU16> = OnceLock::new();
+
+// 1 second query interval for fast tests
+const QUERY_INTERVAL_SECONDS: u64 = 1;
+
+fn setup() -> u16 {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+
+        let mut rng = rand::rng();
+
+        // choose start ports from the ephemeral port range
+        let nats_start = rng.random_range(49152..65500);
+        NEXT_NATS_PORT.set(AtomicU16::new(nats_start)).unwrap();
+    });
+    let nats_port = NEXT_NATS_PORT.get().unwrap().fetch_add(1, Ordering::SeqCst);
+    nats_port
+}
+
+fn make_test_args(nats_port: u16, rpc_url: String, cookie_file: String) -> Args {
+    Args::new(
+        format!("127.0.0.1:{}", nats_port),
+        log::Level::Trace,
+        rpc_url,
+        cookie_file,
+        QUERY_INTERVAL_SECONDS,
+    )
+}
+
+fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+    info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
+    info!("exe_path={:?}", corepc_node::exe_path());
+
+    if let Ok(exe_path) = corepc_node::exe_path() {
+        info!("Using bitcoind at '{}'", exe_path);
+        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+    }
+
+    info!("Trying to download a bitcoind..");
+    return corepc_node::Node::from_downloaded_with_conf(&conf).unwrap();
+}
+
+fn setup_two_connected_nodes() -> (corepc_node::Node, corepc_node::Node) {
+    // node1 listens for p2p connections
+    let mut node1_conf = corepc_node::Conf::default();
+    node1_conf.p2p = corepc_node::P2P::Yes;
+    let node1 = setup_node(node1_conf);
+
+    // node2 connects to node1
+    let mut node2_conf = corepc_node::Conf::default();
+    node2_conf.p2p = node1.p2p_connect(true).unwrap();
+    let node2 = setup_node(node2_conf);
+
+    (node1, node2)
+}
+
+async fn check(_test_getpeerinfo: bool, check_expected: fn(Event) -> ()) {
+    let (node1, _node2) = setup_two_connected_nodes();
+    let nats_port = setup();
+    let _nats_server = NatsServerForTesting::new(nats_port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_port,
+            node1.rpc_url().replace("http://", ""),
+            node1.params.cookie_file.display().to_string(),
+        );
+        rpc_extractor::run(args, shutdown_rx.clone())
+            .await
+            .expect("rpc extractor failed");
+    });
+
+    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_port))
+        .await
+        .unwrap();
+    let mut sub = nc.subscribe("*").await.unwrap();
+
+    while let Some(msg) = sub.next().await {
+        let unwrapped = EventMsg::decode(msg.payload).unwrap();
+        if let Some(event) = unwrapped.event {
+            check_expected(event);
+            break;
+        }
+    }
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+}
+
+
+#[tokio::test]
+async fn test_integration_rpc_getpeerinfo2() {
+    println!("test that we receive getpeerinfo RPC events");
+
+    check(true, |event| {
+        match event {
+            Event::Rpc(r) => {
+                if let Some(ref e) = r.event {
+                    match e {
+                        PeerInfos(p) => {
+                            // we expect 1 peer to be connected
+                            assert_eq!(p.infos.len(), 1);
+                            let peer = p.infos.first().expect("we have expactly one peer here");
+                            assert_eq!(peer.connection_type, "inbound");
+
+                            return;
+                        }
+                        // TODO: once we have more RPCs, we are going to need this.
+                        //_ => panic!("unexpected RPC data {:?}", r.event),
+                    }
+                }
+            }
+            _ => panic!("unexpected event {:?}", event),
+        }
+    }).await;
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -22,6 +22,7 @@ corepc-client = { git = "https://github.com/0xb10c/corepc.git", branch = "2025-0
 tokio = { version = "1.47.0", features = ["rt-multi-thread", "process", "signal"] }
 futures = "0.3.31"
 rand = "0.9.2"
+corepc-node = { version = "0.8.0", features = ["download", "29_0"] }
 
 [build-dependencies]
 prost-build = "0.14"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -4,6 +4,7 @@ pub extern crate async_nats;
 pub extern crate bitcoin;
 pub extern crate clap;
 pub extern crate corepc_client;
+pub extern crate corepc_node;
 pub extern crate futures;
 pub extern crate lazy_static;
 pub extern crate log;

--- a/shell.nix
+++ b/shell.nix
@@ -26,7 +26,17 @@ pkgs.mkShell {
 
       # for code coverage:
       pkgs.cargo-tarpaulin
+
+      # for integration tests
+      pkgs.bitcoind
     ];
+
+    shellHook = ''
+      # during the integration tests, don't try to download a bitcoind binary
+      # use the nix one instead
+      export BITCOIND_SKIP_DOWNLOAD=1
+      export BITCOIND_EXE=${pkgs.bitcoind}/bin/bitcoind
+    '';
 
     # Use for running integration tests
     NATS_SERVER_BINARY = "${pkgs.nats-server}/bin/nats-server";


### PR DESCRIPTION
As part of #26. 

Uses https://crates.io/crates/corepc-node to start two Bitcoin Core nodes.