### PR TITLE
add: getblockchaininfo RPC support

### DIFF
--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -53,6 +53,8 @@ Options:
           Disable querying and publishing of `getchaintxstats` data
       --disable-getnetworkinfo
           Disable querying and publishing of `getnetworkinfo` data
+      --disable-getblockchaininfo
+          Disable querying and publishing of `getblockchaininfo` data
   -h, --help
           Print help
   -V, --version

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -86,6 +86,10 @@ pub struct Args {
     /// Disable querying and publishing of `getnetworkinfo` data.
     #[arg(long, default_value_t = false)]
     pub disable_getnetworkinfo: bool,
+
+    /// Disable querying and publishing of `getblockchaininfo` data.
+    #[arg(long, default_value_t = false)]
+    pub disable_getblockchaininfo: bool,
 }
 
 impl Args {
@@ -104,6 +108,7 @@ impl Args {
         disable_getaddrmaninfo: bool,
         disable_getchaintxstats: bool,
         disable_getnetworkinfo: bool,
+        disable_getblockchaininfo: bool,
     ) -> Args {
         Self {
             nats_address,
@@ -121,6 +126,7 @@ impl Args {
             disable_getaddrmaninfo,
             disable_getchaintxstats,
             disable_getnetworkinfo,
+            disable_getblockchaininfo,
             // when adding more disable_* args, make sure to update the disable_all below
         }
     }
@@ -148,9 +154,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     );
 
     // Use a separate interval for queries that can be run less frequently
-    // Currently only getchaintxstats, hence named as such
-    let chaintxstats_duration = Duration::from_secs(args.query_interval * 60);
-    let mut chaintxstats_interval = time::interval(chaintxstats_duration);
+    let mut less_frequent_interval = time::interval(Duration::from_secs(args.query_interval * 60));
 
     log::info!(
         "Querying getpeerinfo enabled:    {}",
@@ -181,6 +185,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         "Querying getnetworkinfo enabled: {}",
         !args.disable_getnetworkinfo
     );
+    log::info!(
+        "Querying getblockchaininfo enabled: {}",
+        !args.disable_getblockchaininfo
+    );
     // check if we have at least one RPC to query
     let disable_all = args.disable_getpeerinfo
         && args.disable_getmempoolinfo
@@ -189,7 +197,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         && args.disable_getmemoryinfo
         && args.disable_getaddrmaninfo
         && args.disable_getchaintxstats
-        && args.disable_getnetworkinfo;
+        && args.disable_getnetworkinfo
+        && args.disable_getblockchaininfo;
     if disable_all {
         log::warn!("No RPC configured to be queried!");
     }
@@ -226,9 +235,14 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                         log::error!("Could not fetch and publish 'getnetworkinfo': {}", e)
                 }
             }
-            _ = chaintxstats_interval.tick(), if !args.disable_getchaintxstats => {
-                if let Err(e) = getchaintxstats(&rpc_client, &nats_client).await {
-                    log::error!("Could not fetch and publish 'getchaintxstats': {}", e)
+            _ = less_frequent_interval.tick() => {
+                if !args.disable_getchaintxstats
+                    && let Err(e) = getchaintxstats(&rpc_client, &nats_client).await {
+                        log::error!("Could not fetch and publish 'getchaintxstats': {}", e)
+                }
+                if !args.disable_getblockchaininfo
+                    && let Err(e) = getblockchaininfo(&rpc_client, &nats_client).await {
+                        log::error!("Could not fetch and publish 'getblockchaininfo': {}", e)
                 }
             }
             res = shutdown_rx.changed() => {
@@ -378,6 +392,24 @@ async fn getnetworkinfo(
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::NetworkInfo(
             network_info.into(),
+        )),
+    }))?;
+
+    nats_client
+        .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
+        .await?;
+    Ok(())
+}
+
+async fn getblockchaininfo(
+    rpc_client: &Client,
+    nats_client: &async_nats::Client,
+) -> Result<(), FetchOrPublishError> {
+    let blockchain_info = rpc_client.get_blockchain_info()?;
+
+    let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+        rpc_event: Some(rpc_extractor::rpc::RpcEvent::BlockchainInfo(
+            blockchain_info.into(),
         )),
     }))?;
 

