### PR TITLE
fix: metrics-tool self/subnet announcement metric label order

### DIFF
--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -778,14 +778,14 @@ fn check_self_and_subnet_announcement(
     if address.inner() == ip {
         metrics
             .p2p_address_selfannouncements
-            .with_label_values(&[&direction, &network])
+            .with_label_values(&[&network, &direction])
             .inc();
     } else if network == "IPv4" || network == "IPv6" {
         let addr_subnet = util::subnet(address.inner());
         if addr_subnet == subnet {
             metrics
                 .p2p_address_subnetannouncements
-                .with_label_values(&[&direction, &network])
+                .with_label_values(&[&network, &direction])
                 .inc();
         }
     }

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -829,8 +829,8 @@ async fn test_integration_metrics_p2p_address_self_announcement() {
         ],
         Subject::NetMsg,
         r#"
-        peerobserver_p2p_address_selfannouncements{direction="IPv4",network="inbound"} 1
-        peerobserver_p2p_address_selfannouncements{direction="IPv6",network="inbound"} 1
+        peerobserver_p2p_address_selfannouncements{direction="inbound",network="IPv4"} 1
+        peerobserver_p2p_address_selfannouncements{direction="inbound",network="IPv6"} 1
         "#,
     )
     .await;
@@ -915,8 +915,8 @@ async fn test_integration_metrics_p2p_address_subnet_announcement() {
         ],
         Subject::NetMsg,
         r#"
-        peerobserver_p2p_address_subnetannouncements{direction="IPv4",network="inbound"} 1
-        peerobserver_p2p_address_subnetannouncements{direction="IPv6",network="inbound"} 1
+        peerobserver_p2p_address_subnetannouncements{direction="inbound",network="IPv4"} 1
+        peerobserver_p2p_address_subnetannouncements{direction="inbound",network="IPv6"} 1
         "#,
     )
     .await;


### PR DESCRIPTION
The labels were swapped. direction=IPv4 and network=inbound doesn't make any sense.

Introduced in #303 