### PR TITLE
add: getnetworkinfo RPC support

### DIFF
--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -51,6 +51,8 @@ Options:
           Disable querying and publishing of `getaddrmaninfo` data
       --disable-getchaintxstats
           Disable querying and publishing of `getchaintxstats` data
+      --disable-getnetworkinfo
+          Disable querying and publishing of `getnetworkinfo` data
   -h, --help
           Print help
   -V, --version

--- a/protobuf/rpc_extractor.proto
+++ b/protobuf/rpc_extractor.proto
@@ -11,6 +11,7 @@ message rpc {
     MemoryInfo memory_info = 5;
     AddrManInfo addrman_info = 6;
     ChainTxStats chain_tx_stats = 7;
+    NetworkInfo network_info = 8;
   }
 }
 
@@ -138,4 +139,40 @@ message ChainTxStats {
   optional int64  window_tx_count           = 6; // The number of transactions in the window (only if window_block_count > 0)
   optional int64  window_interval           = 7; // The elapsed time in the window in seconds (only if window_block_count > 0)
   optional double tx_rate                   = 8; // The average rate of transactions per second in the window (only if window_interval > 0)
+}
+
+// A getnetworkinfo RPC result: Returns an object containing various state info regarding P2P networking.
+message NetworkInfo {
+  required int32 version = 1;                             // The server version
+  required string subversion = 2;                         // The server subversion string
+  required int32 protocol_version = 3;                    // The protocol version
+  required string local_services = 4;                     // The services we offer to the network (hex string)
+  repeated string local_services_names = 5;               // Human-readable service names
+  required bool local_relay = 6;                          // True if transaction relay is requested from peers
+  required int32 time_offset = 7;                         // The time offset
+  required uint32 connections = 8;                        // The total number of connections
+  required uint32 connections_in = 9;                     // The number of inbound connections
+  required uint32 connections_out = 10;                   // The number of outbound connections
+  required bool network_active = 11;                      // Whether p2p networking is enabled
+  repeated NetworkInfoNetwork networks = 12;              // Information per network
+  required double relay_fee = 13;                         // Minimum relay fee for transactions in BTC/kB
+  required double incremental_fee = 14;                   // Minimum fee rate increment for mempool limiting in BTC/kB
+  repeated NetworkInfoLocalAddress local_addresses = 15;  // List of local addresses
+  repeated string warnings = 16;                          // Any network and blockchain warnings
+}
+
+// Network information for each network type (ipv4, ipv6, onion)
+message NetworkInfoNetwork {
+  required string name = 1;                              // Network name (ipv4, ipv6, onion, i2p, cjdns)
+  required bool limited = 2;                             // Is the network limited using -onlynet?
+  required bool reachable = 3;                           // Is the network reachable?
+  required string proxy = 4;                             // The proxy that is used for this network, or empty string
+  required bool proxy_randomize_credentials = 5;         // Whether randomized credentials are used
+}
+
+// Local address information
+message NetworkInfoLocalAddress {
+  required string address = 1;                           // Network address
+  required uint32 port = 2;                              // Network port
+  required uint32 score = 3;                             // Relative score
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -197,6 +197,49 @@ fn handle_rpc_event(e: &rpc::RpcEvent, metrics: metrics::Metrics) {
                     .set(data.total as i64);
             }
         }