--- a/protobuf/rpc_extractor.proto
+++ b/protobuf/rpc_extractor.proto
@@ -12,6 +12,7 @@ message rpc {
     AddrManInfo addrman_info = 6;
     ChainTxStats chain_tx_stats = 7;
     NetworkInfo network_info = 8;
+    BlockchainInfo blockchain_info = 9;
   }
 }
 
@@ -175,4 +176,23 @@ message NetworkInfoLocalAddress {
   required string address = 1;                           // Network address
   required uint32 port = 2;                              // Network port
   required uint32 score = 3;                             // Relative score
+}
+
+// A getblockchaininfo RPC result: Returns various state info regarding blockchain processing.
+message BlockchainInfo {
+  required string chain = 1;                             // Current network name (main, test, regtest)
+  required uint32 blocks = 2;                            // Height of the most-work fully-validated chain
+  required uint32 headers = 3;                           // Current number of headers validated
+  required string bestblockhash = 4;                     // Hash of the currently best block
+  required double difficulty = 5;                        // Current difficulty
+  required uint64 time = 6;                              // Block time of the best block (UNIX timestamp)
+  required uint64 mediantime = 7;                        // Median time for the current best block
+  required double verificationprogress = 8;              // Estimate of verification progress [0..1]
+  required bool initialblockdownload = 9;                // Whether this node is in Initial Block Download mode
+  required string chainwork = 10;                        // Total amount of work in active chain (hexadecimal)
+  required uint64 size_on_disk = 11;                     // Estimated size of block and undo files on disk
+  required bool pruned = 12;                             // If the blocks are subject to pruning
+  required uint32 prune_height = 13;                      // Lowest-height complete block stored (only if pruning enabled)
+  required uint64 prune_target_size = 14;                // Target size used by pruning (only if automatic pruning enabled)
+  repeated string warnings = 15;                         // Any network and blockchain warnings
 }

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -8,6 +8,7 @@ use corepc_client::types::v26::{
     GetMempoolInfo, GetPeerInfo as RPCGetPeerInfo, PeerInfo as RPCPeerInfo,
 };
 use corepc_client::types::v28::{GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork};
+use corepc_client::types::v29::GetBlockchainInfo;
 use std::fmt;
 
 // structs are generated via the rpc_extractor.proto file
@@ -45,6 +46,7 @@ impl fmt::Display for rpc::RpcEvent {
             rpc::RpcEvent::AddrmanInfo(info) => write!(f, "{}", info),
             rpc::RpcEvent::ChainTxStats(stats) => write!(f, "{}", stats),
             rpc::RpcEvent::NetworkInfo(info) => write!(f, "{}", info),
+            rpc::RpcEvent::BlockchainInfo(info) => write!(f, "{}", info),
         }
     }
 }
@@ -334,5 +336,42 @@ impl fmt::Display for NetworkInfoNetwork {
 impl fmt::Display for NetworkInfoLocalAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "LocalAddress({}:{})", self.address, self.port)
