### PR TITLE
fix(websocket): use OS-assigned port to fix intermittent test failures

### DIFF
--- a/tools/websocket/src/error.rs
+++ b/tools/websocket/src/error.rs
@@ -1,4 +1,5 @@
 use shared::async_nats;
+use shared::async_nats::client::FlushErrorKind;
 use shared::async_nats::ConnectErrorKind;
 use shared::log::SetLoggerError;
 use shared::prost::DecodeError;
@@ -13,6 +14,7 @@ pub enum RuntimeError {
     ProtobufDecode(DecodeError),
     NatsSubscribe(async_nats::client::SubscribeError),
     NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+    NatsFlush(shared::async_nats::error::Error<FlushErrorKind>),
 }
 
 impl fmt::Display for RuntimeError {
@@ -23,6 +25,7 @@ impl fmt::Display for RuntimeError {
             RuntimeError::ProtobufDecode(e) => write!(f, "protobuf decode error {}", e),
             RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
             RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::NatsFlush(e) => write!(f, "NATS flush error {}", e),
         }
     }
 }
@@ -35,6 +38,7 @@ impl error::Error for RuntimeError {
             RuntimeError::ProtobufDecode(ref e) => Some(e),
             RuntimeError::NatsSubscribe(ref e) => Some(e),
             RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::NatsFlush(ref e) => Some(e),
         }
     }
 }
@@ -66,5 +70,11 @@ impl From<async_nats::client::SubscribeError> for RuntimeError {
 impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
     fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
         RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<FlushErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<FlushErrorKind>) -> Self {
+        RuntimeError::NatsFlush(e)
     }
 }

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -15,7 +15,7 @@ use shared::{
     tokio::{
         self,
         net::{TcpListener, TcpStream},
-        sync::{watch, Mutex},
+        sync::{oneshot, watch, Mutex},
     },
 };
 use std::collections::HashMap;
