### PR TITLE
nix: update clang 14 -> 21

### DIFF
--- a/.github/workflows/rust-nix.yml
+++ b/.github/workflows/rust-nix.yml
@@ -20,13 +20,13 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-25.05
     - name: Build
-      run: nix-shell --command "cargo build --all-features"
+      run: nix-shell --pure --command "cargo build --all-features"
     - name: Run tests
-      run: nix-shell --command "cargo test --all-features"
+      run: nix-shell --pure --command "cargo test --all-features"
     - name: Run cargo fmt
-      run: nix-shell --command "cargo fmt --all -- --check"
+      run: nix-shell --pure --command "cargo fmt --all -- --check"
     - name: Run cargo tarpaulin (code coverage)
-      run: nix-shell --command "cargo tarpaulin --out Lcov --out Html --workspace --all-features"
+      run: nix-shell --pure --command "cargo tarpaulin --out Lcov --out Html --workspace --all-features"
     - name: Upload HTML coverage report
       uses: actions/upload-artifact@v4
       with:

--- a/extractors/ebpf/build.rs
+++ b/extractors/ebpf/build.rs
@@ -11,11 +11,34 @@ fn main() {
         .expect("CARGO_CFG_TARGET_ARCH must be set in build script");
     let vmlinux_path = Path::new("./src/bpf/vmlinux").join(arch);
     println!("using vmlinux path: {}", vmlinux_path.display());
-    match SkeletonBuilder::new()
+
+    let mut binding = SkeletonBuilder::new();
+    let mut builder = binding
         .source(SOURCE)
-        .clang_args([OsStr::new("-I"), vmlinux_path.as_os_str()])
-        .build_and_generate(DEST)
-    {
+        .clang_args([OsStr::new("-I"), vmlinux_path.as_os_str()]);
+
+    // If KERNEL_HEADERS env var is set, add it as an include path
+    if let Ok(kernel_headers) = env::var("KERNEL_HEADERS") {
+        println!(
+            "using kernel headers path from KERNEL_HEADERS: {}",
+            kernel_headers
+        );
+        builder = builder.clang_args([
+            OsStr::new("-I"),
+            vmlinux_path.as_os_str(),
+            // don't include any standard includes; this helps in the Ubuntu CI
+            // when building the package with Nix
+            OsStr::new("-nostdinc"),
+            OsStr::new("-v"),
+            OsStr::new("-I"),
+            OsStr::new(&kernel_headers),
+        ]);
+    } else {
+        println!("KERNEL_HEADERS env var not set; skipping kernel headers include");
+        builder = builder.clang_args([OsStr::new("-I"), vmlinux_path.as_os_str()]);
+    }
+
+    match builder.build_and_generate(DEST) {
         Ok(_) => (),
         Err(e) => {
             eprintln!("Failed to build BPF skeleton:");

--- a/extractors/ebpf/build.rs
+++ b/extractors/ebpf/build.rs
@@ -14,13 +14,12 @@ fn main() {
     match SkeletonBuilder::new()
         .source(SOURCE)
         .clang_args([OsStr::new("-I"), vmlinux_path.as_os_str()])
-        //.clang_args(format!("-I {}", vmlinux_path.display()))
         .build_and_generate(DEST)
     {
         Ok(_) => (),
         Err(e) => {
-            println!("Error: {}", e);
-            panic!("could not compile {}", SOURCE);
+            eprintln!("Failed to build BPF skeleton:");
+            panic!("could not compile {}: {:?}", SOURCE, e);
         }
     }
     println!("cargo:rerun-if-changed={}", SOURCE);

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {}}:
 
 let
-  llvm = pkgs.llvmPackages_15;
+  llvm = pkgs.llvmPackages_21;
 in
 pkgs.mkShell {
 


### PR DESCRIPTION
On nixos-unstable:
 
    error: clang_14 has been removed, as it is unmaintained and obsolete