+    }
+}
+
+impl From<GetBlockchainInfo> for BlockchainInfo {
+    fn from(info: GetBlockchainInfo) -> Self {
+        BlockchainInfo {
+            chain: info.chain,
+            blocks: info.blocks as u32,
+            headers: info.headers as u32,
+            bestblockhash: info.best_block_hash,
+            difficulty: info.difficulty,
+            time: info.time as u64,
+            mediantime: info.median_time as u64,
+            verificationprogress: info.verification_progress,
+            initialblockdownload: info.initial_block_download,
+            chainwork: info.chain_work,
+            size_on_disk: info.size_on_disk,
+            pruned: info.pruned,
+            prune_height: info.prune_height.map(|h| h as u32).unwrap_or_default(),
+            prune_target_size: info.prune_target_size.map(|s| s as u64).unwrap_or_default(),
+            warnings: info.warnings,
+        }
+    }
+}
+
+impl fmt::Display for BlockchainInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let warnings_display = if self.warnings.is_empty() {
+            "none".to_string()
+        } else {
+            format!("[{}]", self.warnings.join("; "))
+        };
+        write!(
+            f,
+            "BlockchainInfo(chain={}, blocks={}, ibd={}, warnings={})",
+            self.chain, self.blocks, self.initialblockdownload, warnings_display
+        )
     }
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -240,6 +240,32 @@ fn handle_rpc_event(e: &rpc::RpcEvent, metrics: metrics::Metrics) {
                     .set(if network.reachable { 1 } else { 0 });
             }
         }
