### PR TITLE
add: dashboard for number of invs with >35 items

### DIFF
--- a/tools/metrics/dashboards/playlist/inv-with-more-than-35-tx-entries.json
+++ b/tools/metrics/dashboards/playlist/inv-with-more-than-35-tx-entries.json
@@ -1,0 +1,113 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "As a fix for https://bitcoincore.org/en/2024/10/08/disclose-large-inv-to-send/, bitcoin/bitcoin#27610 made the number of tx INV entries dynamic. This tracks how many INVs with more than 35 entries we send to peers.\n\nSee also https://b10c.me/observations/15-inv-to-send-queue/",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 994,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "https://bitcoincore.org/en/2024/10/08/disclose-large-inv-to-send/",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 23,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "increase(peerobserver_p2p_invs_outbound_large[1d])",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Tx/WTx INVs with more than 35 entries in the 24h (see \"Disclosure of DoS due to inv-to-send sets growing too large\")",
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [
+    "big-playlist",
+    "inv"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "[inv] Number of transaction relay INVs with more than 35 entries (Disclosure of DoS due to inv-to-send sets growing too large)",
+  "uid": "e61b5402-9aed-4f52-bc2e-a369d592d5e7",
+  "version": 2
+}


### PR DESCRIPTION
This adds a simple dashboard showing the number of transaction INVs with more than 35 entries. This is a follow-up to #235 and generally related to:

- https://bitcoincore.org/en/2024/10/08/disclose-large-inv-to-send/
- https://github.com/bitcoin/bitcoin/pull/27610
- https://b10c.me/observations/15-inv-to-send-queue/

Completes #220