### PR TITLE
add: p2p-extractor (initially keeps track of ping-pong durations)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "p2p-extractor"
+version = "0.1.0"
+dependencies = [
+ "shared",
+ "tokio-util",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2441,7 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "shared",
   "extractors/ebpf",
   "extractors/rpc",
+  "extractors/p2p",
   "tools/logger",
   "tools/websocket",
   "tools/metrics",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ NATS server. Each extractor connects to a different interface:
 | **extractor** | **description**                       |             **details**             |
 |---------------|---------------------------------------|:-----------------------------------:|
 | ebpf          | uses tracepoints for real-time events | [extractors/ebpf/](extractors/ebpf) |
-| rpc           | periodically fetches RPC for events   | [tools/rpc/](extractors/rpc)        |
+| rpc           | periodically fetches RPC for events   | [extractors/rpc/](extractors/rpc)   |
+| p2p           |Bitcoin P2P events from an inbound node| [extractors/p2p/](extractors/p2p)   |
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,20 @@ I'll do my best to add more documentation.
 
 ### Integration tests
 
-To run the integration tests, run with the feature `nats_integration_tests`:
+To run the integration tests, run with the feature `nats_integration_tests` and 
+`node_integration_tests`. If you are not using the nix-shell, you need to set the
+`NATS_SERVER_BINARY` to the path to your `nats-server` binary. Addtionally,
+`BITCOIND_EXE` can be set to a custom `bitcoind` binary. By default, a recent
+release will be downloaded and used if `BITCOIND_SKIP_DOWNLOAD` is unset.
 
 ```bash
-$ cargo test --features nats_integration_tests
+$ cargo test --features nats_integration_tests --features node_integration_tests
 ```
-
-If you are not using the nix-shell, you need to set the `NATS_SERVER_BINARY` to the path
-to your `nats-server` binary.
 
 Test coverage can be generated with:
 
 ```bash
-$ cargo tarpaulin --out Html --features nats_integration_tests
+$ cargo tarpaulin --out Html --features nats_integration_tests --features node_integration_tests
 ```
 
 This generates a `tarpaulin-report.html` file which can be viewed in the browser.

--- a/extractors/p2p/Cargo.toml
+++ b/extractors/p2p/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "p2p-extractor"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../../shared" }
+tokio-util = { version = "0.7", features = ["compat"] }
+
+[features]
+# Treat warnings as a build error.
+strict = []
+
+# Run integration tests needing a NATS server.
+nats_integration_tests = []
+
+# Run integration tests needing a Bitcoin Core node.
+node_integration_tests = []

--- a/extractors/p2p/README.md
+++ b/extractors/p2p/README.md
@@ -1,0 +1,39 @@
+# `p2p` extractor
+
+> publishes data received via the P2P interface
+
+A peer-observer extractor that receives an inbound connection from a Bitcoin node
+and publishes selected P2P messages and measurements as events into a NATS pub-sub
+queue.
+
+While the p2p-extractor in theory supports multiple inbound connections from multiple
+Bitcoin nodes, it can't (yet) differentiate between them. 
+
+## Example
+
+For example, connect to a NATS server on 128.0.0.1:1234 and listen on 127.0.0.1:8555
+for an inbound regtest Bitcoin node P2P connection. The Bitcoin node needs to be started with
+`bitcoind --regtest --addnode=127.0.0.1:8555`.
+
+```
+$ cargo run --bin p2p-extractor -- --nats-address 128.0.0.1:1234 --p2p-network regtest --p2p-address 127.0.0.1:8555
+```
+
+## Usage
+
+```
+$ cargo run --bin p2p-extractor -- --help
+The peer-observer p2p-extractor listens for a connection from a Bitcoin node and once connected, extracts events from exchanged P2P messages. It publishes the events into a NATS pub-sub queue
+
+Usage: p2p-extractor [OPTIONS]
+
+Options:
+  -n, --nats-address <NATS_ADDRESS>    Address of the NATS server where the extractor will publish messages to [default: 127.0.0.1:4222]
+  -l, --log-level <LOG_LEVEL>          The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
+      --p2p-address <P2P_ADDRESS>      Address of the P2P interface the P2P extractor will listen on. On the Bitcoin node side, the connection needs to be established with -addnode=<p2p_address> [default: 127.0.0.1:9333]
+      --p2p-network <P2P_NETWORK>      Network (P2P) the Bitcoin node is on. This determines the network magic. The network magic of the p2p-extractor and the Bitcoin node must match [default: mainnet] [possible values: mainnet, testnet3, testnet4, signet, regtest]
+      --ping-interval <PING_INTERVAL>  The p2p_extractor frequently pings the connected node to measure ping and backlog timings. This allows to configure the ping interval (in seconds) [default: 10]
+      --disable-ping                   The p2p_extractor frequently pings the connected node to measure ping and backlog timings. This allows disabling the ping measurements
+  -h, --help                           Print help
+  -V, --version                        Print version
+```

--- a/extractors/p2p/src/error.rs
+++ b/extractors/p2p/src/error.rs
@@ -1,0 +1,94 @@
+use shared::async_nats::ConnectErrorKind;
+use shared::log::SetLoggerError;
+use std::error;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    SetLogger(SetLoggerError),
+    Io(io::Error),
+    NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::SetLogger(e) => write!(f, "set logger error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::SetLogger(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<SetLoggerError> for RuntimeError {
+    fn from(e: SetLoggerError) -> Self {
+        RuntimeError::SetLogger(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
+        RuntimeError::NatsConnect(e)
+    }
+}
+
+#[derive(Debug)]
+pub enum BitcoinMsgDecodeError {
+    HeaderReadError(shared::tokio::io::Error),
+    PayloadReadError(shared::tokio::io::Error),
+    InvalidLengthBytes(std::array::TryFromSliceError),
+    DecodeError(shared::bitcoin::consensus::encode::Error),
+    MagicError([u8; 4], [u8; 4]),
+}
+
+impl fmt::Display for BitcoinMsgDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use BitcoinMsgDecodeError::*;
+        match self {
+            HeaderReadError(e) => write!(f, "Failed to read message header: {}", e),
+            PayloadReadError(e) => write!(f, "Failed to read message payload: {}", e),
+            InvalidLengthBytes(e) => write!(f, "Invalid length bytes in header: {}", e),
+            DecodeError(e) => write!(f, "Consensus decode error: {}", e),
+            MagicError(expected, got) => write!(
+                f,
+                "Network magic mismatch: got={}, expected={}",
+                got.iter()
+                    .fold(String::new(), |a, b| a + &format!("{:02x}", b)),
+                expected
+                    .iter()
+                    .fold(String::new(), |a, b| a + &format!("{:02x}", b)),
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BitcoinMsgDecodeError {}
+
+impl From<shared::bitcoin::consensus::encode::Error> for BitcoinMsgDecodeError {
+    fn from(e: shared::bitcoin::consensus::encode::Error) -> Self {
+        BitcoinMsgDecodeError::DecodeError(e)
+    }
+}
+
+impl From<std::array::TryFromSliceError> for BitcoinMsgDecodeError {
+    fn from(e: std::array::TryFromSliceError) -> Self {
+        BitcoinMsgDecodeError::InvalidLengthBytes(e)
+    }
+}

--- a/extractors/p2p/src/lib.rs
+++ b/extractors/p2p/src/lib.rs
@@ -1,0 +1,335 @@
+use shared::{
+    async_nats,
+    bitcoin::{
+        Network as BitcoinNetwork,
+        consensus::{Decodable, Encodable},
+        io::Cursor as BitcoinCursor,
+        p2p::{
+            ServiceFlags, address,
+            message::{self, NetworkMessage, RawNetworkMessage},
+            message_network,
+        },
+    },
+    clap::{self, Parser, ValueEnum},
+    log,
+    rand::{self, Rng},
+    tokio::{
+        io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
+        net::{TcpListener, TcpStream, tcp::WriteHalf},
+        sync::watch,
+        time::{self, Duration},
+    },
+    util,
+};
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+mod error;
+
+use error::{BitcoinMsgDecodeError, RuntimeError};
+
+const USER_AGENT: &str = "/p2p-extractor:0.1/";
+
+/// Enum of all possible networks. These determine the network magic.
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Network {
+    Mainnet,
+    Testnet3,
+    Testnet4,
+    Signet,
+    Regtest,
+}
+
+impl std::fmt::Display for Network {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Network::Mainnet => "mainnet",
+            Network::Testnet3 => "testnet3",
+            Network::Testnet4 => "testnet4",
+            Network::Regtest => "regtest",
+            Network::Signet => "signet",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl From<Network> for BitcoinNetwork {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Mainnet => BitcoinNetwork::Bitcoin,
+            Network::Testnet3 => BitcoinNetwork::Testnet,
+            Network::Testnet4 => BitcoinNetwork::Testnet4,
+            Network::Regtest => BitcoinNetwork::Regtest,
+            Network::Signet => BitcoinNetwork::Signet,
+        }
+    }
+}
+
+/// The peer-observer p2p-extractor listens for a connection from a Bitcoin
+/// node and once connected, extracts events from exchanged P2P messages. It
+/// publishes the events into a NATS pub-sub queue.
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Address of the NATS server where the extractor will publish messages to.
+    #[arg(short, long, default_value = "127.0.0.1:4222")]
+    pub nats_address: String,
+
+    /// The log level the extractor should run with. Valid log levels are "trace",
+    /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html.
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    pub log_level: log::Level,
+
+    /// Address of the P2P interface the P2P extractor will listen on.
+    /// On the Bitcoin node side, the connection needs to be established
+    /// with -addnode=<p2p_address>.
+    #[arg(long, default_value = "127.0.0.1:9333")]
+    pub p2p_address: String,
+
+    /// Network (P2P) the Bitcoin node is on. This determines the network magic.
+    /// The network magic of the p2p-extractor and the Bitcoin node must match.
+    #[arg(long, default_value_t = Network::Mainnet)]
+    pub p2p_network: Network,
+
+    /// The p2p_extractor frequently pings the connected node to measure ping and backlog timings.
+    /// This allows to configure the ping interval (in seconds).
+    #[arg(long, default_value_t = 10)]
+    pub ping_interval: u64,
+
+    /// The p2p_extractor frequently pings the connected node to measure ping and backlog timings.
+    /// This allows disabling the ping measurements.
+    #[arg(long, default_value_t = false)]
+    pub disable_ping: bool,
+}
+
+impl Args {
+    pub fn new(
+        nats_address: String,
+        log_level: log::Level,
+        p2p_address: String,
+        p2p_network: Network,
+        ping_interval: u64,
+        disable_ping: bool,
+    ) -> Args {
+        Self {
+            nats_address,
+            log_level,
+            p2p_address,
+            p2p_network,
+            ping_interval,
+            disable_ping,
+            // when adding more disable_* args, make sure to update the disable_all below
+        }
+    }
+}
+
+pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    log::info!("Using network magic for: {}", args.p2p_network);
+    let network: BitcoinNetwork = args.p2p_network.clone().into();
+    log::info!("Ping measurements enabled: {}", !args.disable_ping);
+    if !args.disable_ping {
+        log::info!("Ping measurements interval: {}s", args.ping_interval);
+    }
+    // check if at least one P2P measurement is enabled
+    let disable_all = args.disable_ping;
+    if disable_all {
+        log::warn!("No P2P measurement enabled!");
+    }
+
+    log::debug!("Connecting to NATS server at {}..", args.nats_address);
+    let nats_client = async_nats::connect(&args.nats_address).await?;
+    log::info!("Connected to NATS server at {}", &args.nats_address);
+
+    log::debug!("Starting TCP listener on {}..", args.p2p_address);
+    let listener = TcpListener::bind(args.p2p_address.clone()).await?;
+    log::info!("P2P-extractor listening on {}", args.p2p_address);
+
+    loop {
+        shared::tokio::select! {
+            res = listener.accept() => {
+                if let Ok(connection) = res {
+                    let (socket, addr) = connection;
+                    log::info!("accepted a new connection from: {}", addr);
+                    shared::tokio::task::spawn(handle_connection(socket, network, args.clone()));
+                } else {
+                    log::warn!("Could not accept connection on socket: {:?}", res);
+                }
+            },
+            res = shutdown_rx.changed() => {
+                match res {
+                    Ok(_) => {
+                        if *shutdown_rx.borrow() {
+                            log::info!("p2p-extractor received shutdown signal.");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        // all senders dropped -> treat as shutdown
+                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_connection(mut stream: TcpStream, network: BitcoinNetwork, args: Args) {
+    let addr: &str = match stream.peer_addr() {
+        Ok(addr) => &addr.to_string(),
+        Err(e) => {
+            log::error!("Could not get the address of the peer: {}", e);
+            return;
+        }
+    };
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+    let mut ping_interval = time::interval(Duration::from_secs(args.ping_interval));
+    let mut verack_done = false;
+
+    async fn send_message(
+        msg: message::NetworkMessage,
+        network: BitcoinNetwork,
+        write_half: &mut WriteHalf<'_>,
+        addr: &str,
+    ) {
+        let reply: RawNetworkMessage = build_raw_network_message(msg.clone(), network);
+        let mut out_bytes = Vec::new();
+        reply.consensus_encode(&mut out_bytes).unwrap();
+        match write_half.write_all(&out_bytes).await {
+            Ok(_) => log::trace!(target: addr, "sent message: {:?}", msg),
+            Err(e) => log::warn!(target: addr, "failed to sent message: {:?}", e),
+        };
+    }
+
+    loop {
+        shared::tokio::select! {
+            _ = ping_interval.tick() => {
+                if !args.disable_ping && verack_done {
+                    let timestamp: u64 = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .expect("Time error")
+                        .as_nanos() as u64; // Treating nanoseconds as u64 will be fine for the next 500 years or so.
+                    send_message(NetworkMessage::Ping(timestamp), network, &mut write_half, addr).await;
+                }
+            }
+            result = read_and_decode_message(&mut reader, network, addr) => {
+                match result {
+                    Ok(raw_msg) => {
+                        log::trace!(target: addr, "received message: {:?}", raw_msg.payload());
+                        match raw_msg.payload() {
+                            NetworkMessage::Version(_) => {
+                                send_message(build_version_message(), network, &mut write_half, addr).await;
+                            }
+                            NetworkMessage::Verack => {
+                                send_message(NetworkMessage::Verack, network, &mut write_half, addr).await;
+                                verack_done = true;
+                            }
+                            NetworkMessage::Ping(nonce) => {
+                                send_message(NetworkMessage::Pong(*nonce), network, &mut write_half, addr).await;
+                            }
+                            NetworkMessage::Pong(nonce) => {
+                                // The "nonce" we initial sent is a timestamp.
+                                let now: u64 = SystemTime::now()
+                                    .duration_since(UNIX_EPOCH)
+                                    .expect("Time error")
+                                    .as_nanos() as u64;
+                                log::debug!(target: addr, "processing the ping message took: {}ns", now - nonce);
+                            }
+                            NetworkMessage::GetAddr | NetworkMessage::Alert(_) => {
+                                // ignore these for now..
+                                // and treat all other messages as unhandled
+                            }
+                            _ => {
+                                log::debug!(target: addr, "unhandled message type: {}", raw_msg.command());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(target: addr, "error decoding message: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    log::info!("closing connection: '{}'", addr);
+    let _ = stream.shutdown();
+}
+
+pub async fn read_and_decode_message<R: AsyncRead + Unpin>(
+    reader: &mut BufReader<R>,
+    network: BitcoinNetwork,
+    addr: &str,
+) -> Result<RawNetworkMessage, BitcoinMsgDecodeError> {
+    let mut header = [0u8; 24];
+    if let Err(e) = reader.read_exact(&mut header).await {
+        log::debug!(
+            "reading the P2P message header from '{}' failed: {}",
+            addr,
+            e
+        );
+        return Err(BitcoinMsgDecodeError::HeaderReadError(e));
+    }
+
+    // We only accept v1 connections. To filter out V2 connections, error on everything
+    // that doesn't match the network magic.
+    let header_magic: [u8; 4] = header[0..4].try_into().expect("slice should have length 4");
+    if header_magic != network.magic().to_bytes() {
+        log::debug!(target: addr,
+            "mismatch in the P2P message magic: this could mean the node is on a different network or it's attempting a P2Pv2 connection..",
+        );
+        return Err(BitcoinMsgDecodeError::MagicError(
+            network.magic().to_bytes(),
+            header_magic,
+        ));
+    }
+
+    let payload_length = u32::from_le_bytes(header[16..20].try_into()?);
+    let mut payload = vec![0u8; payload_length as usize];
+    if let Err(e) = reader.read_exact(&mut payload).await {
+        log::debug!(target: addr,
+            "reading the P2P message payload failed: {}",
+            e
+        );
+        return Err(BitcoinMsgDecodeError::PayloadReadError(e));
+    }
+
+    let mut full_msg_bytes = Vec::with_capacity(24 + payload.len());
+    full_msg_bytes.extend_from_slice(&header);
+    full_msg_bytes.extend_from_slice(&payload);
+
+    let mut cursor = BitcoinCursor::new(full_msg_bytes);
+    let msg = RawNetworkMessage::consensus_decode(&mut cursor)?;
+
+    Ok(msg)
+}
+
+fn build_raw_network_message(
+    payload: message::NetworkMessage,
+    network: BitcoinNetwork,
+) -> message::RawNetworkMessage {
+    message::RawNetworkMessage::new(network.magic(), payload)
+}
+
+fn build_version_message() -> message::NetworkMessage {
+    message::NetworkMessage::Version(message_network::VersionMessage::new(
+        ServiceFlags::NONE,
+        util::current_timestamp() as i64,
+        address::Address::new(
+            &SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
+            ServiceFlags::NONE,
+        ),
+        address::Address::new(
+            &SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
+            ServiceFlags::NONE,
+        ),
+        rand::rng().random(),
+        String::from(USER_AGENT),
+        0,
+    ))
+}

--- a/extractors/p2p/src/main.rs
+++ b/extractors/p2p/src/main.rs
@@ -1,0 +1,23 @@
+use p2p_extractor::Args;
+use shared::log::error;
+use shared::tokio::{self, signal, sync::watch};
+use shared::{clap::Parser, simple_logger};
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("p2p extractor error: {}", e);
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let p2p_handle = tokio::spawn(p2p_extractor::run(args, shutdown_rx));
+
+    signal::ctrl_c().await.expect("Failed to listen for ctrl+c");
+    let _ = shutdown_tx.send(true);
+
+    if let Err(e) = p2p_handle.await {
+        error!("p2p_extractor task failed: {:?}", e);
+    }
+}

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -1,0 +1,157 @@
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+use shared::{
+    async_nats, corepc_node,
+    event_msg::{EventMsg, event_msg::Event},
+    futures::StreamExt,
+    log::{self, info},
+    nats_server_for_testing::NatsServerForTesting,
+    p2p_extractor::p2p_extractor_event::Event::PingDuration,
+    prost::Message,
+    rand::{self, Rng},
+    simple_logger::SimpleLogger,
+    tokio::{
+        self,
+        sync::watch,
+        time::{Duration, sleep},
+    },
+};
+
+use std::sync::{
+    Once, OnceLock,
+    atomic::{AtomicU16, Ordering},
+};
+
+use p2p_extractor::{Args, Network};
+
+static INIT: Once = Once::new();
+static NEXT_NATS_PORT: OnceLock<AtomicU16> = OnceLock::new();
+static NEXT_P2PEXTRACTOR_PORT: OnceLock<AtomicU16> = OnceLock::new();
+
+// 1 second ping interval for fast tests
+const PING_INTERVAL_SECONDS: u64 = 1;
+
+fn setup() -> (u16, u16) {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+
+        let mut rng = rand::rng();
+
+        // choose start ports from the ephemeral port range
+        let nats_start = rng.random_range(49152..65500);
+        NEXT_NATS_PORT.set(AtomicU16::new(nats_start)).unwrap();
+        let p2p_extractor_start = rng.random_range(49152..65500);
+        NEXT_P2PEXTRACTOR_PORT
+            .set(AtomicU16::new(p2p_extractor_start))
+            .unwrap();
+    });
+    let nats_port = NEXT_NATS_PORT.get().unwrap().fetch_add(1, Ordering::SeqCst);
+    let p2p_extractor_port = NEXT_P2PEXTRACTOR_PORT
+        .get()
+        .unwrap()
+        .fetch_add(1, Ordering::SeqCst);
+    (nats_port, p2p_extractor_port)
+}
+
+fn make_test_args(nats_port: u16, p2p_address: String, disable_ping: bool) -> Args {
+    Args::new(
+        format!("127.0.0.1:{}", nats_port),
+        log::Level::Trace,
+        p2p_address,
+        Network::Regtest,
+        PING_INTERVAL_SECONDS,
+        disable_ping,
+    )
+}
+
+fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+    info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
+    info!("exe_path={:?}", corepc_node::exe_path());
+
+    if let Ok(exe_path) = corepc_node::exe_path() {
+        info!("Using bitcoind at '{}'", exe_path);
+        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+    }
+
+    info!("Trying to download a bitcoind..");
+    return corepc_node::Node::from_downloaded_with_conf(&conf).unwrap();
+}
+
+fn setup_node_with_addnode(p2p_extractor_port: u16) -> corepc_node::Node {
+    let mut node_conf = corepc_node::Conf::default();
+    let addnode = format!("--addnode=127.0.0.1:{}", p2p_extractor_port);
+    node_conf.args = vec!["--regtest", "--debug=net", &addnode];
+    // enabling this is useful for debugging, but enabling this by default will
+    // be quite spammy.
+    node_conf.view_stdout = false;
+    let node = setup_node(node_conf);
+    node
+}
+
+async fn check(disable_ping: bool, check_expected: fn(Event) -> ()) {
+    let (nats_port, p2p_extractor_port) = setup();
+    let _nats_server = NatsServerForTesting::new(nats_port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let p2p_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_port,
+            format!("127.0.0.1:{}", p2p_extractor_port),
+            disable_ping,
+        );
+        p2p_extractor::run(args, shutdown_rx.clone())
+            .await
+            .expect("p2p-extractor failed");
+    });
+
+    // allow the p2p-extractor to start
+    sleep(Duration::from_secs(2)).await;
+
+    // only start the node after the P2P extractor to make sure the
+    // extractor is ready to accept connections
+    let _node = setup_node_with_addnode(p2p_extractor_port);
+
+    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_port))
+        .await
+        .unwrap();
+    let mut sub = nc.subscribe("*").await.unwrap();
+
+    while let Some(msg) = sub.next().await {
+        let unwrapped = EventMsg::decode(msg.payload).unwrap();
+        if let Some(event) = unwrapped.event {
+            check_expected(event);
+            break;
+        }
+    }
+
+    shutdown_tx.send(true).unwrap();
+    p2p_extractor_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_integration_p2pextractor_ping_measurements() {
+    println!("test that we receive Ping measurement P2P-extractor events");
+
+    check(false, |event| {
+        match event {
+            Event::P2pExtractorEvent(p) => {
+                if let Some(ref e) = p.event {
+                    match e {
+                        PingDuration(p) => {
+                            // we expect the duration to be >0ns
+                            assert!(p.duration > 0);
+                            return;
+                        } // TODO: once we have more P2P extractor events, we are going to need this.
+                          //_ => panic!("unexpected P2P extractor event {:?}", p.event),
+                    }
+                }
+            }
+            _ => panic!("unexpected event {:?}", event),
+        }
+    })
+    .await;
+}

--- a/protobuf/proto-types/event_msg.proto
+++ b/protobuf/proto-types/event_msg.proto
@@ -12,6 +12,9 @@ import "validation.proto";
 // rpc extractor
 import "rpc.proto";
 
+// p2p-extractor
+import "p2p_extractor.proto";
+
 message EventMsg {
   required uint64  timestamp = 10;  // Timestamp (seconds since UNIX epoch) when the message was received.
   required uint32  timestamp_subsec_micros = 11;  // The fractional part of the timestamp, in whole milliseconds. Always represents a fractional portion of a second (i.e., it is less than one million).
@@ -22,5 +25,6 @@ message EventMsg {
     mempool.MempoolEvent mempool = 4;
     validation.ValidationEvent validation = 5;
     rpc.RPCEvent rpc = 6;
+    p2p_extractor.P2PExtractorEvent P2PExtractorEvent = 7;
   }
 }

--- a/protobuf/proto-types/p2p_extractor.proto
+++ b/protobuf/proto-types/p2p_extractor.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+// This file is only for Events of the p2p-extractor.
+package p2p_extractor;
+
+message P2PExtractorEvent {
+  oneof event {
+    PingDuration ping_duration = 1;
+  }
+}
+
+// A Ping-Pong duration measurement performed by the p2p-extractor.
+message PingDuration {
+  required uint64 duration = 1; // Time it takes for the node to respond with a pong to a ping in nanoseconds. This is useful to measure node processing backlog.
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -21,6 +21,7 @@ pub mod mempool;
 pub mod nats_subjects;
 pub mod net_conn;
 pub mod net_msg;
+pub mod p2p_extractor;
 pub mod primitive;
 pub mod rpc;
 pub mod validation;

--- a/shared/src/nats_subjects.rs
+++ b/shared/src/nats_subjects.rs
@@ -6,6 +6,7 @@ const NATS_SUBJECT_NETMSG: &str = "netmsg";
 const NATS_SUBJECT_NETCONN: &str = "netconn";
 const NATS_SUBJECT_VALIDATION: &str = "validation";
 const NATS_SUBJECT_RPC: &str = "rpc";
+const NATS_SUBJECT_P2P_EXTRACTOR: &str = "p2p-extractor";
 
 pub enum Subject {
     Addrman,
@@ -14,6 +15,7 @@ pub enum Subject {
     NetConn,
     Validation,
     Rpc,
+    P2PExtractor,
 }
 
 impl fmt::Display for Subject {
@@ -25,6 +27,7 @@ impl fmt::Display for Subject {
             Subject::NetMsg => write!(f, "{}", NATS_SUBJECT_NETMSG),
             Subject::Validation => write!(f, "{}", NATS_SUBJECT_VALIDATION),
             Subject::Rpc => write!(f, "{}", NATS_SUBJECT_RPC),
+            Subject::P2PExtractor => write!(f, "{}", NATS_SUBJECT_P2P_EXTRACTOR),
         }
     }
 }

--- a/shared/src/p2p_extractor.rs
+++ b/shared/src/p2p_extractor.rs
@@ -1,0 +1,18 @@
+use std::fmt;
+
+// structs are generated via the p2p-extractor.proto file
+include!(concat!(env!("OUT_DIR"), "/p2p_extractor.rs"));
+
+impl fmt::Display for PingDuration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PingDuration({}ns)", self.duration)
+    }
+}
+
+impl fmt::Display for p2p_extractor_event::Event {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            p2p_extractor_event::Event::PingDuration(duration) => write!(f, "{}", duration),
+        }
+    }
+}

--- a/tools/logger/README.md
+++ b/tools/logger/README.md
@@ -68,6 +68,7 @@ Options:
       --mempool                      If passed, show mempool events
       --validation                   If passed, show validation events
       --rpc                          If passed, show RPC events
+      --p2p-extractor                If passed, show p2p-extractor events
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/tools/logger/src/main.rs
+++ b/tools/logger/src/main.rs
@@ -50,6 +50,10 @@ struct Args {
     /// If passed, show RPC events
     #[arg(long)]
     rpc: bool,
+
+    /// If passed, show p2p-extractor events
+    #[arg(long)]
+    p2p_extractor: bool,
 }
 
 impl Args {
@@ -59,7 +63,8 @@ impl Args {
             || self.addrman
             || self.mempool
             || self.validation
-            || self.rpc)
+            || self.rpc
+            || self.p2p_extractor)
     }
 }
 
@@ -74,6 +79,7 @@ async fn main() {
     let mempool = args.mempool;
     let validation = args.validation;
     let rpc = args.rpc;
+    let p2p_extractor = args.p2p_extractor;
     simple_logger::init_with_level(args.log_level).unwrap();
 
     // TODO: handle unwraps
@@ -118,6 +124,11 @@ async fn main() {
                     Event::Rpc(r) => {
                         if should_show_all || rpc {
                             log::info!("!RPC {}", r.event.unwrap());
+                        }
+                    }
+                    Event::P2pExtractorEvent(p) => {
+                        if should_show_all || p2p_extractor {
+                            log::info!("%P2P {}", p.event.unwrap());
                         }
                     }
                 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -558,9 +558,13 @@ fn handle_connection_event(
     }
 }
 
-fn handle_p2p_extractor_event(p2p_event: &p2p_extractor_event::Event, _metrics: metrics::Metrics) {
+fn handle_p2p_extractor_event(p2p_event: &p2p_extractor_event::Event, metrics: metrics::Metrics) {
     match p2p_event {
-        _ => (), // FIXME: this is implemented in a following commit
+        p2p_extractor_event::Event::PingDuration(ping_duration) => {
+            metrics
+                .p2pextractor_ping_duration_nanoseconds
+                .set(ping_duration.duration as i64);
+        }
     }
 }
 

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -13,6 +13,7 @@ use shared::metricserver;
 use shared::net_conn::connection_event;
 use shared::net_msg;
 use shared::net_msg::{message::Msg, reject::RejectReason};
+use shared::p2p_extractor::p2p_extractor_event;
 use shared::prost::Message;
 use shared::rpc::rpc_event;
 use shared::tokio::sync::watch;
@@ -139,6 +140,11 @@ fn handle_event(
             Event::Rpc(r) => {
                 if let Some(e) = r.event {
                     handle_rpc_event(&e, metrics);
+                }
+            }
+            Event::P2pExtractorEvent(p) => {
+                if let Some(e) = p.event {
+                    handle_p2p_extractor_event(&e, metrics);
                 }
             }
         }
@@ -549,6 +555,12 @@ fn handle_connection_event(
                 .with_label_values(&[&m.message])
                 .inc();
         }
+    }
+}
+
+fn handle_p2p_extractor_event(p2p_event: &p2p_extractor_event::Event, _metrics: metrics::Metrics) {
+    match p2p_event {
+        _ => (), // FIXME: this is implemented in a following commit
     }
 }
 

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -237,6 +237,7 @@ pub struct Metrics {
     pub rpc_peer_info_minping_mean: Gauge,
     pub rpc_peer_info_sub1satvb_relay: IntGauge,
     pub rpc_peer_info_connection_divserity_inbound_ipv4: Gauge,
+    pub p2pextractor_ping_duration_nanoseconds: IntGauge,
 }
 
 impl Metrics {
@@ -326,6 +327,9 @@ impl Metrics {
         ig!(rpc_peer_info_sub1satvb_relay, "Number of peers that relay sub-1 sat/vbyte transactions.", registry);
         g!(rpc_peer_info_connection_divserity_inbound_ipv4, "Diversity of IPv4 inbound connections by /16 (higher is better). Calculated: <number of distinct /16 IPv4 inbound connection subnets>/<number of inbound IPv4 peers>", registry);
 
+        // RPC-extractor
+        ig!(p2pextractor_ping_duration_nanoseconds, "The time it takes for a connected Bitcoin node to respond to a ping with a pong in nanoseconds.", registry);
+
         Self {
             registry,
             runtime_start_timestamp,
@@ -409,6 +413,7 @@ impl Metrics {
             rpc_peer_info_minping_mean,
             rpc_peer_info_sub1satvb_relay,
             rpc_peer_info_connection_divserity_inbound_ipv4,
+            p2pextractor_ping_duration_nanoseconds,
         }
     }
 }

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -15,6 +15,7 @@ use shared::{
     net_msg::{
         self, message::Msg, Addr, AddrV2, FeeFilter, Inv, Metadata, Ping, Pong, Reject, Version,
     },
+    p2p_extractor,
     primitive::{self, inventory_item::Item, Address, InventoryItem},
     prost::Message,
     rand::{self, Rng},
@@ -1962,6 +1963,27 @@ async fn test_integration_metrics_rpc_peerinfo_ipv4_inbound_diversity() {
         Subject::Rpc,
         r#"
         peerobserver_rpc_peer_info_connection_divserity_inbound_ipv4 0.6666666666666666
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_p2pextractor_ping_duration() {
+    println!("test that p2p-extractor ping duration metrics work");
+
+    publish_and_check(
+        &[
+            EventMsg::new(Event::P2pExtractorEvent(p2p_extractor::P2pExtractorEvent {
+                event: Some(p2p_extractor::p2p_extractor_event::Event::PingDuration(
+                    p2p_extractor::PingDuration { duration: 1234567 },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::Validation,
+        r#"
+        peerobserver_p2pextractor_ping_duration_nanoseconds 1234567
         "#,
     )
     .await;


### PR DESCRIPTION
This adds a p2p-extractor. The extractor listens on a TCP socket and accepts inbound connections from a Bitcoin node. A Bitcoin node configured with `--addnode=ip:port` will connect (and reconnect) to the extractor. Additionally, the connection will count as a manual connection and not reduce the number of normal outbound (and not inbounds) the node makes. The extractor does only support P2Pv1 for now. This means, the node and the extractor must have the same network magic. The node will open a v2 connection to the p2p-extractor at first, which will be closed. The node will then retry with a v1 connection which then should succeed. 

Currently, the p2p-extractor only sends a ping and measures the time it takes for the node to respond to a pong. When done on localhost (to reduce network latency), this measures the time it takes for the node to process all other network messages that arrived before it. In a way, we measure the Bitcoin node backlog here.

Additional measurements and events can be extracted in the future. Some ideas are in: https://github.com/0xB10C/peer-observer/issues/263

part of #141 
closes https://github.com/0xB10C/peer-observer/issues/212