+        rpc::RpcEvent::BlockchainInfo(info) => {
+            metrics.rpc_blockchaininfo_blocks.set(info.blocks as i64);
+            metrics.rpc_blockchaininfo_headers.set(info.headers as i64);
+            metrics.rpc_blockchaininfo_difficulty.set(info.difficulty);
+            metrics
+                .rpc_blockchaininfo_verification_progress
+                .set(info.verificationprogress);
+            metrics
+                .rpc_blockchaininfo_initial_block_download
+                .set(if info.initialblockdownload { 1 } else { 0 });
+            metrics
+                .rpc_blockchaininfo_size_on_disk
+                .set(info.size_on_disk as i64);
+            metrics
+                .rpc_blockchaininfo_pruned
+                .set(if info.pruned { 1 } else { 0 });
+            metrics
+                .rpc_blockchaininfo_prune_height
+                .set(info.prune_height as i64);
+            metrics
+                .rpc_blockchaininfo_prune_target_size
+                .set(info.prune_target_size as i64);
+            metrics
+                .rpc_blockchaininfo_warnings
+                .set(info.warnings.len() as i64);
+        }
         rpc::RpcEvent::MempoolInfo(info) => {
             metrics
                 .rpc_mempoolinfo_mempool_loaded

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -313,6 +313,18 @@ pub struct Metrics {
     pub rpc_networkinfo_local_addresses_count: IntGauge,
     pub rpc_networkinfo_networks: IntGaugeVec,
 
+    // getblockchaininfo
+    pub rpc_blockchaininfo_blocks: IntGauge,
+    pub rpc_blockchaininfo_headers: IntGauge,
+    pub rpc_blockchaininfo_difficulty: Gauge,
+    pub rpc_blockchaininfo_verification_progress: Gauge,
+    pub rpc_blockchaininfo_initial_block_download: IntGauge,
+    pub rpc_blockchaininfo_size_on_disk: IntGauge,
+    pub rpc_blockchaininfo_pruned: IntGauge,
+    pub rpc_blockchaininfo_prune_height: IntGauge,
+    pub rpc_blockchaininfo_prune_target_size: IntGauge,
+    pub rpc_blockchaininfo_warnings: IntGauge,
+
     // P2P-extractor
     pub p2pextractor_ping_duration_nanoseconds: IntGauge,
     pub p2pextractor_addrv2relay_addresses: IntCounterVec,
@@ -488,6 +500,18 @@ impl Metrics {
         ig!(rpc_networkinfo_local_addresses_count, "Number of local addresses from getnetworkinfo.", registry);
         igv!(rpc_networkinfo_networks, "Network status by network type from getnetworkinfo.", [LABEL_RPC_NETWORK_TYPE, "property"], registry);
 
+        // getblockchaininfo
+        ig!(rpc_blockchaininfo_blocks, "Height of the most-work fully-validated chain from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_headers, "Current number of headers validated from getblockchaininfo.", registry);
+        g!(rpc_blockchaininfo_difficulty, "Current difficulty from getblockchaininfo.", registry);
+        g!(rpc_blockchaininfo_verification_progress, "Estimate of verification progress [0..1] from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_initial_block_download, "Whether this node is in Initial Block Download mode (1=yes, 0=no) from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_size_on_disk, "Estimated size of block and undo files on disk in bytes from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_pruned, "Whether the blocks are subject to pruning (1=yes, 0=no) from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_prune_height, "Height of the last block pruned, plus one from getblockchaininfo.", registry);
+        ig!(rpc_blockchaininfo_prune_target_size, "The target size used by pruning (set to 0 if automatic pruning is disabled).", registry);
+        ig!(rpc_blockchaininfo_warnings, "Number of warnings from getblockchaininfo.", registry);
+
         // P2P-extractor
         ig!(p2pextractor_ping_duration_nanoseconds, "The time it takes for a connected Bitcoin node to respond to a ping with a pong in nanoseconds.", registry);
         icv!(p2pextractor_addrv2relay_addresses, "The total number of addresses relayed to the p2p-extractor by the node, per network", ["network"], registry);
@@ -658,6 +682,18 @@ impl Metrics {
             rpc_networkinfo_warnings,
             rpc_networkinfo_local_addresses_count,
             rpc_networkinfo_networks,
+
+            // getblockchaininfo
+            rpc_blockchaininfo_blocks,
+            rpc_blockchaininfo_headers,
+            rpc_blockchaininfo_difficulty,
+            rpc_blockchaininfo_verification_progress,
+            rpc_blockchaininfo_initial_block_download,
+            rpc_blockchaininfo_size_on_disk,
+            rpc_blockchaininfo_pruned,
+            rpc_blockchaininfo_prune_height,
+            rpc_blockchaininfo_prune_target_size,
+            rpc_blockchaininfo_warnings,
 
             // p2p-extractor
             p2pextractor_ping_duration_nanoseconds,


### PR DESCRIPTION
## Add getblockchaininfo RPC Support

This PR adds support for extracting and monitoring `getblockchaininfo` RPC data, following the same pattern established for other RPC extractors.

### Changes

- **RPC Extractor**: Added `getblockchaininfo` query and NATS publishing in `extractors/rpc`
- **Protobuf Schema**: Added `BlockchainInfo` message definition with all relevant fields
- **Prometheus Metrics**: Added 8 metrics for blockchain state monitoring:
  - `rpc_blockchaininfo_blocks` - Current block height
  - `rpc_blockchaininfo_headers` - Current header count
  - `rpc_blockchaininfo_difficulty` - Current difficulty
  - `rpc_blockchaininfo_verification_progress` - Sync progress [0..1]
  - `rpc_blockchaininfo_initial_block_download` - IBD status (0/1)
  - `rpc_blockchaininfo_size_on_disk` - Disk usage in bytes
  - `rpc_blockchaininfo_pruned` - Pruning status (0/1)
  - `rpc_blockchaininfo_warnings` - Warnings present (0/1)

### Privacy Considerations

Similar to `getnetworkinfo`, this implementation follows a privacy-conscious approach:

**Low Risk Fields** (exposed in both NATS and Prometheus):
- Block height, headers, difficulty - Public blockchain state
- Verification progress, IBD status - Operational state (low sensitivity)
- Size on disk, pruning status - Configuration info (low sensitivity)

**Moderate Risk Fields** (exposed in NATS, not in Prometheus):
- `bestblockhash` - Could aid in fingerprinting specific node state
- `chainwork` - Total work calculation (could help identify node)
- `time` / `mediantime` - Block timestamps (could aid temporal fingerprinting)
- `chain` - Network identifier (main/test/regtest)
- `pruneheight` / `prune_target_size` - Pruning configuration details

**Recommendations**:
- Ensure NATS server is only accessible on localhost or private network
- Consider adding authentication if NATS is shared across hosts
- The privacy risk is **lower** than `getnetworkinfo` since no network identifiers are exposed