### PR TITLE
add: support binding on port 0 for tools and p2p-extractor

### DIFF
--- a/extractors/p2p/src/lib.rs
+++ b/extractors/p2p/src/lib.rs
@@ -149,7 +149,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
     log::debug!("Starting TCP listener on {}..", args.p2p_address);
     let listener = TcpListener::bind(args.p2p_address.clone()).await?;
-    log::info!("P2P-extractor listening on {}", args.p2p_address);
+    let local_addr = listener.local_addr()?;
+    log::info!("P2P-extractor listening on {}", local_addr);
 
     loop {
         shared::tokio::select! {

--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -17,10 +17,11 @@ const LOG_TARGET: &str = "metricserver";
 
 pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(), io::Error> {
     let listener = TcpListener::bind(prometheus_address)?;
+    let local_addr = listener.local_addr()?;
     log::info!(
         target: LOG_TARGET,
         "Started Prometheus metric server listening on {}.",
-        prometheus_address
+        local_addr
     );
     thread::spawn(move || {
         for incoming_request in listener.incoming() {

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -68,7 +68,6 @@ pub async fn run(
     let metrics = metrics::Metrics::new();
 
     metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
-    log::info!(target: LOG_TARGET, "metrics-server listening on: {}", args.metrics_address);
 
     let nc = async_nats::connect(args.nats_address).await?;
     let mut sub = nc.subscribe("*").await?;

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -87,8 +87,10 @@ pub async fn run(
         });
     }
 
-    log::info!("Starting websocket server on {}", args.websocket_address);
+    log::debug!("Starting websocket server on {}...", args.websocket_address);
     let server = TcpListener::bind(args.websocket_address).await?;
+    let local_addr = server.local_addr()?;
+    log::info!("Started websocket server on {}", local_addr);
 
     // Accept WebSocket clients
     loop {


### PR DESCRIPTION
to get an ephemeral port assinged by the OS. This is useful during development.

Previously, the tools would log port 0, but were listening on another, in this case unknown, port.

closes #232