### PR TITLE
refactor: split Rust Nix CI job into multiple jobs

### DIFF
--- a/.github/workflows/rust-nix.yml
+++ b/.github/workflows/rust-nix.yml
@@ -1,4 +1,4 @@
-name: build (nix-shell)
+name: nix
 
 on:
   workflow_dispatch:
@@ -11,6 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -21,11 +22,41 @@ jobs:
         nix_path: nixpkgs=channel:nixos-25.11
     - name: Build
       run: nix-shell --pure --command "cargo build --all-features"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-25.11
     - name: Run tests
       run: nix-shell --pure --command "cargo test --all-features"
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-25.11
+    # needed to have all packages code-generated for fmt
+    - name: Run cargo check
+      run: nix-shell --pure --command "cargo check --all"
     - name: Run cargo fmt
       run: nix-shell --pure --command "cargo fmt --all -- --check"
-    - name: Run cargo tarpaulin (code coverage)
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-25.11
+    - name: Run coverage
       run: nix-shell --pure --command "cargo tarpaulin --out Lcov --out Html --workspace --all-features"
     - name: Upload HTML coverage report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/rust-ubuntu.yml
+++ b/.github/workflows/rust-ubuntu.yml
@@ -1,4 +1,4 @@
-name: build (ubuntu)
+name: ubuntu
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This allows e.g. the format check, integration tests, and build to run in parallel. This provides faster and more direct feedback to developers by clearly showing which job failed, and showing that earlier.

Along with #318, it allows us to introduce a lint/clippy job sometime later.