@@ -84,12 +84,14 @@ type Clients = Arc<Mutex<HashMap<SocketAddr, Client>>>;
 pub async fn run(
     args: Args,
     mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<(), error::RuntimeError> {
     let nc = nats_util::prepare_connection(&args.nats)?
         .connect(&args.nats.address)
         .await?;
     log::info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc.subscribe("*").await?;
+    nc.flush().await?;
 
     let clients = Arc::new(Mutex::new(HashMap::new()));
 
@@ -114,6 +116,11 @@ pub async fn run(
     let server = TcpListener::bind(args.websocket_address).await?;
     let local_addr = server.local_addr()?;
     log::info!("Started websocket server on {}", local_addr);
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     // Accept WebSocket clients
     loop {

--- a/tools/websocket/src/main.rs
+++ b/tools/websocket/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_handle = tokio::spawn(websocket::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let websocket_handle = tokio::spawn(websocket::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -1,26 +1,26 @@
 #![cfg(feature = "nats_integration_tests")]
 
 use shared::{
-    futures::{SinkExt, StreamExt, stream},
+    futures::{stream, SinkExt, StreamExt},
     log,
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         ebpf_extractor::{
-            Ebpf,
             connection::{self, Connection},
             ebpf,
             mempool::{self, Added},
-            message::{self, Metadata, Ping, Pong, message_event::Msg},
+            message::{self, message_event::Msg, Metadata, Ping, Pong},
             validation::{self, BlockConnected},
+            Ebpf,
         },
-        event::{Event, event::PeerObserverEvent},
+        event::{event::PeerObserverEvent, Event},
     },
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
-        self,
+        self, select,
         sync::{oneshot, watch},
         time::{sleep, timeout},
     },
@@ -88,6 +88,122 @@ fn make_test_args(nats_port: u16) -> Args {
     )
 }
 
+/// Creates a marker event matching the first active subscription type in the
+/// given subscriptions. Returns `(subject, payload, detect)` where `detect` is
+/// a substring that uniquely identifies this marker in the JSON-serialized
+/// websocket message. Returns `None` if no subscriptions are active.
+/// Only covers types exercised by tests: messages and mempool.
+fn marker_for_subscriptions(
+    marker: &str,
+    client_index: usize,
+    subs: &ClientSubscriptions,
+) -> Option<(String, Vec<u8>, String)> {
+    let (subject, ebpf_event, detect) = if subs.ebpf.messages {
+        (
+            Subject::NetMsg,
+            ebpf::EbpfEvent::Message(message::MessageEvent {
+                meta: Metadata {
+                    peer_id: 0,
+                    addr: marker.to_string(),
+                    conn_type: 0,
+                    command: "marker".to_string(),
+                    inbound: false,
+                    size: 0,
+                },
+                msg: Some(Msg::Ping(Ping { value: 0 })),
+            }),
+            marker.to_string(),
+        )
+    } else if subs.ebpf.mempool {
+        // Mempool events have no string fields, so we use a unique fee value
+        // derived from the client index as the detection substring.
+        let fee: i64 = 21212121 + client_index as i64;
+        (
+            Subject::Mempool,
+            ebpf::EbpfEvent::Mempool(mempool::MempoolEvent {
+                event: Some(mempool::mempool_event::Event::Added(Added {
+                    txid: vec![],
+                    vsize: 0,
+                    fee,
+                })),
+            }),
+            fee.to_string(),
+        )
+    } else {
+        return None;
+    };
+
+    let event = Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf_event),
+    }))
+    .unwrap();
+
+    Some((subject.to_string(), event.encode_to_vec(), detect))
+}
+
+/// Publishes a marker event to NATS and waits for it to arrive on the given
+/// websocket client stream, proving the full NATS -> server -> client path is
+/// live. The marker is re-published on a short interval because early
+/// publications may arrive before the server has fully registered the client.
+/// Panics on timeout.
+async fn wait_for_marker<S>(
+    publisher: &NatsPublisherForTesting,
+    marker: &str,
+    subject: &str,
+    payload: &[u8],
+    detect: &str,
+    client: &mut S,
+) where
+    S: StreamExt<Item = Result<TungsteniteMessage, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    let mut marker_seen = false;
+    select! {
+        _ = sleep(Duration::from_secs(5)) => {
+            panic!("timed out waiting for pipeline-ready marker '{marker}'");
+        }
+        _ = async {
+            loop {
+                publisher
+                    .publish(subject.to_string(), payload.to_vec())
+                    .await;
+                log::debug!("published pipeline-ready marker '{marker}'");
+
+                // Drain all available messages before re-publishing. Earlier
+                // clients' markers may have accumulated in this stream.
+                loop {
+                    match tokio::time::timeout(Duration::from_millis(50), client.next()).await {
+                        Ok(Some(msg)) => {
+                            let msg = msg.expect("websocket message should be valid");
+                            if msg.to_string().contains(detect) {
+                                log::info!("received pipeline-ready marker: {marker}");
+                                marker_seen = true;
+                                return;
+                            }
+                            // Not our marker; keep draining.
+                        }
+                        Ok(None) => panic!(
+                            "websocket stream closed before pipeline-ready marker '{marker}' arrived"
+                        ),
+                        Err(_) => break, // no more messages, re-publish
+                    }
+                }
+            }
+        } => {}
+    }
+    assert!(
+        marker_seen,
+        "websocket stream closed before pipeline-ready marker '{marker}' arrived"
+    );
+
+    // Drain any extra copies of the marker that arrived while re-publishing.
+    // No real test events have been published yet, so everything here is a
+    // marker (ours or another client's from a prior iteration).
+    sleep(Duration::from_millis(50)).await;
+    while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(10), client.next()).await {
+        let _ = msg.expect("websocket message should be valid");
+    }
+}
+
 async fn publish_and_check_simple(
     events: &[(Subject, Event)],
     expected_events: Vec<&'static str>,
@@ -140,6 +256,53 @@ async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]
             .await
             .expect("Should be able to send subscription message");
         clients_stream.push((outgoing, incoming));
