### PR TITLE
update: Nix package version in CI

### DIFF
--- a/.github/workflows/rust-nix.yml
+++ b/.github/workflows/rust-nix.yml
@@ -14,11 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-25.05
+        nix_path: nixpkgs=channel:nixos-25.11
     - name: Build
       run: nix-shell --pure --command "cargo build --all-features"
     - name: Run tests

--- a/.github/workflows/rust-ubuntu.yml
+++ b/.github/workflows/rust-ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo apt-get install -y \
           nats-server
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Build
       run: cargo build --all-features
     - name: Run tests and integration tests


### PR DESCRIPTION
This gives us a more recent rust version, which is needed in https://github.com/peer-observer/peer-observer/pull/318 (the Ubuntu rust version knows a feature which the nix version does not. Causes CI to fail).