### PR TITLE
fix(p2p): accumulate Wtx items across multiple inv messages

### DIFF
--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -112,7 +112,7 @@ async fn check(
     disable_invs: bool,
     disable_feefilter: bool,
     test_setup: fn(&corepc_node::Node),
-    check_expected: fn(PeerObserverEvent) -> bool,
+    mut check_expected: impl FnMut(PeerObserverEvent) -> bool,
 ) {
     setup();
     let nats_server = NatsServerForTesting::new(&[]).await;
@@ -325,31 +325,42 @@ async fn test_integration_p2pextractor_inv_annoucement() {
                     .unwrap();
             }
         },
-        |event| {
-            match event {
-                PeerObserverEvent::P2pExtractor(p) => {
-                    if let Some(ref e) = p.p2p_event {
-                        match e {
-                            InventoryAnnouncement(i) => {
-                                log::info!("{}", i);
-                                // we expect an inv with NUM_TX from the node, however the node
-                                // will also send invs for blocks. So ignore all other invs and
-                                // only pass the test on the inv with the size of NUM_TX
-                                if i.inventory.len() == NUM_TX {
-                                    assert!(i.inventory.iter().all(|inventory| matches!(
-                                        inventory.item.clone().unwrap(),
-                                        Item::Wtx(_)
-                                    )));
-                                    return true;
+        {
+            let mut wtx_count = 0usize;
+            move |event| {
+                match event {
+                    PeerObserverEvent::P2pExtractor(p) => {
+                        if let Some(ref e) = p.p2p_event {
+                            match e {
+                                InventoryAnnouncement(i) => {
+                                    log::info!("{}", i);
+                                    // Count Wtx items in this inv message. Bitcoin Core's
+                                    // trickle relay may split transaction invs across
+                                    // multiple messages, so we accumulate across all of
+                                    // them rather than expecting a single batch.
+                                    let new_wtx = i
+                                        .inventory
+                                        .iter()
+                                        .filter(|inv| {
+                                            matches!(inv.item.clone().unwrap(), Item::Wtx(_))
+                                        })
+                                        .count();
+                                    if new_wtx > 0 {
+                                        wtx_count += new_wtx;
+                                        log::info!("accumulated {wtx_count}/{NUM_TX} Wtx items");
+                                        if wtx_count == NUM_TX {
+                                            return true;
+                                        }
+                                    }
                                 }
+                                _ => log::info!("unhandled P2P extractor event {:?}", p.p2p_event),
                             }
-                            _ => log::info!("unhandled P2P extractor event {:?}", p.p2p_event),
                         }
                     }
+                    _ => panic!("unexpected event {:?}", event),
                 }
-                _ => panic!("unexpected event {:?}", event),
+                false
             }
-            false
         },
     )
     .await;


### PR DESCRIPTION
## Summary

The `inv_annoucement` integration test intermittently times out because it expects all `NUM_TX` (5) Wtx items in a single inv message. Bitcoin Core's trickle relay splits transaction announcements across multiple messages on a (Poisson) timer, so items sometimes arrive as separate messages (e.g. I saw 2+1+2 = 3 messages on slower test hardware 😅). The trickle relay code in Bitcoin Core is in [src/net_processing.cpp](https://github.com/bitcoin/bitcoin/blob/master/src/net_processing.cpp#L165-L176), e.g.

```
static constexpr auto OUTBOUND_INVENTORY_BROADCAST_INTERVAL{2s};
static constexpr unsigned int INVENTORY_BROADCAST_PER_SECOND{14};
...
```

Transactions submitted between trickle intervals are queued and sent in the next batch. The old test checked `i.inventory.len() == NUM_TX` on each individual message, which wouldn't match if items were split across messages!

The fix changes `check()` to accept `FnMut` closures so the test can capture a `wtx_count` accumulator across all received inv messages (`FnMut` allows `wtx_count` to mutate on each invocation: https://doc.rust-lang.org/std/ops/trait.FnMut.html). Once the accumulated count reaches `NUM_TX`, the test passes.

Fixes #357

## Testing

Reproduced on local testing environment by running the test suite 5 times with `--test-threads=4`. Before the fix, the test timed out when Wtx items arrived split across multiple inv messages (e.g. I observed 2+1+2, CI failures on #357 were 4+1). After the fix, the accumulator collects items across messages and the test passes consistently.