### PR TITLE
fix: retrying ports for NATS and tools during integration tests

### DIFF
--- a/shared/src/testing/nats_publisher.rs
+++ b/shared/src/testing/nats_publisher.rs
@@ -4,8 +4,10 @@ pub struct NatsPublisherForTesting {
 
 impl NatsPublisherForTesting {
     pub async fn new(port: u16) -> Self {
+        let addr = format!("127.0.0.1:{}", port);
+        log::debug!("The testing NATS publisher is connecting to {}..", addr);
         Self {
-            client: async_nats::connect(format!("127.0.0.1:{}", port))
+            client: async_nats::connect(addr)
                 .await
                 .expect("should be able to connect to NATS server"),
         }

--- a/shared/src/testing/nats_server.rs
+++ b/shared/src/testing/nats_server.rs
@@ -6,8 +6,9 @@
 // https://github.com/davidMcneil/rants/blob/beb187b49bd6ade187cb5b92023cb67ba0e15baa/tests/common.rs:
 // - Renamed NATS_PATH_ENV to ENV_NATS_SERVER_BINARY
 // - Renamed NatsServer to NatsServerForTesting
-// - Changed the function new() to take a port as argument and hardcode all other nats-server args
+// - Changed the function new() to attempt to find a working port for NATS and hardcode all other nats-server args
 
+use rand::Rng;
 use std::{env, process::Stdio, time::Duration};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -16,15 +17,19 @@ use tokio::{
     time::timeout,
 };
 
+const PORT_ATTEMPTS: usize = 10;
+
 const ENV_NATS_SERVER_BINARY: &str = "NATS_SERVER_BINARY";
 const NATS_READY_MESSAGE: &str = "Server is ready";
+const NATS_PORT_IN_USE_MESSAGE: &str = "address already in use";
 
 pub struct NatsServerForTesting {
     kill: Option<Sender<()>>,
+    pub port: u16,
 }
 
 impl NatsServerForTesting {
-    pub async fn new(port: u16) -> Self {
+    pub async fn new() -> Self {
         let nats_server_binary_path: String = match env::var(ENV_NATS_SERVER_BINARY) {
             Ok(b) => b,
             Err(e) => {
@@ -35,86 +40,116 @@ impl NatsServerForTesting {
             }
         };
 
-        let args = [&format!("--port={}", port), "--addr=127.0.0.1"];
+        for attempt in 1..=PORT_ATTEMPTS {
+            let mut rng = rand::rng();
+            let nats_port = rng.random_range(49152..65500);
 
-        println!(
-            "Starting NATS server with: {} {}",
-            nats_server_binary_path,
-            args.join(" ")
-        );
+            log::debug!(
+                "attempting to use port={} for the testing NATS server (attempt={})",
+                nats_port,
+                attempt
+            );
+            let args = [&format!("--port={}", nats_port), "--addr=127.0.0.1"];
 
-        let mut child = Command::new(nats_server_binary_path.clone())
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .expect(&format!(
-                "Failed to start nats-server with binary='{}' and args='{}'",
+            log::info!(
+                "Starting NATS server with: {} {}",
                 nats_server_binary_path,
                 args.join(" ")
-            ));
+            );
 
-        // Spawn a task to handle stdout
-        let stdout = child
-            .stdout
-            .take()
-            .expect("child did not have a handle to stdout");
-        tokio::spawn(async {
-            let mut reader = BufReader::new(stdout).lines();
-            while let Some(line) = reader.next_line().await.expect("valid stdout line") {
-                println!("{}", line);
-            }
-        });
+            let mut child = Command::new(nats_server_binary_path.clone())
+                .args(args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .expect(&format!(
+                    "Failed to start nats-server with binary='{}' and args='{}'",
+                    nats_server_binary_path,
+                    args.join(" ")
+                ));
 
-        // Spawn a task to handle stderr and check if nats is ready
-        let (ready_tx, ready_rx) = oneshot::channel::<()>();
-        let stderr = child
-            .stderr
-            .take()
-            .expect("child did not have a handle to stdout");
-        tokio::spawn(async {
-            let mut ready_tx = Some(ready_tx);
-            let mut reader = BufReader::new(stderr).lines();
-            while let Some(line) = reader.next_line().await.expect("valid stdout line") {
-                println!("{}", line);
-                if line.contains(NATS_READY_MESSAGE) {
-                    if let Some(ready_tx) = ready_tx.take() {
-                        ready_tx.send(()).expect("to send nats ready oneshot");
+            // Spawn a task to handle stdout
+            let stdout = child
+                .stdout
+                .take()
+                .expect("child did not have a handle to stdout");
+            tokio::spawn(async {
+                let mut reader = BufReader::new(stdout).lines();
+                while let Some(line) = reader.next_line().await.expect("valid stdout line") {
+                    log::info!("{}", line);
+                }
+            });
+
+            // Spawn a task to handle stderr and check if nats is ready
+            let (ready_tx, ready_rx) = oneshot::channel::<bool>();
+            let stderr = child
+                .stderr
+                .take()
+                .expect("child did not have a handle to stdout");
+            tokio::spawn(async {
+                let mut ready_tx = Some(ready_tx);
+                let mut reader = BufReader::new(stderr).lines();
+                while let Some(line) = reader.next_line().await.expect("valid stdout line") {
+                    log::debug!("{}", line);
+                    if line.contains(NATS_READY_MESSAGE) {
+                        if let Some(ready_tx) = ready_tx.take() {
+                            ready_tx.send(true).expect("to send nats ready oneshot");
+                        }
+                    }
+                    if line.contains(NATS_PORT_IN_USE_MESSAGE) {
+                        if let Some(ready_tx) = ready_tx.take() {
+                            ready_tx.send(false).expect("to send nats ready oneshot");
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        // Spawn a task to run the child and wait for the kill oneshot
-        let (kill_tx, kill_rx) = oneshot::channel::<()>();
-        tokio::spawn(async move {
-            tokio::select! {
-                exit = child.wait()  => {
-                    if let Err(_) = exit {
-                        panic!("NATS produced Err while running");
+            // Spawn a task to run the child and wait for the kill oneshot
+            let (kill_tx, kill_rx) = oneshot::channel::<()>();
+            tokio::spawn(async move {
+                tokio::select! {
+                    exit = child.wait()  => {
+                        if let Err(e) = exit {
+                            panic!("NATS produced Err while running: {}", e);
+                        } else {
+                            // We might right reach this if the port is alrady in use..
+                            // This is handled below.
+                            log::debug!("NATS exited on it's own before we killed it: {:?}", exit);
+                        }
+                    }
+                    rx = kill_rx => {
+                        if let Err(_) = rx {
+                            panic!("failed to receive ready oneshot");
+                        } else {
+                            ();
+                        }
+                    }
+                }
+            });
+
+            // Wait for NATS to be ready or timeout
+            match timeout(Duration::from_secs(5), ready_rx).await {
+                Ok(ready) => {
+                    if ready.unwrap() {
+                        return Self {
+                            kill: Some(kill_tx),
+                            port: nats_port,
+                        };
                     } else {
-                        panic!("NATS exited early");
+                        log::warn!("NATS port already in use - trying again with another one");
+                        continue;
                     }
                 }
-                rx = kill_rx => {
-                    if let Err(_) = rx {
-                        panic!("failed to receive ready oneshot");
-                    } else {
-                        ();
-                    }
+                Err(e) => {
+                    log::warn!(
+                        "NATS server failed to reach ready state within timeout: {}",
+                        e
+                    );
                 }
             }
-        });
-
-        // Wait for nats to be ready or timeout
-        if let Err(_) = timeout(Duration::from_secs(5), ready_rx).await {
-            panic!("NATS server failed to reach ready state within timeout");
         }
-
-        Self {
-            kill: Some(kill_tx),
-        }
+        panic!("Could not spawn NATS server")
     }
 }
 


### PR DESCRIPTION
Retrying for ports didn't work at all (the initial port was used to, even if we retried) and the NATS server didn't retry at all.

This is fixed here and should provide more integration test stabillity going forward.