### PR TITLE
fix(p2p): use OS-assigned port to fix intermittent test failures

### DIFF
--- a/extractors/p2p/src/lib.rs
+++ b/extractors/p2p/src/lib.rs
@@ -25,7 +25,7 @@ use shared::{
     tokio::{
         io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
         net::{TcpListener, TcpStream, tcp::WriteHalf},
-        sync::watch,
+        sync::{oneshot, watch},
         time::{self, Duration},
     },
     util,
@@ -157,7 +157,11 @@ impl Args {
     }
 }
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+) -> Result<(), RuntimeError> {
     log::info!("Using network magic for: {}", args.p2p_network);
     let network: BitcoinNetwork = args.p2p_network.clone().into();
     log::info!("Ping measurements enabled: {}", !args.disable_ping);
@@ -181,6 +185,11 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let listener = TcpListener::bind(args.p2p_address.clone()).await?;
     let local_addr = listener.local_addr()?;
     log::info!("P2P-extractor listening on {}", local_addr);
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     loop {
         shared::tokio::select! {

--- a/extractors/p2p/src/main.rs
+++ b/extractors/p2p/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let p2p_handle = tokio::spawn(p2p_extractor::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let p2p_handle = tokio::spawn(p2p_extractor::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -16,26 +16,21 @@ use shared::{
             AddressAnnouncement, FeefilterAnnouncement, InventoryAnnouncement, PingDuration,
         },
     },
-    rand::{self, Rng},
     simple_logger::SimpleLogger,
     testing::nats_server::NatsServerForTesting,
     tokio::{
         self, select,
-        sync::watch,
+        sync::{oneshot, watch},
         time::{Duration, sleep},
     },
     util,
 };
 use std::str::FromStr;
-use std::sync::{
-    Once, OnceLock,
-    atomic::{AtomicU16, Ordering},
-};
+use std::sync::Once;
 
 use p2p_extractor::{Args, Network};
 
 static INIT: Once = Once::new();
-static NEXT_P2PEXTRACTOR_PORT: OnceLock<AtomicU16> = OnceLock::new();
 
 // 1 second ping interval for fast tests
 const PING_INTERVAL_SECONDS: u64 = 1;
@@ -43,26 +38,13 @@ const PING_INTERVAL_SECONDS: u64 = 1;
 // 10 second check() timeout.
 const TEST_TIMEOUT_SECONDS: u64 = 10;
 
-fn setup() -> u16 {
+fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
             .with_level(log::LevelFilter::Trace)
             .init()
             .unwrap();
-
-        let mut rng = rand::rng();
-
-        // choose start ports from the ephemeral port range
-        let p2p_extractor_start = rng.random_range(49152..65500);
-        NEXT_P2PEXTRACTOR_PORT
-            .set(AtomicU16::new(p2p_extractor_start))
-            .unwrap();
     });
-
-    NEXT_P2PEXTRACTOR_PORT
-        .get()
-        .unwrap()
-        .fetch_add(1, Ordering::SeqCst)
 }
 
 fn make_test_args(
@@ -132,26 +114,36 @@ async fn check(
     test_setup: fn(&corepc_node::Node),
     check_expected: fn(PeerObserverEvent) -> bool,
 ) {
-    let p2p_extractor_port = setup();
+    setup();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    let p2p_extractor_handle = tokio::spawn(async move {
+    let mut p2p_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
-            format!("127.0.0.1:{}", p2p_extractor_port),
+            "127.0.0.1:0".to_string(),
             disable_ping,
             disable_addrv2,
             disable_invs,
             disable_feefilter,
         );
-        p2p_extractor::run(args, shutdown_rx.clone())
+        p2p_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
             .await
             .expect("p2p-extractor failed");
     });
 
-    // allow the p2p-extractor to start
-    sleep(Duration::from_secs(2)).await;
+    // Wait for the p2p-extractor to bind and report its actual port.
+    // We race against the task handle so that if the extractor fails
+    // before binding (e.g. NATS connection error), we surface the
+    // real error instead of a generic "channel closed" panic.
+    let p2p_extractor_port = select! {
+        addr = addr_rx => addr.expect("p2p-extractor should send bound address").port(),
+        result = &mut p2p_extractor_handle => {
+            result.unwrap();  // propagates the task's panic (with its message)
+            unreachable!("p2p-extractor task exited before sending bound address");
+        }
+    };
 
     // only start the node after the P2P extractor to make sure the
     // extractor is ready to accept connections


### PR DESCRIPTION
## Summary

Use port 0 (OS-assigned) for the p2p-extractor TCP listener in integration tests instead of manually picking random ephemeral ports. 

https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind

> "Binding with a port number of 0 will request that the OS assigns a port to this listener. The port allocated can be queried via the `local_addr` method."

This is race-free by design, there's no window between choosing a port and binding it where another process could grab it, so this eliminates the race condition that caused intermittent "Address already in use" failures (#316). 

The `run()` function now accepts an optional `oneshot::Sender<SocketAddr>` that reports the actual bound address back to the caller. This also replaces the previous 2-second sleep with a proper synchronisation barrier via `tokio::select!`, making tests both faster and more reliable. If the extractor fails before binding (e.g. NATS connection error), the real error is surfaced instead of a generic channel-closed panic.

Fixes #316.

## Testing

The fix was validated in my local testing setup with a before/after test script. To reliably reproduce the race condition on the old code, `setup()` was patched to return the same port for all parallel tests (changing `fetch_add` to `load`), forcing every test to compete for a single port:

```bash
sed -i 's/\.fetch_add(1, Ordering::SeqCst)/.load(Ordering::SeqCst)/' \
    extractors/p2p/tests/integration.rs
```

Both phases ran the integration test suite 5 times with `--test-threads=4`:

| | AddrInUse failures | Other failures |
|---|---|---|
| **Old code** (patched, same port) | 5/5 | — |
| **Fixed code** (OS-assigned) | 0/5 | 1/5 (split INV messages as per #357, another fix incoming!) |
