### PR TITLE
add: metric for private transaction broadcast connections

### DIFF
--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -37,6 +37,10 @@ mod stat_util;
 
 const LOG_TARGET: &str = "main";
 
+// User agent of private transaction broadcast connections from Bitcoin Core (and others).
+// See https://github.com/bitcoin/bitcoin/blob/9ec1ae0e98c0d60fa6ebc9713dd344b454ebe0b6/src/net_processing.cpp#L1559
+const PRIVATE_TRANSACTION_BROADCAST_USERAGENT: &str = "/pynode:0.0.1/";
+
 /// A peer-observer tool that produces Prometheus metrics for received events
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -1404,6 +1408,10 @@ fn handle_p2p_message(msg: &message::MessageEvent, timestamp_ms: u64, metrics: m
                         .p2p_version_useragent
                         .with_label_values(&[&user_agent])
                         .inc();
+
+                    if user_agent == PRIVATE_TRANSACTION_BROADCAST_USERAGENT {
+                        metrics.conn_private_transaction_broadcast.inc();
+                    }
                 }
             }
             Msg::Feefilter(f) => {

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -179,6 +179,16 @@ pub struct Metrics {
     pub p2p_address_subnetannouncements: IntCounterVec,
     pub p2p_addrv2_empty: IntCounterVec,
     pub p2p_ping_inbound_value: IntCounterVec,
+    pub p2p_inv_entries: IntCounterVec,
+    pub p2p_inv_entries_histogram: HistogramVec,
+    pub p2p_invs_homogeneous: IntCounterVec,
+    pub p2p_invs_heterogeneous: IntCounterVec,
+    pub p2p_invs_outbound_large: IntCounter,
+    pub p2p_oldping_subnet: IntCounterVec,
+    pub p2p_version_useragent: IntCounterVec,
+    pub p2p_feefilter_feerate: IntCounterVec,
+    pub p2p_reject_message: IntCounterVec,
+
     pub conn_inbound: IntCounter,
     pub conn_inbound_network: IntCounterVec,
     pub conn_inbound_banlist_monero: IntCounter,
@@ -195,15 +205,8 @@ pub struct Metrics {
     pub conn_evicted_inbound: IntCounter,
     pub conn_misbehaving: IntCounterVec,
     pub conn_misbehaving_reason: IntCounterVec,
-    pub p2p_inv_entries: IntCounterVec,
-    pub p2p_inv_entries_histogram: HistogramVec,
-    pub p2p_invs_homogeneous: IntCounterVec,
-    pub p2p_invs_heterogeneous: IntCounterVec,
-    pub p2p_invs_outbound_large: IntCounter,
-    pub p2p_oldping_subnet: IntCounterVec,
-    pub p2p_version_useragent: IntCounterVec,
-    pub p2p_feefilter_feerate: IntCounterVec,
-    pub p2p_reject_message: IntCounterVec,
+    pub conn_private_transaction_broadcast: IntCounter,
+
     pub addrman_new_insert: IntCounterVec,
     pub addrman_tried_insert: IntCounter,
     pub mempool_added: IntCounter,
@@ -407,6 +410,7 @@ impl Metrics {
         ic!(conn_evicted_inbound, "Number of evicted inbound connections.", registry);
         icv!(conn_misbehaving, "Number of misbehaving connections.", [LABEL_CONN_MISBEHAVING_ID, LABEL_CONN_MISBEHAVING_MESSAGE], registry);
         icv!(conn_misbehaving_reason, "Occurences of misbehavior by reasons", [LABEL_CONN_MISBEHAVING_MESSAGE], registry);
+        ic!(conn_private_transaction_broadcast, "Number of private transaction broadcast (https://github.com/bitcoin/bitcoin/pull/29415) connections (detected by user_agent).", registry);
         icv!(p2p_inv_entries, "Number of INV entries send and received with INV type.", [LABEL_P2P_DIRECTION, LABEL_P2P_INV_TYPE], registry);
         hv!(p2p_inv_entries_histogram, "Histogram number of entries contained in an INV message.", BUCKETS_INV_SIZE, [LABEL_P2P_DIRECTION], registry);
         icv!(p2p_invs_homogeneous, "Number of homogeneous INV entries sent and received.", [LABEL_P2P_DIRECTION], registry);
@@ -615,6 +619,8 @@ impl Metrics {
             conn_evicted_inbound,
             conn_misbehaving,
             conn_misbehaving_reason,
+            conn_private_transaction_broadcast,
+
             p2p_inv_entries,
             p2p_inv_entries_histogram,
             p2p_invs_homogeneous,

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -1652,6 +1652,53 @@ async fn test_integration_metrics_conn_special_ip() {
 }
 
 #[tokio::test]
+async fn test_integration_metrics_conn_private_transaction_broadcast() {
+    println!("test that the private_transaction_broadcast connection metrics work");
+
+    publish_and_check(
+        &[Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+                meta: Metadata {
+                    peer_id: 1,
+                    addr: "127.0.0.1:2134".to_string(),
+                    conn_type: 3,
+                    command: "version".to_string(),
+                    inbound: true,
+                    size: 80,
+                },
+                msg: Some(Msg::Version(Version {
+                    version: 123,
+                    services: 232,
+                    timestamp: 1,
+                    receiver: Address {
+                        timestamp: 0,
+                        port: 1,
+                        services: 1,
+                        address: None,
+                    },
+                    sender: Address {
+                        timestamp: 0,
+                        port: 2,
+                        services: 2,
+                        address: None,
+                    },
+                    nonce: 3,
+                    user_agent: "/pynode:0.0.1/".to_string(),
+                    start_height: 1,
+                    relay: true,
+                })),
+            })),
+        }))
+        .unwrap()],
+        Subject::NetConn,
+        r#"
+        peerobserver_conn_private_transaction_broadcast 1
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_integration_metrics_validation() {
     println!("test that validation metrics work");
 


### PR DESCRIPTION
To keep track of the usage of this feature, count the number of version messages with the `/pynode:0.0.1/` user agents. This isn't perfect, but a good proxy for now.

closes #349