### PR TITLE
change: use same corepc crate commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,12 +176,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -478,25 +472,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corepc-client"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ce205b817339b55d93bdb41d66704cfc5299f89576ab24107bd2abf4c29c1e"
-dependencies = [
- "bitcoin",
- "corepc-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "corepc-client"
-version = "0.9.0"
 source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
 dependencies = [
  "bitcoin",
- "corepc-types 0.9.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
- "jsonrpc 0.18.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
+ "corepc-types",
+ "jsonrpc",
  "log",
  "serde",
  "serde_json",
@@ -505,12 +485,11 @@ dependencies = [
 [[package]]
 name = "corepc-node"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76025e0755bc411fda75e0912a0a0e511d13b54988bf05b90d7681f0c7570b67"
+source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
- "corepc-client 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "corepc-client",
  "flate2",
  "log",
  "minreq",
@@ -519,17 +498,6 @@ dependencies = [
  "tempfile",
  "which",
  "zip",
-]
-
-[[package]]
-name = "corepc-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0231e773ddcfebb8eb8627a16553de56ab064a03843d847f409107ad661f25"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1214,18 +1182,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
-dependencies = [
- "base64 0.13.1",
- "minreq",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2163,7 +2119,7 @@ dependencies = [
  "base32",
  "bitcoin",
  "clap",
- "corepc-client 0.9.0 (git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780)",
+ "corepc-client",
  "corepc-node",
  "futures",
  "hex",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -20,9 +20,9 @@ tokio = { version = "1.47.0", features = ["rt-multi-thread", "process", "signal"
 futures = "0.3.31"
 rand = "0.9.2"
 
-corepc-node = { version = "0.9.0", features = ["download", "29_0"] }
 # using https://github.com/rust-bitcoin/corepc/commit/3a9c52ad5a1ecb47a64342471b6cf8bbbe800780 util 0.10.0 is taged
-# to have https://github.com/rust-bitcoin/corepc/pull/367 (see https://github.com/0xB10C/peer-observer/issues/260) 
+# to have https://github.com/rust-bitcoin/corepc/pull/367 (see https://github.com/0xB10C/peer-observer/issues/260)
+corepc-node = { git = "https://github.com/rust-bitcoin/corepc", rev = "3a9c52ad5a1ecb47a64342471b6cf8bbbe800780", features = ["download", "29_0"] }
 corepc-client = { git = "https://github.com/rust-bitcoin/corepc", rev = "3a9c52ad5a1ecb47a64342471b6cf8bbbe800780", features = ["client-sync"]}
 
 [build-dependencies]


### PR DESCRIPTION
This makes packaging in e.g. Nix easier.


    found duplicate version of package `corepc-client v0.9.0` vendored from two sources:

  	source 1: registry `crates-io`
  	source 2: https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad