### PR TITLE
chore: mark C/H files as documentation for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c linguist-documentation
+*.h linguist-documentation


### PR DESCRIPTION
This PR adds .gitattributes entries to mark *.c and *.h as linguist-documentation, removing C/H in GitHub language stats. No functional/build changes.