### PR TITLE
log-extractor: Log level and line bytes

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -608,3 +608,30 @@ async fn test_integration_logextractor_testsshouldtimeout() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn test_integration_logextractor_log_bytes() {
+    println!("test that we can parse log line bytes");
+
+    check(
+        vec!["-debug=net"],
+        |_node1| {},
+        |event| match event {
+            PeerObserverEvent::LogExtractor(r) => {
+                if let Some(log::LogEvent::UnknownLogMessage(_)) = r.log_event
+                    && r.category == LogDebugCategory::Net as i32
+                {
+                    assert!(r.log_line_bytes > 0, "log_line_bytes should be > 0");
+                    info!(
+                        "Received log event with log_line_bytes={}",
+                        r.log_line_bytes
+                    );
+                    return true;
+                }
+                false
+            }
+            _ => panic!("unexpected event {:?}", event),
+        },
+    )
+    .await;
+}

--- a/protobuf/log_extractor.proto
+++ b/protobuf/log_extractor.proto
@@ -2,10 +2,20 @@ syntax = "proto2";
 
 package log_extractor;
 
+enum LogLevel {
+    INFO = 0;      // no bracket
+    WARNING = 1;   // [warning] bracket
+    ERROR = 2;     // [error] bracket
+    DEBUG = 3;     // [category] bracket
+    TRACE = 4;     // [category:trace] bracket
+}
+
 message log {
   required uint64 log_timestamp = 1; // unix timestamp in microseconds
   required LogDebugCategory category = 2;
   required string threadname = 3;
+  required LogLevel log_level = 7;
+  required uint64 log_line_bytes = 8;
   oneof log_event {
     UnknownLogMessage unknown_log_message = 4;
     BlockConnectedLog block_connected_log = 5;

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -1,6 +1,6 @@
 use crate::protobuf::log_extractor::log::LogEvent;
 use crate::protobuf::log_extractor::{
-    BlockCheckedLog, BlockConnectedLog, Log, LogDebugCategory, UnknownLogMessage,
+    BlockCheckedLog, BlockConnectedLog, Log, LogDebugCategory, LogLevel, UnknownLogMessage,
 };
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -140,6 +140,7 @@ pub fn parse_log_event(line: &str) -> Log {
         timestamp_micro,
         category,
         threadname,
+        level,
         message,
     } = parse_common_log_data(line);
 
@@ -151,6 +152,8 @@ pub fn parse_log_event(line: &str) -> Log {
                 log_timestamp: timestamp_micro,
                 category: category.into(),
                 threadname,
+                log_level: level.into(),
+                log_line_bytes: line.len() as u64,
                 log_event: Some(event),
             };
         }
@@ -161,6 +164,8 @@ pub fn parse_log_event(line: &str) -> Log {
         log_timestamp: timestamp_micro,
         category: category.into(),
         threadname,
+        log_level: level.into(),
+        log_line_bytes: line.len() as u64,
         log_event: UnknownLogMessage::parse_event(&message),
     }
 }
@@ -169,6 +174,7 @@ struct CommonLogData {
     pub timestamp_micro: u64,
     pub category: LogDebugCategory,
     pub threadname: String,
+    pub level: LogLevel,
     pub message: String,
 }
 
@@ -183,11 +189,21 @@ fn is_standalone_log_level(s: &str) -> bool {
     matches!(s.to_lowercase().as_str(), "error" | "warning")
 }
 
