### PR TITLE
Add metric for large inv sets (>35) sent to peers

### DIFF
--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -694,6 +694,14 @@ fn handle_p2p_message(msg: &net_msg::Message, timestamp: u64, metrics: metrics::
                         .with_label_values(&[&direction])
                         .inc();
                 }
+                // Large inv-to-send, see bitcoincore.org/en/2024/10/08/disclose-large-inv-to-send/
+                if direction == "outbound" {
+                    let tx_count = count_by_invtype.get("Tx").unwrap_or(&0);
+                    let wtx_count = count_by_invtype.get("WTx").unwrap_or(&0);
+                    if (*tx_count > 35) || (*wtx_count > 35) {
+                        metrics.p2p_invs_outbound_large.inc();
+                    }
+                }
             }
             Msg::Ping(_) => {
                 if msg.meta.inbound {

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -194,6 +194,7 @@ pub struct Metrics {
     pub p2p_inv_entries_histogram: HistogramVec,
     pub p2p_invs_homogeneous: IntCounterVec,
     pub p2p_invs_heterogeneous: IntCounterVec,
+    pub p2p_invs_outbound_large: IntCounter,
     pub p2p_ping_subnet: IntCounterVec,
     pub p2p_oldping_subnet: IntCounterVec,
     pub p2p_version_subnet: IntCounterVec,
@@ -285,6 +286,7 @@ impl Metrics {
         hv!(p2p_inv_entries_histogram, "Histogram number of entries contained in an INV message.", BUCKETS_INV_SIZE, [LABEL_P2P_DIRECTION], registry);
         icv!(p2p_invs_homogeneous, "Number of homogeneous INV entries sent and received.", [LABEL_P2P_DIRECTION], registry);
         icv!(p2p_invs_heterogeneous, "Number of heterogeneous INV entries sent and received.", [LABEL_P2P_DIRECTION], registry);
+        ic!(p2p_invs_outbound_large, "Number of outbound INV messages with more than 35 entries, see https://bitcoincore.org/en/2024/10/08/disclose-large-inv-to-send/ and associated PR https://github.com/bitcoin/bitcoin/pull/27610.", registry);
         icv!(p2p_ping_subnet, "Number of Pings received by subnet (where applicable).", [LABEL_P2P_SUBNET], registry);
         icv!(p2p_oldping_subnet, "Number of 'old' Pings (without a value) received by subnet.", [LABEL_P2P_SUBNET], registry);
         icv!(p2p_version_subnet, "Number of version messages received by subnet.", [LABEL_P2P_SUBNET], registry);
@@ -373,6 +375,7 @@ impl Metrics {
             p2p_inv_entries_histogram,
             p2p_invs_homogeneous,
             p2p_invs_heterogeneous,
+            p2p_invs_outbound_large,
             p2p_ping_subnet,
             p2p_oldping_subnet,
             p2p_version_subnet,


### PR DESCRIPTION
Adds a metric to track inv sets larger than 35 called `p2p_invs_outbound_large`.

closes #220 