### PR TITLE
fix: rpc-extractor allow extra fields in RPC results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,8 +482,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ce205b817339b55d93bdb41d66704cfc5299f89576ab24107bd2abf4c29c1e"
 dependencies = [
  "bitcoin",
- "corepc-types",
- "jsonrpc",
+ "corepc-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-client"
+version = "0.9.0"
+source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+dependencies = [
+ "bitcoin",
+ "corepc-types 0.9.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
+ "jsonrpc 0.18.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
  "log",
  "serde",
  "serde_json",
@@ -497,7 +510,7 @@ checksum = "76025e0755bc411fda75e0912a0a0e511d13b54988bf05b90d7681f0c7570b67"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
- "corepc-client",
+ "corepc-client 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2",
  "log",
  "minreq",
@@ -513,6 +526,16 @@ name = "corepc-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0231e773ddcfebb8eb8627a16553de56ab064a03843d847f409107ad661f25"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.9.0"
+source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1200,6 +1223,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64 0.13.1",
+ "minreq",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.18.0"
+source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+dependencies = [
+ "base64 0.22.1",
  "minreq",
  "serde",
  "serde_json",
@@ -2129,7 +2163,7 @@ dependencies = [
  "base32",
  "bitcoin",
  "clap",
- "corepc-client",
+ "corepc-client 0.9.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
  "corepc-node",
  "futures",
  "hex",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,11 +16,14 @@ log = "0.4"
 async-nats = "0.42.0"
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
-corepc-client = { version = "0.9.0",  features = ["client-sync"]}
 tokio = { version = "1.47.0", features = ["rt-multi-thread", "process", "signal"] }
 futures = "0.3.31"
 rand = "0.9.2"
+
 corepc-node = { version = "0.9.0", features = ["download", "29_0"] }
+# using https://github.com/rust-bitcoin/corepc/commit/3a9c52ad5a1ecb47a64342471b6cf8bbbe800780 util 0.10.0 is taged
+# to have https://github.com/rust-bitcoin/corepc/pull/367 (see https://github.com/0xB10C/peer-observer/issues/260) 
+corepc-client = { git = "https://github.com/rust-bitcoin/corepc", rev = "3a9c52ad5a1ecb47a64342471b6cf8bbbe800780", features = ["client-sync"]}
 
 [build-dependencies]
 prost-build = "0.14"


### PR DESCRIPTION
Newer Bitcoin Core versions and e.g. Bitcoin Knots might return fields not present in the corepc-types version used. These previously caused a panic. This was fixed in https://github.com/rust-bitcoin/corepc/pull/367, so use corepc master until there's a new release.

Closes https://github.com/0xB10C/peer-observer/issues/260