### PR TITLE
Fix/log level filter and state guards

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -349,9 +349,10 @@ async fn test_integration_logextractor_block_checked() {
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
-                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event {
+                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event
+                        && block_checked.state == "Valid"
+                    {
                         assert!(!block_checked.block_hash.is_empty());
-                        assert_eq!(block_checked.state, "Valid");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;
                     }
@@ -400,8 +401,8 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-witness-nonce-size"
                     {
-                        assert_eq!(block_checked.state, "bad-witness-nonce-size");
                         assert_eq!(
                             block_checked.debug_message,
                             "CheckWitnessMalleation : invalid witness reserved value size"
@@ -455,8 +456,8 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
                 PeerObserverEvent::LogExtractor(l) => {
                     if let Some(ref e) = l.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-txnmrklroot"
                     {
-                        assert_eq!(block_checked.state, "bad-txnmrklroot");
                         assert_eq!(block_checked.debug_message, "hashMerkleRoot mismatch");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -172,6 +172,17 @@ struct CommonLogData {
     pub message: String,
 }
 
+/// Returns `true` if `s` is a standalone Bitcoin Core log level bracket token.
+///
+/// Only `LogError()` and `LogWarning()` produce standalone bracket tokens
+/// (`[error]` and `[warning]`). Other Bitcoin Core log levels never appear as
+/// standalone brackets: `LogInfo()` emits no bracket at all, and
+/// `LogDebug()`/`LogTrace()` require a category argument so they produce
+/// `[category]` or `[category:trace]`, never standalone `[debug]` or `[trace]`.
+fn is_standalone_log_level(s: &str) -> bool {
+    matches!(s.to_lowercase().as_str(), "error" | "warning")
+}
+
 fn parse_common_log_data(line: &str) -> CommonLogData {
     let caps = LOG_LINE_REGEX.captures(line);
     if caps.is_none() {
@@ -200,6 +211,11 @@ fn parse_common_log_data(line: &str) -> CommonLogData {
         .captures_iter(metadata)
         .map(|cap| cap[1].to_string())
         .collect();
+
+    // Filter out log level markers. Bitcoin Core uses LogError(), LogWarning(),
+    // etc. which emit [error], [warning], etc. These are log LEVELS, not
+    // threadnames or debug categories.
+    metadata_items.retain(|item| !is_standalone_log_level(item));
 
     // if exists, category is usually the last metadata item
     let mut category = LogDebugCategory::Unknown;
@@ -449,5 +465,72 @@ mod tests {
             return;
         }
         panic!("Expected BlockCheckedLog event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_not_treated_as_threadname() {
+        // Bitcoin Core LogError() emits [error] as a log level, not a threadname
+        let log = "2025-10-02T02:31:14Z [error] AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+        assert_eq!(log_event.threadname, "");
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(
+                unknown_log.raw_message,
+                "AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size"
+            );
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_with_threadname() {
+        // [threadname] [error] message - error should be filtered, threadname preserved
+        let log = "2025-10-02T02:31:14Z [msghand] [error] some error message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "msghand");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some error message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_warning_level_filtered() {
+        let log = "2025-10-02T02:31:14Z [warning] some warning message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some warning message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_is_standalone_log_level() {
+        assert!(is_standalone_log_level("error"));
+        assert!(is_standalone_log_level("Error"));
+        assert!(is_standalone_log_level("ERROR"));
+        assert!(is_standalone_log_level("warning"));
+        assert!(is_standalone_log_level("Warning"));
+        // info/debug/trace are NOT standalone bracket tokens in Bitcoin Core
+        assert!(!is_standalone_log_level("info"));
+        assert!(!is_standalone_log_level("debug"));
+        assert!(!is_standalone_log_level("trace"));
+        assert!(!is_standalone_log_level("net"));
+        assert!(!is_standalone_log_level("validation"));
+        assert!(!is_standalone_log_level("msghand"));
+        assert!(!is_standalone_log_level("dnsseed"));
     }
 }


### PR DESCRIPTION
## Summary

The log line parser in `shared/src/log_matchers.rs` treats all `[bracketed]` metadata tokens as either thread names or debug categories. This breaks when Bitcoin Core emits log level markers via `LogError()` and `LogWarning()`, which produce lines like:

```
2025-10-02T02:31:14Z [error] AcceptBlock: bad-witness-nonce-size, ...
2025-10-02T02:31:14Z [msghand] [error] ConnectBlock: ...
```

The parser would interpret `[error]` as a thread name (in the first case) or a debug category (in the second). This is incorrect - it's a severity level emitted by `GetLogPrefix()` in Bitcoin Core's [`logging.cpp`](https://github.com/bitcoin/bitcoin/blob/master/src/logging.cpp#L343-L366).

When `-logthreadnames=1` is enabled, the thread name bracket and the level bracket appear as two separate tokens (e.g. `[msghand] [error]` as above), so both cases need handling.

This is the root cause behind the flaky `BlockCheckedLog` test failures reported in #366. The nix-coverage CI job captured logs showing `threadname: "error",` with `[error]` having been misinterpreted as a thread name! I also hit this locally while working on #338.

This PR adds an `is_standalone_log_level()` filter that strips `[error]` and `[warning]` from the parsed metadata items before thread name/category assignment. The function is scoped to only these two levels because they are the only ones that appear as standalone bracket tokens under default Bitcoin Core configuration (see the linked `logging.cpp`): 
- `LogInfo()` produces no bracket at all (`GetLogPrefix` returns empty for uncategorised info-level messages)
- `LogDebug()`/`LogTrace()` both require a category argument so they produce `[category]` or `[category:trace]` as single bracket tokens, never standalone `[debug]` or `[trace]`

In a separate commit, the integration tests for `BlockCheckedLog` events are tightened using the same pattern as #354: the state value check (e.g. `"Valid"`, `"bad-witness-nonce-size"`, `"bad-txnmrklroot"`) is moved from an `assert_eq!` inside the match body into an `if-let` guard condition. This prevents the callback from panicking on a legitimate but unexpected state value arriving first (it skips non-matching events and waits for the correct one).

Fixes #366 🥳 

## Testing

Four new tests in `shared/src/log_matchers.rs`:

- `test_log_matcher_error_level_not_treated_as_threadname` - standalone `[error]` is filtered, not assigned as thread name
- `test_log_matcher_error_level_with_threadname` - `[msghand] [error]` preserves the real thread name and filters the level
- `test_log_matcher_warning_level_filtered` - standalone `[warning]` is filtered
- `test_is_standalone_log_level` - exercises the filter against known levels, non-standalone levels (`info`, `debug`, `trace`), and known non-levels (categories and thread names like `net`, `validation`, `msghand`)

Existing integration tests (`test_integration_logextractor_block_checked`, `test_integration_logextractor_mutated_block_bad_witness_nonce_size`, `test_integration_logextractor_mutated_block_bad_txnmrklroot`) continue to pass with the guard-style predicates. 

Full pre-push quality gate (fmt, clippy, unit tests, NATS integration tests) passes.

See green CI via PR opened against my fork: https://github.com/deadmanoz/peer-observer/actions/runs/22381839058