+fn parse_category(item: &str) -> Option<LogDebugCategory> {
+    let base = item.strip_suffix(":trace").unwrap_or(item);
+    LogDebugCategory::from_str_name(&base.to_uppercase())
+}
+
+fn is_trace(item: &str) -> bool {
+    item.ends_with(":trace")
+}
+
 fn parse_common_log_data(line: &str) -> CommonLogData {
     let caps = LOG_LINE_REGEX.captures(line);
     if caps.is_none() {
         return CommonLogData {
             timestamp_micro: 0,
+            level: LogLevel::Info,
             category: LogDebugCategory::Unknown,
             threadname: String::new(),
             message: String::new(),
@@ -212,18 +228,41 @@ fn parse_common_log_data(line: &str) -> CommonLogData {
         .map(|cap| cap[1].to_string())
         .collect();
 
+    let mut level = metadata_items
+        .iter()
+        .find_map(|item| match item.to_lowercase().as_str() {
+            "error" => Some(LogLevel::Error),
+            "warning" => Some(LogLevel::Warning),
+            _ => None,
+        })
+        .unwrap_or(LogLevel::Info);
+
     // Filter out log level markers. Bitcoin Core uses LogError(), LogWarning(),
     // etc. which emit [error], [warning], etc. These are log LEVELS, not
     // threadnames or debug categories.
     metadata_items.retain(|item| !is_standalone_log_level(item));
 
-    // if exists, category is usually the last metadata item
     let mut category = LogDebugCategory::Unknown;
+    let mut is_trace_log = false;
+
+    // If exists, category is usually the last metadata item.
+    // LogDebug(cat, ..) emits [category], LogTrace(cat, ..) emits [category:trace].
     if let Some(last_item) = metadata_items.last() {
-        if let Some(cat) = LogDebugCategory::from_str_name(&last_item.to_uppercase()) {
-            category = cat;
+        if let Some(parsed_category) = parse_category(last_item) {
+            category = parsed_category;
+            is_trace_log = is_trace(last_item);
             metadata_items.pop();
         }
+    }
+
+    // LogInfo() emits no category bracket, so a category bracket implies
+    // LogDebug or LogTrace. Don't override error/warning.
+    if level == LogLevel::Info {
+        level = match (category, is_trace_log) {
+            (_, true) => LogLevel::Trace,
+            (LogDebugCategory::Unknown, _) => LogLevel::Info,
+            _ => LogLevel::Debug,
+        };
     }
 
     // if exists, threadname is usually the first metadata item
@@ -233,6 +272,7 @@ fn parse_common_log_data(line: &str) -> CommonLogData {
         timestamp_micro,
         category,
         threadname,
+        level,
         message: caps["message"].to_string(),
     }
 }
@@ -532,5 +572,90 @@ mod tests {
         assert!(!is_standalone_log_level("validation"));
         assert!(!is_standalone_log_level("msghand"));
         assert!(!is_standalone_log_level("dnsseed"));
+    }
+
+    #[test]
+    fn test_parse_category() {
+        assert_eq!(parse_category("net"), Some(LogDebugCategory::Net));
+        assert_eq!(parse_category("net:trace"), Some(LogDebugCategory::Net));
+        assert_eq!(
+            parse_category("validation"),
+            Some(LogDebugCategory::Validation)
+        );
+        assert_eq!(
+            parse_category("validation:trace"),
+            Some(LogDebugCategory::Validation)
+        );
+        assert_eq!(parse_category("This-Is-N0t-a-valid-category"), None);
+    }
+
+    #[test]
+    fn test_is_trace() {
+        assert!(is_trace("net:trace"));
+        assert!(is_trace("validation:trace"));
+        assert!(!is_trace("net"));
+        assert!(!is_trace("validation"));
+        assert!(!is_trace("error"));
+    }
+
+    #[test]
+    fn test_log_level_info_no_category() {
+        // LogInfo() emits no bracket and no category — should be INFO
+        let log = "2025-10-02T02:31:14Z Verification progress: 50%";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Info as i32);
+    }
+
+    #[test]
+    fn test_log_level_debug_with_category() {
+        // LogDebug(BCLog::NET, ..) emits [net] — should be DEBUG
+        let log = "2025-10-02T02:31:21Z [net] Flushed 0 addresses to peers.dat  2ms";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Debug as i32);
+        assert_eq!(log_event.category, LogDebugCategory::Net as i32);
+    }
+
+    #[test]
+    fn test_log_level_debug_with_threadname_and_category() {
+        // [threadname] [category] — category implies DEBUG
+        let log = "2026-03-08T00:00:21.563170Z [msghand] [net] sending inv (289 bytes) peer=26148";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Debug as i32);
+        assert_eq!(log_event.category, LogDebugCategory::Net as i32);
+        assert_eq!(log_event.threadname, "msghand");
+    }
+
+    #[test]
+    fn test_log_level_trace_with_category() {
+        // LogTrace(BCLog::NET, ..) emits [net:trace] — should be TRACE
+        let log = "2026-03-08T00:00:21.563170Z [net:trace] sending inv (289 bytes) peer=26148";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Trace as i32);
+        assert_eq!(log_event.category, LogDebugCategory::Net as i32);
+    }
+
+    #[test]
+    fn test_log_level_trace_with_threadname_and_category() {
+        // [threadname] [category:trace] — should be TRACE
+        let log =
+            "2026-03-08T00:00:21.563170Z [msghand] [net:trace] sending inv (289 bytes) peer=26148";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Trace as i32);
+        assert_eq!(log_event.category, LogDebugCategory::Net as i32);
+        assert_eq!(log_event.threadname, "msghand");
+    }
+
+    #[test]
+    fn test_log_level_error() {
+        let log = "2025-10-02T02:31:14Z [error] some error";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Error as i32);
+    }
+
+    #[test]
+    fn test_log_level_warning() {
+        let log = "2025-10-02T02:31:14Z [warning] some warning";
+        let log_event = parse_log_event(log);
+        assert_eq!(log_event.log_level, LogLevel::Warning as i32);
     }
 }

