### PR TITLE
fix(tests): move category assertions into guards to prevent log event ordering races

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -39,6 +39,11 @@ fn setup() {
     });
 }
 
+/// Bridges Bitcoin Core's `debug.log` into a named pipe for the log extractor.
+///
+/// The log extractor reads from a pipe (not a regular file), so we create one
+/// with `mkfifo` and spawn a background `tail -f` process that continuously
+/// streams new log lines from `log_path` into `pipe_path`.
 fn spawn_pipe(log_path: String, pipe_path: String) {
     // Create pipe
     std::process::Command::new("mkfifo")
@@ -69,6 +74,11 @@ fn make_test_args(nats_port: u16, bitcoind_pipe: String) -> Args {
     )
 }
 
+/// Starts a regtest `bitcoind` node with the given configuration.
+///
+/// The binary is resolved from the `BITCOIND_EXE` environment variable
+/// (via `corepc_node::exe_path`); if unset, a pre-built binary is
+/// downloaded automatically.
 fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
     info!("exe_path={:?}", corepc_node::exe_path());
@@ -82,6 +92,12 @@ fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
     corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
 }
 
+/// Creates a two-node regtest topology:
+/// - node1 listens for inbound P2P connections
+/// - node2 connects to node1.
+///
+/// `node1_args` are appended as extra `bitcoind` CLI flags (e.g. `-debug=validation`) so tests
+/// can enable the specific logging needed to trigger the events they want to observe.
 fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corepc_node::Node) {
     // node1 listens for p2p connections
     let mut node1_conf = corepc_node::Conf::default();
@@ -100,6 +116,25 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
     (node1, node2)
 }
 