+    }
+
+    // Pipeline readiness barrier: wait for EVERY subscribing client to
+    // confirm the full NATS -> websocket server -> client path is live.
+    // Each client is independently inserted into the server's broadcast map
+    // and has its subscriptions applied independently, so one
+    // client receiving a marker does NOT prove the others are registered.
+    // The marker event type must match the client's subscription because
+    // broadcast_to_clients() filters by protobuf variant.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    for (i, client_config) in clients.iter().enumerate() {
+        if client_config.disconnect {
+            continue;
+        }
+        let marker = format!("PIPELINE_READY:{nanos}:{i}");
+        if let Some((subject, payload, detect)) =
+            marker_for_subscriptions(&marker, i, &client_config.subscriptions)
+        {
+            wait_for_marker(
+                &nats_publisher,
+                &marker,
+                &subject,
+                &payload,
+                &detect,
+                &mut clients_stream[i].1,
+            )
+            .await;
+        }
+    }
+
+    // Final drain: flush any markers that leaked to other clients during
+    // the sequential readiness checks above.
+    sleep(Duration::from_millis(50)).await;
+    for (i, client_config) in clients.iter().enumerate() {
+        if client_config.disconnect {
+            continue;
+        }
+        let incoming = &mut clients_stream[i].1;
+        while let Ok(Some(msg)) =
+            tokio::time::timeout(Duration::from_millis(10), incoming.next()).await
+        {
+            let _ = msg.expect("websocket message should be valid");
+        }
     }
 
     for (subject, event) in events.iter() {

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -1,43 +1,35 @@
 #![cfg(feature = "nats_integration_tests")]
 
 use shared::{
-    futures::{stream, SinkExt, StreamExt},
-    log::{self, warn},
+    futures::{SinkExt, StreamExt, stream},
+    log,
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         ebpf_extractor::{
+            Ebpf,
             connection::{self, Connection},
             ebpf,
             mempool::{self, Added},
-            message::{self, message_event::Msg, Metadata, Ping, Pong},
+            message::{self, Metadata, Ping, Pong, message_event::Msg},
             validation::{self, BlockConnected},
-            Ebpf,
         },
-        event::{event::PeerObserverEvent, Event},
+        event::{Event, event::PeerObserverEvent},
     },
-    rand::{self, Rng},
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
         self,
-        sync::{watch, Mutex},
+        sync::{oneshot, watch},
         time::{sleep, timeout},
     },
 };
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
-use std::{
-    io::ErrorKind,
-    sync::{
-        atomic::{AtomicU16, Ordering},
-        Arc, Once, OnceLock,
-    },
-    time::Duration,
-};
+use std::{sync::Once, time::Duration};
 
-use websocket::{error::RuntimeError, Args, ClientSubscriptions, ClientSubscriptionsEbpf};
+use websocket::{Args, ClientSubscriptions, ClientSubscriptionsEbpf};
 
 const SUBSCRIBE_NONE: ClientSubscriptions = ClientSubscriptions {
     ebpf: ClientSubscriptionsEbpf {
@@ -74,32 +66,16 @@ struct ClientConfig {
 
 static INIT: Once = Once::new();
 
-static NEXT_WEBSOCKET_PORT: OnceLock<AtomicU16> = OnceLock::new();
-
-fn setup() -> u16 {
+fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
             .with_level(log::LevelFilter::Trace)
             .init()
             .unwrap();
-
-        let mut rng = rand::rng();
-
-        // choose start ports from the ephemeral port range
-        let websocket_start = rng.random_range(49152..65500);
-        NEXT_WEBSOCKET_PORT
-            .set(AtomicU16::new(websocket_start))
-            .unwrap();
     });
-
-    let websocket_port = NEXT_WEBSOCKET_PORT
-        .get()
-        .unwrap()
-        .fetch_add(1, Ordering::SeqCst);
-    websocket_port
 }
 
-fn make_test_args(nats_port: u16, websocket_port: u16) -> Args {
+fn make_test_args(nats_port: u16) -> Args {
     Args::new(
         NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -107,7 +83,7 @@ fn make_test_args(nats_port: u16, websocket_port: u16) -> Args {
             password: None,
             password_file: None,
         },
-        format!("127.0.0.1:{}", websocket_port),
+        "127.0.0.1:0".to_string(),
         log::Level::Trace,
     )
 }
@@ -131,52 +107,27 @@ async fn publish_and_check_simple(
 }
 
 async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]) {
-    let initial_websocket_port = setup();
-    let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_port_clone = websocket_port.clone();
+    let (bound_addr_tx, bound_addr_rx) = oneshot::channel();
+    let args = make_test_args(nats_server.port);
     let websocket_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *websocket_port_clone.lock().await;
-            }
-
-            let args = make_test_args(nats_server.port, port);
-            match websocket::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_WEBSOCKET_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = websocket_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start websocket tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start websocket tool: {}", e),
-                },
-            }
-        }
+        websocket::run(args, shutdown_rx, Some(bound_addr_tx))
+            .await
+            .expect("websocket tool should start successfully");
     });
