### PR TITLE
update: use upstream corepc crates and v0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -448,8 +454,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.9.0"
-source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7755b8b9219b23d166a5897b5e2d8266cbdd0de5861d351b96f6db26bcf415f3"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -461,8 +468,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.9.0"
-source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768391062ec3812e223bb3031c5b2fcdd6e0e60b816157f21df82fd3e6617dc0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -479,8 +487,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.9.0"
-source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22db78b0223b66f82f92b14345f06307078f76d94b18280431ea9bc6cd9cbb6"
 dependencies = [
  "bitcoin",
  "serde",
@@ -751,9 +760,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1147,9 +1156,10 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.18.0"
-source = "git+https://github.com/rust-bitcoin/corepc?rev=3a9c52ad5a1ecb47a64342471b6cf8bbbe800780#3a9c52ad5a1ecb47a64342471b6cf8bbbe800780"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.13.1",
  "minreq",
  "serde",
  "serde_json",
@@ -1211,13 +1221,13 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.4.0",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall 0.5.18",
 ]
 
 [[package]]
@@ -1228,9 +1238,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1297,6 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1724,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.4.0",
 ]
@@ -1805,15 +1816,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2134,6 +2145,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_logger"
@@ -3004,12 +3021,12 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -21,11 +21,8 @@ futures = "0.3.31"
 rand = "0.9.2"
 time = "0.3.44"
 regex = "1.12"
-
-# using https://github.com/rust-bitcoin/corepc/commit/3a9c52ad5a1ecb47a64342471b6cf8bbbe800780 util 0.10.0 is taged
-# to have https://github.com/rust-bitcoin/corepc/pull/367 (see https://github.com/0xB10C/peer-observer/issues/260)
-corepc-node = { git = "https://github.com/rust-bitcoin/corepc", rev = "3a9c52ad5a1ecb47a64342471b6cf8bbbe800780", features = ["download", "29_0"] }
-corepc-client = { git = "https://github.com/rust-bitcoin/corepc", rev = "3a9c52ad5a1ecb47a64342471b6cf8bbbe800780", features = ["client-sync"]}
+corepc-node = {version = "0.10.1", features = ["download", "29_0"]}
+corepc-client = {version = "0.10", features = ["client-sync"]}
 
 [build-dependencies]
 prost-build = "0.14"


### PR DESCRIPTION
Previously, were were using master somewhere between v0.9 and v0.10, but we can use v0.10 now. This also allows dependabot to open a PR for upgrading to v0.11 once it's out.

- ref https://github.com/rust-bitcoin/corepc/pull/367#issuecomment-3334821515
- ref https://github.com/0xB10C/peer-observer/issues/260