+/// Integration test harness that verifies the log extractor produces expected
+/// NATS events in response to Bitcoin Core activity.
+///
+/// 1. Initializes logging and spins up two connected regtest nodes (node1
+///    accepts inbound P2P; node2 connects to it). `args` are passed as extra
+///    bitcoind CLI flags to node1 (e.g. `-debug=validation`).
+/// 2. Starts a throwaway NATS server and launches the log extractor, which
+///    reads node1's `debug.log` via a named pipe (`mkfifo` + `tail -f`) and
+///    publishes protobuf-encoded events to NATS.
+/// 3. Calls `test_setup` against node1's RPC client so the test can trigger
+///    the specific node behaviour it wants to observe (mine a block, submit a
+///    transaction, etc.).
+/// 4. Subscribes to all NATS subjects and polls incoming messages, decoding
+///    each into a `PeerObserverEvent` and passing it to `check_event`. The
+///    loop breaks as soon as `check_event` returns `true`, signalling that the
+///    expected event was received.
+/// 5. Panics if the expected event is not seen within `TEST_TIMEOUT_SECONDS`.
+/// 6. Sends a shutdown signal to the log extractor task and awaits its clean
+///    exit before returning.
 async fn check(
     args: Vec<&str>,
     test_setup: fn(&corepc_node::Client),

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -447,10 +447,10 @@ async fn test_integration_logextractor_unknown_with_threadname() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::UnknownLogMessage(unknown_log_message) = e
+                        && !r.threadname.is_empty()
+                        && r.category == LogDebugCategory::Unknown as i32
                     {
                         assert!(!unknown_log_message.raw_message.is_empty());
-                        assert!(!r.threadname.is_empty(), "threadname should not be empty");
-                        assert_eq!(r.category, LogDebugCategory::Unknown as i32);
                         info!("UnknownLogMessage with threadname: {}", r.threadname);
                         return true;
                     }
@@ -475,9 +475,9 @@ async fn test_integration_logextractor_unknown_with_category() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::UnknownLogMessage(unknown_log_message) = e
+                        && r.category == LogDebugCategory::Net as i32
                     {
                         assert!(!unknown_log_message.raw_message.is_empty());
-                        assert_eq!(r.category, LogDebugCategory::Net as i32);
                         info!("UnknownLogMessage with category Net");
                         return true;
                     }
@@ -502,10 +502,10 @@ async fn test_integration_logextractor_unknown_with_threadname_and_category() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::UnknownLogMessage(unknown_log_message) = e
+                        && r.category == LogDebugCategory::Net as i32
                     {
                         assert!(!unknown_log_message.raw_message.is_empty());
                         assert!(!r.threadname.is_empty(), "threadname should not be empty");
-                        assert_eq!(r.category, LogDebugCategory::Net as i32);
                         info!(
                             "UnknownLogMessage with threadname {} and category Net",
                             r.threadname
@@ -533,10 +533,10 @@ async fn test_integration_logextractor_unknown_with_all_metadata() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::UnknownLogMessage(unknown_log_message) = e
+                        && r.category == LogDebugCategory::Net as i32
                     {
                         assert!(!unknown_log_message.raw_message.is_empty());
                         assert!(!r.threadname.is_empty(), "threadname should not be empty");
-                        assert_eq!(r.category, LogDebugCategory::Net as i32);
                         info!(
                             "UnknownLogMessage with threadname {} and category Net",
                             r.threadname


### PR DESCRIPTION
## Summary

- Move `LogDebugCategory::Net` assertions from inside `check_event` closures into `if let` guards so tests filter for the expected category rather than asserting on the first `UnknownLogMessage` received
- Document `setup_node`, `setup_two_connected_nodes`, and `check` test harness functions

Fixes https://github.com/peer-observer/peer-observer/issues/338

## Context

On slower CPUs (e.g. my trusty old Xeon E5-2630 v4 or even GitHub's own runners), bitcoind takes longer to initialise. This caused an event ordering race.

Three tests (`unknown_with_category`, `unknown_with_threadname_and_category`, `unknown_with_all_metadata`) matched the first `UnknownLogMessage` and asserted `category == Net`. On slower hardware, non-net messages (e.g. `dnsseed thread start` with category `Unknown`) arrive before any `[net]` line, causing assertion failures. Moving the category check into the `if let` guard lets the event loop skip non-matching messages and continue scanning until a `Net` category event arrives. If the log extractor breaks its category parsing, no event will ever match and the test will time out (preserves the original intent).

Here's a snippet from from logs identifying the failure of the reported issue (https://github.com/peer-observer/peer-observer/issues/338). Note that the test expects category `Net`, but the first `UnknownLogMessage` is from the `dnsseed` thread with category `Unknown`!

```
2026-02-11T02:04:28.780Z INFO  [log_extractor] Started reading lines from bitcoind log pipe at /tmp/nix-shell-319968-3831661800/.tmpocGJcs/bitcoind_pipe
2026-02-11T02:04:28.806Z TRACE [log_extractor] Read log line: 2026-02-11T02:04:27Z [dnsseed] dnsseed thread start
2026-02-11T02:04:28.806Z TRACE [shared::protobuf::event] creating new Event: LogExtractor(Log { log_timestamp: 1770775467000000, category: Unknown, threadname: "dnsseed", log_event: Some(UnknownLogMessage(UnknownLogMessage { raw_message: "dnsseed thread start" })) })
2026-02-11T02:04:28.806Z TRACE [log_extractor] published log into NATS: Event { timestamp: 1770775468806, peer_observer_event: Some(LogExtractor(Log { log_timestamp: 1770775467000000, category: Unknown, threadname: "dnsseed", log_event: Some(UnknownLogMessage(UnknownLogMessage { raw_message: "dnsseed thread start" })) })) }
2026-02-11T02:04:28.806Z TRACE [log_extractor] Read log line: 2026-02-11T02:04:27Z [dnsseed] Loading addresses from DNS seed dummySeed.invalid.
```

## Testing
I have run these changes through CI on my fork, all green: https://github.com/deadmanoz/peer-observer/actions/runs/21893170475