--- a/tools/logger/tests/integration.rs
+++ b/tools/logger/tests/integration.rs
@@ -534,6 +534,8 @@ async fn test_integration_logger_logextractor_unknown_log() {
                 category: LogDebugCategory::Unknown.into(),
                 log_timestamp: 1234,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
                 log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
                     log_extractor::UnknownLogMessage {
                         raw_message: "test".to_string(),
@@ -560,6 +562,8 @@ async fn test_integration_logger_logextractor_blockconnected_log() {
                 category: LogDebugCategory::Validation.into(),
                 log_timestamp: 345,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::BlockConnectedLog(
                     log_extractor::BlockConnectedLog {
                         block_height: 1337,

--- a/tools/metrics/dashboards/logs.json
+++ b/tools/metrics/dashboards/logs.json
@@ -18,13 +18,474 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 16,
+  "id": 1506,
   "links": [],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Logs by log-level",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
-        "uid": "fetjtg0ozx98ge"
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "linearThreshold": 10,
+              "log": 10,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fetjtg0ozx98ge"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(level, host) (increase(peerobserver_log_events[1m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "interval": "1m",
+          "legendFormat": "{{host}}-{{level}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Logs by level (1min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "linearThreshold": 1000,
+              "log": 10,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fetjtg0ozx98ge"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(level, host) (increase(peerobserver_log_bytes[1m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "interval": "1m",
+          "legendFormat": "{{host}}-{{level}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Log bytes by level (1min)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Logs by category",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.7,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.2",
+      "repeat": "category",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fetjtg0ozx98ge"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "increase(peerobserver_log_events{category=\"$category\"}[1m])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "interval": "1m",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Debug log lines with \"$category\" category\" (per 1min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.7,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.2",
+      "repeat": "category",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fetjtg0ozx98ge"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "increase(peerobserver_log_bytes{category=\"$category\"}[1m]) / 60",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "interval": "1m",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Debug log bytes with \"$category\" category",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Mutated blocks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
       },
       "fieldConfig": {
         "defaults": {
@@ -70,133 +531,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.8,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "showValue": "auto",
-        "stacking": "normal",
-        "tooltip": {
-          "hideZeros": true,
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 100
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "fetjtg0ozx98ge"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "increase(peerobserver_log_events[1m])",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "legendFormat": "{{category}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Logs by category (1min)",
-      "type": "barchart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "fetjtg0ozx98ge"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Value"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 87
       },
       "id": 3,
       "options": {
@@ -222,7 +560,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.2",
       "targets": [
         {
           "datasource": {
@@ -230,9 +568,9 @@
             "uid": "fetjtg0ozx98ge"
           },
           "disableTextWrap": false,
-          "editorMode": "code",
+          "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum by(status) (peerobserver_log_mutated_blocks)",
+          "expr": "sum by(host, status) (peerobserver_log_mutated_blocks)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
@@ -250,7 +588,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "fetjtg0ozx98ge"
+        "uid": "P1809F7CD0C75ACF3"
       },
       "fieldConfig": {
         "defaults": {
@@ -299,7 +637,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 87
       },
       "id": 2,
       "options": {
@@ -324,7 +662,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.2",
       "targets": [
         {
           "datasource": {
@@ -334,11 +672,11 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "increase(peerobserver_log_mutated_blocks[1m])",
+          "expr": "sum by(host, status) (increase(peerobserver_log_mutated_blocks[1m]))",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
-          "legendFormat": "{{status}}",
+          "legendFormat": "{{host}} {{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -349,19 +687,43 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
-  "schemaVersion": 41,
+  "refresh": "1m",
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(peerobserver_log_events,category)",
+        "includeAll": true,
+        "label": "category",
+        "multi": true,
+        "name": "category",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(peerobserver_log_events,category)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Logs",
-  "uid": "5f1da208-e8fe-4375-9c27-060ccd77184a",
-  "version": 9
+  "uid": "bc2d7kl",
+  "version": 8
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -20,7 +20,7 @@ use shared::protobuf::{
         validation::validation_event,
     },
     event::{event::PeerObserverEvent, Event},
-    log_extractor::{log, Log, LogDebugCategory},
+    log_extractor::{log, Log, LogDebugCategory, LogLevel},
     p2p_extractor::p2p,
     rpc_extractor::{rpc, Addrman, AddrmanBucket},
 };
@@ -1443,7 +1443,21 @@ fn handle_log_event(log: &Log, metrics: metrics::Metrics) {
         .as_str_name()
         .to_lowercase();
 
-    metrics.log_events.with_label_values(&[&category]).inc();
+    let level = LogLevel::try_from(log.log_level)
+        .unwrap_or(LogLevel::Info)
+        .as_str_name()
+        .to_lowercase();
+
+    metrics
+        .log_events
+        .with_label_values(&[&category, &level])
+        .inc();
+
+    let bytes = log.log_line_bytes;
+    metrics
+        .log_bytes
+        .with_label_values(&[&category, &level])
+        .inc_by(bytes);
 
     let Some(e) = &log.log_event else { return };
     match e {

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -36,6 +36,7 @@ pub const LABEL_RPC_PROTOCOL_VERSION: &str = "protocol_version";
 pub const LABEL_RPC_ASN: &str = "ASN";
 
 pub const LABEL_LOG_CATEGORY: &str = "category";
+pub const LABEL_LOG_LEVEL: &str = "level";
 pub const LABEL_LOG_MUTATED_BLOCK_STATUS: &str = "status";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
@@ -367,6 +368,7 @@ pub struct Metrics {
 
     // log-extractor
     pub log_events: IntCounterVec,
+    pub log_bytes: IntCounterVec,
     pub log_block_connected_events: IntCounter,
     pub log_block_checked_events: IntCounter,
     pub log_mutated_blocks: IntCounterVec,
@@ -579,7 +581,8 @@ impl Metrics {
         ig!(p2pextractor_feefilter_last, "The value of the last feefilter received by the p2p-extractor from the node.", registry);
 
         // log-extractor
-        icv!(log_events, "Number of log events received by category.", [LABEL_LOG_CATEGORY], registry);
+        icv!(log_events, "Number of log events received by category and level.", [LABEL_LOG_CATEGORY, LABEL_LOG_LEVEL], registry);
+        icv!(log_bytes, "Total bytes logged to debug.log by category and level.", [LABEL_LOG_CATEGORY, LABEL_LOG_LEVEL], registry);
         ic!(log_block_connected_events, "Number of block connected log events received.", registry);
         ic!(log_block_checked_events, "Number of block checked log events received.", registry);
         icv!(log_mutated_blocks, "Number of mutated blocks detected by status.", [LABEL_LOG_MUTATED_BLOCK_STATUS], registry);
@@ -789,6 +792,7 @@ impl Metrics {
             p2pextractor_feefilter_last,
             // log-extractor
             log_events,
+            log_bytes,
             log_block_connected_events,
             log_block_checked_events,
             log_mutated_blocks,

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -3372,6 +3372,8 @@ async fn test_integration_metrics_logextractor_logevents() {
                 category: LogDebugCategory::Unknown.into(),
                 log_timestamp: 1234,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 5,
                 log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
                     log_extractor::UnknownLogMessage {
                         raw_message: "test1".to_string(),
@@ -3383,6 +3385,8 @@ async fn test_integration_metrics_logextractor_logevents() {
                 category: LogDebugCategory::Unknown.into(),
                 log_timestamp: 1234,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 5,
                 log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
                     log_extractor::UnknownLogMessage {
                         raw_message: "test2".to_string(),
@@ -3393,7 +3397,7 @@ async fn test_integration_metrics_logextractor_logevents() {
         ],
         Subject::LogExtractor,
         r#"
-        peerobserver_log_events{category="unknown"} 2
+        peerobserver_log_events{category="unknown",level="info"} 2
         "#,
     )
     .await;
@@ -3409,6 +3413,8 @@ async fn test_integration_metrics_logextractor_blockconnected_events() {
                 category: LogDebugCategory::Validation.into(),
                 log_timestamp: 345,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Debug.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::BlockConnectedLog(
                     log_extractor::BlockConnectedLog {
                         block_height: 1234,
@@ -3423,6 +3429,8 @@ async fn test_integration_metrics_logextractor_blockconnected_events() {
                 category: LogDebugCategory::Validation.into(),
                 log_timestamp: 3452,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Debug.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::BlockConnectedLog(
                     log_extractor::BlockConnectedLog {
                         block_height: 2222,
@@ -3437,6 +3445,8 @@ async fn test_integration_metrics_logextractor_blockconnected_events() {
                 category: LogDebugCategory::Unknown.into(),
                 log_timestamp: 1234,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
                     log_extractor::UnknownLogMessage {
                         raw_message: "test2".to_string(),
@@ -3448,8 +3458,8 @@ async fn test_integration_metrics_logextractor_blockconnected_events() {
         Subject::LogExtractor,
         r#"
         peerobserver_log_block_connected_events 2
-        peerobserver_log_events{category="unknown"} 1
-        peerobserver_log_events{category="validation"} 2
+        peerobserver_log_events{category="unknown",level="info"} 1
+        peerobserver_log_events{category="validation",level="debug"} 2
         "#,
     )
     .await;
@@ -3465,6 +3475,8 @@ async fn test_integration_metrics_logextractor_blockchecked_events() {
                 category: LogDebugCategory::Validation.into(),
                 log_timestamp: 345,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Debug.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::BlockCheckedLog(
                     log_extractor::BlockCheckedLog {
                         debug_message: "".to_string(),
@@ -3480,7 +3492,7 @@ async fn test_integration_metrics_logextractor_blockchecked_events() {
         Subject::LogExtractor,
         r#"
         peerobserver_log_block_checked_events 1
-        peerobserver_log_events{category="validation"} 1
+        peerobserver_log_events{category="validation",level="debug"} 1
         "#,
     )
     .await;
@@ -3496,6 +3508,8 @@ async fn test_integration_metrics_logextractor_blockchecked_mutated_events() {
                 category: LogDebugCategory::Validation.into(),
                 log_timestamp: 345,
                 threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 100,
                 log_event: Some(log_extractor::log::LogEvent::BlockCheckedLog(
                     log_extractor::BlockCheckedLog {
                         debug_message: "duplicate transaction".to_string(),

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -3752,3 +3752,44 @@ async fn test_integration_metrics_rpc_getorphantxs() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn test_integration_metrics_log_line_bytes() {
+    println!("test that log-extractor log line bytes metric work");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: 1234,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
+                    log_extractor::UnknownLogMessage {
+                        raw_message: "test".to_string(),
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: 1234,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 8,
+                log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
+                    log_extractor::UnknownLogMessage {
+                        raw_message: "testtest".to_string(),
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::LogExtractor,
+        r#"
+        peerobserver_log_bytes{category="unknown",level="info"} 12
+        "#,
+    )
+    .await;
+}


### PR DESCRIPTION
Closes #371 

This is my first contribution, so any feedback is appreciated.

This adds two new fields to the `log` protobuf message and corresponding metrics:

### Log level (`log_level`)

Bitcoin Core's `LogError()` and `LogWarning()` emit `[error]` and `[warning]` bracket
tokens in log lines. The log parser now extracts these into a `LogLevel` enum
(INFO/WARNING/ERROR/DEBUG/TRACE) and populates `log_level` on every event. The `log_events` metric
gains a `level` label so events can be broken down by severity.

### Line byte size (`log_line_bytes`)

Now the log extractor records the exact byte length of the original `debug.log` line in
`log_line_bytes`, and the metrics tool reads it directly. A new `peerobserver_log_bytes`
counter (labeled by category and level) tracks total bytes written to `debug.log`.

### Grafana

The logs dashboard gets new panels: "Log bytes by category (1min)", "Logs by level (1min)" and "Log bytes by level (1min)".

<img width="1642" height="517" alt="image" src="https://github.com/user-attachments/assets/cbadd9b3-a9ab-4995-ac5d-b0339e386c97" />

### Protobuf changes

```proto
enum LogLevel {
    INFO = 0;      // no bracket
    WARNING = 1;   // [warning] bracket
    ERROR = 2;     // [error] bracket
    DEBUG = 3;     // [category] bracket
    TRACE = 4;     // [category:trace] bracket
}

 message log {
   ...
  required LogLevel log_level = 7;
  required uint64 log_line_bytes = 8;
 }
``