+        rpc::RpcEvent::NetworkInfo(info) => {
+            metrics.rpc_networkinfo_version.set(info.version as i64);
+            metrics
+                .rpc_networkinfo_protocol_version
+                .set(info.protocol_version as i64);
+            metrics
+                .rpc_networkinfo_time_offset
+                .set(info.time_offset as i64);
+            metrics
+                .rpc_networkinfo_connections
+                .set(info.connections as i64);
+            metrics
+                .rpc_networkinfo_connections_in
+                .set(info.connections_in as i64);
+            metrics
+                .rpc_networkinfo_connections_out
+                .set(info.connections_out as i64);
+            metrics
+                .rpc_networkinfo_network_active
+                .set(if info.network_active { 1 } else { 0 });
+            metrics.rpc_networkinfo_relay_fee.set(info.relay_fee);
+            metrics
+                .rpc_networkinfo_incremental_fee
+                .set(info.incremental_fee);
+            metrics
+                .rpc_networkinfo_warnings
+                .set(info.warnings.len() as i64);
+            metrics
+                .rpc_networkinfo_local_addresses_count
+                .set(info.local_addresses.len() as i64);
+
+            // Set dimensional metrics for each network
+            for network in &info.networks {
+                metrics
+                    .rpc_networkinfo_networks
+                    .with_label_values(&[network.name.as_str(), "limited"])
+                    .set(if network.limited { 1 } else { 0 });
+                metrics
+                    .rpc_networkinfo_networks
+                    .with_label_values(&[network.name.as_str(), "reachable"])
+                    .set(if network.reachable { 1 } else { 0 });
+            }
+        }
         rpc::RpcEvent::MempoolInfo(info) => {
             metrics
                 .rpc_mempoolinfo_mempool_loaded

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -299,6 +299,20 @@ pub struct Metrics {
     pub rpc_chaintxstats_window_interval: IntGauge,
     pub rpc_chaintxstats_tx_rate: Gauge,
 
+    // getnetworkinfo
+    pub rpc_networkinfo_version: IntGauge,
+    pub rpc_networkinfo_protocol_version: IntGauge,
+    pub rpc_networkinfo_time_offset: IntGauge,
+    pub rpc_networkinfo_connections: IntGauge,
+    pub rpc_networkinfo_connections_in: IntGauge,
+    pub rpc_networkinfo_connections_out: IntGauge,
+    pub rpc_networkinfo_network_active: IntGauge,
+    pub rpc_networkinfo_relay_fee: Gauge,
+    pub rpc_networkinfo_incremental_fee: Gauge,
+    pub rpc_networkinfo_warnings: IntGauge,
+    pub rpc_networkinfo_local_addresses_count: IntGauge,
+    pub rpc_networkinfo_networks: IntGaugeVec,
+
     // P2P-extractor
     pub p2pextractor_ping_duration_nanoseconds: IntGauge,
     pub p2pextractor_addrv2relay_addresses: IntCounterVec,
@@ -460,6 +474,20 @@ impl Metrics {
         ig!(rpc_chaintxstats_window_interval, "Elapsed time in the window in seconds.", registry);
         g!(rpc_chaintxstats_tx_rate, "Average rate of transactions per second in the window.", registry);
 
+        // getnetworkinfo
+        ig!(rpc_networkinfo_version, "Bitcoin Core version from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_protocol_version, "Protocol version from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_time_offset, "Time offset from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_connections, "Total number of connections from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_connections_in, "Number of inbound connections from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_connections_out, "Number of outbound connections from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_network_active, "Whether p2p networking is enabled (1=yes, 0=no) from getnetworkinfo.", registry);
+        g!(rpc_networkinfo_relay_fee, "Minimum relay fee in BTC/kB from getnetworkinfo.", registry);
+        g!(rpc_networkinfo_incremental_fee, "Minimum fee increment in BTC/kB from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_warnings, "Whether warnings exist (1=yes, 0=no) from getnetworkinfo.", registry);
+        ig!(rpc_networkinfo_local_addresses_count, "Number of local addresses from getnetworkinfo.", registry);
+        igv!(rpc_networkinfo_networks, "Network status by network type from getnetworkinfo.", [LABEL_RPC_NETWORK_TYPE, "property"], registry);
+
         // P2P-extractor
         ig!(p2pextractor_ping_duration_nanoseconds, "The time it takes for a connected Bitcoin node to respond to a ping with a pong in nanoseconds.", registry);
         icv!(p2pextractor_addrv2relay_addresses, "The total number of addresses relayed to the p2p-extractor by the node, per network", ["network"], registry);
@@ -616,6 +644,20 @@ impl Metrics {
             rpc_chaintxstats_window_tx_count,
             rpc_chaintxstats_window_interval,
             rpc_chaintxstats_tx_rate,
+
+            // getnetworkinfo
+            rpc_networkinfo_version,
+            rpc_networkinfo_protocol_version,
+            rpc_networkinfo_time_offset,
+            rpc_networkinfo_connections,
+            rpc_networkinfo_connections_in,
+            rpc_networkinfo_connections_out,
+            rpc_networkinfo_network_active,
+            rpc_networkinfo_relay_fee,
+            rpc_networkinfo_incremental_fee,
+            rpc_networkinfo_warnings,
+            rpc_networkinfo_local_addresses_count,
+            rpc_networkinfo_networks,
 
             // p2p-extractor
             p2pextractor_ping_duration_nanoseconds,

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -29,7 +29,7 @@ use shared::{
         p2p_extractor,
         rpc_extractor::{
             self, AddrManInfo, AddrManInfoNetwork, ChainTxStats, MemoryInfo, MempoolInfo,
-            NetTotals, PeerInfo, PeerInfos, UploadTarget,
+            NetTotals, NetworkInfo, NetworkInfoNetwork, PeerInfo, PeerInfos, UploadTarget,
         },
     },
     rand::{self, Rng},
@@ -3286,6 +3286,71 @@ async fn test_integration_metrics_logextractor_blockchecked_mutated_events() {
         r#"
         peerobserver_log_block_checked_events 1
         peerobserver_log_mutated_blocks{status="bad-txns-duplicate"} 1
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_rpc_getnetworkinfo() {
+    println!("test that the getnetworkinfo metrics work");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::NetworkInfo(NetworkInfo {
+                    version: 270000,
+                    subversion: "/Satoshi:27.0.0/".to_string(),
+                    protocol_version: 70016,
+                    local_services: "000000000000040d".to_string(),
+                    local_services_names: vec!["NETWORK".to_string(), "WITNESS".to_string()],
+                    local_relay: true,
+                    time_offset: -100,
+                    connections: 8,
+                    connections_in: 3,
+                    connections_out: 5,
+                    network_active: true,
+                    networks: vec![
+                        NetworkInfoNetwork {
+                            name: "ipv4".to_string(),
+                            limited: false,
+                            reachable: true,
+                            proxy: "".to_string(),
+                            proxy_randomize_credentials: false,
+                        },
+                        NetworkInfoNetwork {
+                            name: "ipv6".to_string(),
+                            limited: false,
+                            reachable: true,
+                            proxy: "".to_string(),
+                            proxy_randomize_credentials: false,
+                        },
+                    ],
+                    relay_fee: 0.00001,
+                    incremental_fee: 0.00001,
+                    local_addresses: vec![],
+                    warnings: vec!["warning1".to_string(), "warning2".to_string()],
+                })),
+            }))
+            .unwrap(),
+        ],
+        Subject::Rpc,
+        r#"
+        peerobserver_rpc_networkinfo_version 270000
+        peerobserver_rpc_networkinfo_protocol_version 70016
+        peerobserver_rpc_networkinfo_time_offset -100
+        peerobserver_rpc_networkinfo_connections 8
+        peerobserver_rpc_networkinfo_connections_in 3
+        peerobserver_rpc_networkinfo_connections_out 5
+        peerobserver_rpc_networkinfo_network_active 1
+        peerobserver_rpc_networkinfo_relay_fee 0.00001
+        peerobserver_rpc_networkinfo_incremental_fee 0.00001
+        peerobserver_rpc_networkinfo_warnings 2
+        peerobserver_rpc_networkinfo_local_addresses_count 0
+        peerobserver_rpc_networkinfo_networks{network="ipv4",property="limited"} 0
+        peerobserver_rpc_networkinfo_networks{network="ipv4",property="reachable"} 1
+        peerobserver_rpc_networkinfo_networks{network="ipv6",property="limited"} 0
+        peerobserver_rpc_networkinfo_networks{network="ipv6",property="reachable"} 1
         "#,
     )
     .await;


### PR DESCRIPTION
## Implementation of `getnetworkinfo` RPC Extractor

This PR adds support for Bitcoin Core's `getnetworkinfo` RPC call to the rpc-extractor, following patterns established in previous PRs.

### Main Changes

**Protobuf Schema** (`protobuf/rpc_extractor.proto`)
- Added `NetworkInfo` message with all `getnetworkinfo` fields
- Added `NetworkInfoNetwork` for per-network information (ipv4, ipv6, onion, i2p, cjdns)
- Added `NetworkInfoLocalAddress` for local addresses
- Integrated into the `rpc` message's `oneof rpc_event`

**Type Conversions** (`shared/src/protobuf/rpc_extractor.rs`)
- Implemented `From<>` conversions from `corepc_node::vtype::GetNetworkInfo`
- Added `fmt::Display` implementations for logging
- Correct conversion of `warnings` field (Vec<String> → String)

**RPC Extractor** (`extractors/rpc/src/lib.rs`)
- Added new CLI flag `--disable-getnetworkinfo`
- Implemented `getnetworkinfo()` function that queries and publishes events
- Integrated into main loop and `disable_all` check
- Added status logging

**Prometheus Metrics** (`tools/metrics/src/metrics.rs` and `lib.rs`)
- Individual metrics for main fields (version, connections, fees, etc.)
- **Dimensional metric** `rpc_networkinfo_networks` using `IntGaugeVec` with labels `[network, property]` (following lesson from PR #309)
- Complete handler in `handle_rpc_event()`

**Integration Tests**
- Added `test_integration_rpc_getnetworkinfo` test
- All existing tests updated with new `disable_getnetworkinfo` parameter

**Documentation**
- README updated with new CLI flag

## Privacy Analysis: `getnetworkinfo` RPC Extractor

### Data Exposed

**Network Information (Low Sensitivity)**
- `version`, `subversion`, `protocol_version`: Already exposed in P2P handshakes
- `connections`, `connections_in`, `connections_out`: Aggregated counts, do not identify specific peers
- `network_active`, `networks[]`: Connectivity state, not sensitive
- `relay_fee`, `incremental_fee`: Public node configuration

**Information with Privacy Considerations**
- `local_addresses[]`: IP/onion addresses where the node is listening
  - Already semi-public (announced to peers via `addr`/`addrv2` messages)
  - **Note**: Centralized in Prometheus metrics - ensure metrics endpoint is not publicly exposed
- `warnings`: May reveal problematic node states
  - Legitimate use for monitoring (Issue #199)
  - Requires protection of metrics endpoint

### Security Measures Implemented

1. **RPC Authentication Required**: Extractor requires RPC credentials (`--rpc-user`/`--rpc-cookie-file`)
2. **No Critical Data Exposed**: Does not expose private keys, wallet addresses, or user transaction data
3. **Data Equivalent to P2P**: Information is similar to what any P2P peer can obtain