-    // allow the websocket tool to start
-    sleep(Duration::from_secs(1)).await;
 
-    let port = websocket_port.lock().await;
+    let bound_addr = bound_addr_rx
+        .await
+        .expect("Should receive bound address from websocket tool");
+
     let mut clients_stream = vec![];
     for client_config in clients {
-        let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
+        let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://{}", bound_addr))
             .await
             .expect("Should be able to connect to websocket");
         let (mut outgoing, incoming) = ws_stream.split();
@@ -242,50 +193,24 @@ async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]
 }
 
 async fn custom_message_check(message: &str) {
-    let initial_websocket_port = setup();
-    let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_port_clone = websocket_port.clone();
+    let (bound_addr_tx, bound_addr_rx) = oneshot::channel();
+    let args = make_test_args(nats_server.port);
     let websocket_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *websocket_port_clone.lock().await;
-            }
-
-            let args = make_test_args(nats_server.port, port);
-            match websocket::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_WEBSOCKET_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = websocket_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start websocket tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start websocket tool: {}", e),
-                },
-            }
-        }
+        websocket::run(args, shutdown_rx, Some(bound_addr_tx))
+            .await
+            .expect("websocket tool should start successfully");
     });
-    // allow the websocket tool to start
-    sleep(Duration::from_secs(1)).await;
 
-    let port = websocket_port.lock().await;
+    let bound_addr = bound_addr_rx
+        .await
+        .expect("Should receive bound address from websocket tool");
 
-    let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
+    let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://{}", bound_addr))
         .await
         .expect("Should be able to connect to websocket");
     let (mut outgoing, mut incoming) = ws_stream.split();


### PR DESCRIPTION
## Summary

Use port 0 (OS-assigned) for the websocket TCP listener in integration tests instead of manually picking random ephemeral ports.

Same approach as the P2P extractor fix in #358. The old code used `AtomicU16` with a random ephemeral start port, a retry loop on `AddrInUse`, and a 1-second sleep to wait for the server to start. This had the same race condition, a window between choosing a port and binding it where another process could grab it.

The `run()` function now accepts an optional `oneshot::Sender<SocketAddr>` that reports the actual bound address back to the caller. Tests bind to port 0, receive the OS-assigned address via the oneshot, and connect clients immediately (no sleep, no race).

This PR also adds a **pipeline readiness barrier** (as was introduced with https://github.com/peer-observer/peer-observer/pull/372) to eliminate the following race: after a client connects and sends its subscription JSON, there's a window where NATS events can arrive at the server before the client is registered in the broadcast map with its subscriptions applied. 

As each client is inserted and subscribed independently, one client receiving events does not prove the others are ready. So the barrier publishes a marker event through NATS for *every* subscribing client and waits for it to arrive on that client's websocket stream, thus proving the full pipeline is live. 

The marker event type matches the client's subscription (just messages or mempool for now, because only those were present in the tests) because `broadcast_to_clients` filters by protobuf variant. A final drain pass flushes any cross-contamination markers between clients before real test events are published.

Fixes #327.

## Testing

All 6 integration tests pass a 50-run stress testing on Linux (NixOS x86_64), zero failures.