### PR TITLE
Add IPC extractor

### DIFF
--- a/.github/actions/install-bitcoin/action.yml
+++ b/.github/actions/install-bitcoin/action.yml
@@ -1,0 +1,79 @@
+name: 'Install and Verify Bitcoin Core'
+description: 'Downloads, Verify signatures and installs Bitcoin Core'
+
+inputs:
+  version:
+    description: 'Bitcoin Core version to install'
+    required: true
+    default: '31.0'
+  trusted_keys:
+    description: 'List of GPG fingerprints to validate'
+    required: false
+    # Signatures from the following GPG public keys checked during verification of the source code.
+    # The list can be found at https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys
+    # 15281230078...: achow101.gpg
+    # 9EDAFF80E08...: Emzy.gpg
+    # D1DBF2C4B96...: hebasto.gpg
+    default: >-
+      152812300785C96444D3334D17565732E08E5E41
+      9EDAFF80E080659604F4A76B2EBB056FD847F8A7
+      D1DBF2C4B96F2DEBF4C16654410108112E7EA81F
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install verification dependencies
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y gnupg wget
+
+    - name: Download and Verify Bitcoin Core
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        
+        # 1. Download Binaries & Manifests
+        wget -q "https://bitcoincore.org/bin/bitcoin-core-${VERSION}/bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz"
+        wget -q "https://bitcoincore.org/bin/bitcoin-core-${VERSION}/SHA256SUMS"
+        wget -q "https://bitcoincore.org/bin/bitcoin-core-${VERSION}/SHA256SUMS.asc"
+
+        # 2. Fetch builder keys
+        git clone --depth 1 https://github.com/bitcoin-core/guix.sigs
+        
+        # 3. Setup temporary GPG environment
+        export GNUPGHOME=$(mktemp -d)
+        gpg --batch --import guix.sigs/builder-keys/*.gpg
+
+        # 4. Verify the SHA256SUMS signature
+        gpg --batch --verify --status-fd 1 SHA256SUMS.asc SHA256SUMS > verify.log
+        
+        # 5. Check against trusted fingerprints
+        TRUSTED_KEYS=(${{ inputs.trusted_keys }})
+        MATCH=false
+        for KEY in "${TRUSTED_KEYS[@]}"; do
+          if grep -q "VALIDSIG .* $KEY" verify.log; then
+            echo "Verified signature from trusted developer: $KEY"
+            MATCH=true
+            break
+          fi
+        done
+
+        if [ "$MATCH" != true ]; then
+          echo "No signatures from the trusted key list were found."
+          exit 1
+        fi
+
+        # 6. Verify checksum and extract
+        sha256sum --ignore-missing --check SHA256SUMS
+        tar -xzf bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz
+        
+        # 7. Install to path (core v31.0 lists `bitcoin-node` in libexec/)
+        sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-${VERSION}/bin/*
+        sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-${VERSION}/libexec/*
+        
+        # Cleanup workspace
+        rm -rf guix.sigs bitcoin-${VERSION}* SHA256SUMS* verify.log
+        echo "Bitcoin Core v${VERSION} installed successfully."
+
+    - name: Verify Installation
+      shell: bash
+      run: bitcoind --version

--- a/.github/actions/setup-ubuntu-action/action.yml
+++ b/.github/actions/setup-ubuntu-action/action.yml
@@ -17,7 +17,9 @@ runs:
           zstd \
           binutils-dev \
           elfutils \
-          gcc-multilib
+          gcc-multilib \
+          libcapnp-dev \
+          capnproto 
     
     - name: Cache cargo
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,14 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-ubuntu-action
+    - name: Setup Bitcoin
+      uses: ./.github/actions/install-bitcoin
+      with:
+        version: '31.0'
     - name: Install integration test dependecies
       run: sudo apt-get install -y nats-server
     - name: Run tests and integration tests
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
 
   ubuntu-test-detect-intermittent-failures:
     runs-on: ubuntu-latest
@@ -117,29 +121,33 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-ubuntu-action
+    - name: Setup Bitcoin
+      uses: ./.github/actions/install-bitcoin
+      with:
+        version: '31.0'
     - name: Install integration test dependecies
       run: sudo apt-get install -y nats-server
     # use separate steps for iterations here to easily see on GHA the time it took
     - name: Iteration 0
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 1
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 2
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 3
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 4
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 5
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 6
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 7
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 8
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
     - name: Iteration 9
-      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+      run: NATS_SERVER_BINARY=$(which nats-server) BITCOIN_NODE_EXE=$(which bitcoin-node) cargo test --all-features
 
   ubuntu-docs-tools:
     needs: ubuntu-build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnp"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae0593da254d02d0e69525b5eec7a59586753aa3bd2e54842eca33c6786330c"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnp-futures"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b69dfddccc57844f9a90f9d72b44b97c326914851ea94fb7da40ef9cad6e8d"
+dependencies = [
+ "capnp",
+ "futures-channel",
+ "futures-util",
+]
+
+[[package]]
+name = "capnp-rpc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ccca6d26009f4d6c12b741994f33b421da613b5dcf461508e236b53ef862f1"
+dependencies = [
+ "capnp",
+ "capnp-futures",
+ "futures",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6cdfa6b0df161a71201367910265b97180541ecdb48bd08e05ef8694c295d1f"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +674,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
 name = "equivalent"
@@ -1049,7 +1095,11 @@ dependencies = [
 name = "ipc-extractor"
 version = "0.1.0"
 dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
  "shared",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2232,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-extractor"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-extractor"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "capnp"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae0593da254d02d0e69525b5eec7a59586753aa3bd2e54842eca33c6786330c"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnp-futures"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b69dfddccc57844f9a90f9d72b44b97c326914851ea94fb7da40ef9cad6e8d"
+dependencies = [
+ "capnp",
+ "futures-channel",
+ "futures-util",
+]
+
+[[package]]
+name = "capnp-rpc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ccca6d26009f4d6c12b741994f33b421da613b5dcf461508e236b53ef862f1"
+dependencies = [
+ "capnp",
+ "capnp-futures",
+ "futures",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6cdfa6b0df161a71201367910265b97180541ecdb48bd08e05ef8694c295d1f"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +714,12 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
 name = "equivalent"
@@ -1126,7 +1172,11 @@ dependencies = [
 name = "ipc-extractor"
 version = "0.1.0"
 dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
  "shared",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2306,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "extractors/rpc",
   "extractors/p2p",
   "extractors/log",
+  "extractors/ipc",
   "tools/logger",
   "tools/websocket",
   "tools/metrics",

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ I'll do my best to add more documentation.
 
 To run the integration tests, run with the feature `nats_integration_tests` and
 `node_integration_tests`. If you are not using the nix-shell, you need to set the
-`NATS_SERVER_BINARY` to the path to your `nats-server` binary. Addtionally,
+`NATS_SERVER_BINARY` to the path to your `nats-server` binary and `BITCOIN_NODE_EXE` to the path to a `bitcoin-node` binary. Additionally,
 `BITCOIND_EXE` can be set to a custom `bitcoind` binary. By default, a recent
 release will be downloaded and used if `BITCOIND_SKIP_DOWNLOAD` is unset.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ selected P2P measurements as events into a NATS pub-sub queue.
 
 The `log-extractor` publishes them parsed `debug.log` log messages as events to NATS.
 
+And finally an experimental `ipc-extractor` which periodically fetch data from a `bitcoin-node` binary through a UNIX socket created with the `-ipcbind` option. Publishes to NATS as IPC events.
+
 The tools are written in Rust (or any other language that supports NATS 
 and protobuf). They subscribe to the NATS server. For example, the `logger` tool 
 simply prints out all messages that it receives, the `metrics` tool produces prometheus 
@@ -36,21 +38,27 @@ messages. For other languages, types can be generated directly from the Protobuf
                                            messages
 ┌─────────────┐    ┌───────────────┐     ┌─────────┐      ┌──────────────────────┐
 │             ├────► ebpf-extractor├─────┤         │      │                      │
-│             │    └───────────────┘     │         │      │ Tools                │
-│             │                          │         │      │                      │
-│             │    ┌───────────────┐     │         ├──────┼──►logger             │
+│             │    └───────────────┘     │         │      │                      │
+│             │                          │         │      │ Tools                │
+│             │    ┌───────────────┐     │         │      │                      │
 │             ├────► rpc-extractor │─────┤         │      │                      │
-│   Bitcoin   │    └───────────────┘     │ NATS.io ├──────┼──►metrics            │
+│             │    └───────────────┘     │         ├──────┼──►logger             │
 │             │                          │         │      │                      │
-│     Node    │    ┌───────────────┐     │ PUB-SUB ├──────┼──►websocket          │
+│   Bitcoin   │    ┌───────────────┐     │ NATS.io ├──────┼──►metrics            │
 │             ├────► p2p-extractor │─────┤         │      │                      │
-│             │    └───────────────┘     │         ├──────┼──►connectivity-check │
+│     Node    │    └───────────────┘     │ PUB-SUB ├──────┼──►websocket          │
 │             │                          │         │      │                      │
-│             │    ┌───────────────┐     │         │      │   ...                │
+│             │    ┌───────────────┐     │         ├──────┼──►connectivity-check │
 │             ├────► log-extractor │─────┤         │      │                      │
+│             │    └───────────────┘     │         │      │   ...                │
+│             │                          │         │      │                      │
+│             │    ┌───────────────┐     │         │      │                      │
+│             ├────► ipc-extractor ├─────┤         │      │                      │
 └─────────────┘    └───────────────┘     └─────────┘      └──────────────────────┘
 
  (edit on asciiflow.com)
+
+
 ```
 
 [nats.io]: https://nats.io
@@ -69,6 +77,7 @@ NATS server. Each extractor connects to a different interface:
 | rpc           | periodically fetches RPC for events   | [extractors/rpc/](extractors/rpc)   |
 | p2p           |Bitcoin P2P events from an inbound node| [extractors/p2p/](extractors/p2p)   |
 | log           | parses the debug.log of a node        | [extractors/log/](extractors/log)   |
+| ipc           | Fetch data over via IPC socket (experimental) | [extractors/ipc/](extractors/ipc)    |
 
 ## Tools
 

--- a/extractors/ipc/Cargo.toml
+++ b/extractors/ipc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ipc-extractor"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../../shared" }
+
+[features]
+# Treat warnings as a build error.
+strict = []
+
+# Run integration tests needing a NATS server.
+nats_integration_tests = []
+
+# Run integration tests needing a Bitcoin Core node.
+node_integration_tests = []

--- a/extractors/ipc/Cargo.toml
+++ b/extractors/ipc/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+capnp = "0.25.1"
+capnp-rpc = "0.25.0"
 shared = { path = "../../shared" }
+tokio-util = { version = "0.7.18", features = ["compat"] }
 
 [features]
 # Treat warnings as a build error.
@@ -15,3 +18,6 @@ nats_integration_tests = []
 
 # Run integration tests needing a Bitcoin Core node.
 node_integration_tests = []
+
+[build-dependencies]
+capnpc = "0.25.0"

--- a/extractors/ipc/README.md
+++ b/extractors/ipc/README.md
@@ -2,7 +2,7 @@
 
 > publishes data fetched from IPC
 
-A peer-observer extractor that periodically queries the Bitcoin Core IPC interfaces and publishes the results as events into a NATS pub-sub queue.
+The peer-observer ipc-extractor periodically queries data from the Bitcoin Core IPC interface and publishes the results as events into a NATS pub-sub queue
 
 ## Usage
 
@@ -13,6 +13,8 @@ The peer-observer ipc-extractor periodically queries data from the Bitcoin Core 
 Usage: ipc-extractor [OPTIONS] --ipc-socket-path <IPC_SOCKET_PATH>
 
 Options:
+  -i, --ipc-socket-path <IPC_SOCKET_PATH>
+          A path to an UNIX socket to read IPC data from
   -a, --nats-address <ADDRESS>
           The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
   -u, --nats-username <USERNAME>
@@ -23,8 +25,6 @@ Options:
           A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
   -l, --log-level <LOG_LEVEL>
           The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
-      --ipc-socket-path <IPC_SOCKET_PATH>
-          A UNIX socket path to read IPC data from
       --query-interval <QUERY_INTERVAL>
           Interval (in seconds) in which to query from the Bitcoin Core IPC interface [default: 10]
   -h, --help

--- a/extractors/ipc/README.md
+++ b/extractors/ipc/README.md
@@ -1,0 +1,34 @@
+# `ipc` extractor
+
+> publishes data fetched from IPC
+
+A peer-observer extractor that periodically queries the Bitcoin Core IPC interfaces and publishes the results as events into a NATS pub-sub queue.
+
+## Usage
+
+```
+$ cargo run --bin ipc-extractor -- --help
+The peer-observer ipc-extractor periodically queries data from the Bitcoin Core IPC endpoint and publishes the results as events into a NATS pub-sub queue
+
+Usage: ipc-extractor [OPTIONS] --ipc-socket-path <IPC_SOCKET_PATH>
+
+Options:
+  -a, --nats-address <ADDRESS>
+          The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
+  -u, --nats-username <USERNAME>
+          The NATS username the extractor/tool should try to authentificate to the NATS server with
+  -p, --nats-password <PASSWORD>
+          The NATS password the extractor/tool should try to authentificate to the NATS server with
+  -f, --nats-password-file <PASSWORD_FILE>
+          A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
+  -l, --log-level <LOG_LEVEL>
+          The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
+      --ipc-socket-path <IPC_SOCKET_PATH>
+          A UNIX socket path to read IPC data from
+      --query-interval <QUERY_INTERVAL>
+          Interval (in seconds) in which to query from the Bitcoin Core IPC interface [default: 10]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```

--- a/extractors/ipc/README.md
+++ b/extractors/ipc/README.md
@@ -1,0 +1,47 @@
+# `ipc` extractor
+
+> publishes data fetched from IPC
+
+A peer-observer extractor that periodically queries the Bitcoin Core IPC interfaces and publishes the results as events into a NATS pub-sub queue.
+
+## Example
+
+Start `bitcoin-node` with `-ipcbind=unix` to expose the IPC interface over a UNIX socket. With the bare `unix` value the socket is created at `<datadir>/node.sock` relative to the *network* data directory, for instance regtest with a default datadir results in the socket located at `~/.bitcoin/regtest/node.sock`. `~/.bitcoin/node.sock` for mainnet.
+
+For example, run a regtest node and point the ipc-extractor at the generated socket:
+
+```bash
+$ bitcoin-node -regtest -ipcbind=unix &
+$ cargo run --bin ipc-extractor -- --ipc-socket-path ~/.bitcoin/regtest/node.sock
+```
+
+Note that `bitcoin-node` is compiled by setting `-DENABLE_IPC=ON` when building from source. Alternatively, there is also a proxy binary named `bitcoin` that lets you spawn a specific process with the `-m` option. That's it, running `bitcoin -m node -regtest -ipcbind=unix` is equivalent to the start command above.
+
+## Usage
+
+```
+$ cargo run --bin ipc-extractor -- --help
+The peer-observer ipc-extractor periodically queries data from the Bitcoin Core IPC endpoint and publishes the results as events into a NATS pub-sub queue
+
+Usage: ipc-extractor [OPTIONS] --ipc-socket-path <IPC_SOCKET_PATH>
+
+Options:
+  -a, --nats-address <ADDRESS>
+          The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
+  -u, --nats-username <USERNAME>
+          The NATS username the extractor/tool should try to authentificate to the NATS server with
+  -p, --nats-password <PASSWORD>
+          The NATS password the extractor/tool should try to authentificate to the NATS server with
+  -f, --nats-password-file <PASSWORD_FILE>
+          A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
+  -l, --log-level <LOG_LEVEL>
+          The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
+      --ipc-socket-path <IPC_SOCKET_PATH>
+          A UNIX socket path to read IPC data from
+      --query-interval <QUERY_INTERVAL>
+          Interval (in seconds) in which to query from the Bitcoin Core IPC interface [default: 10]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```

--- a/extractors/ipc/README.md
+++ b/extractors/ipc/README.md
@@ -2,7 +2,7 @@
 
 > publishes data fetched from IPC
 
-A peer-observer extractor that periodically queries the Bitcoin Core IPC interfaces and publishes the results as events into a NATS pub-sub queue.
+The peer-observer ipc-extractor periodically queries data from the Bitcoin Core IPC interface and publishes the results as events into a NATS pub-sub queue
 
 ## Example
 
@@ -26,6 +26,8 @@ The peer-observer ipc-extractor periodically queries data from the Bitcoin Core 
 Usage: ipc-extractor [OPTIONS] --ipc-socket-path <IPC_SOCKET_PATH>
 
 Options:
+  -i, --ipc-socket-path <IPC_SOCKET_PATH>
+          A path to an UNIX socket to read IPC data from
   -a, --nats-address <ADDRESS>
           The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
   -u, --nats-username <USERNAME>
@@ -36,8 +38,6 @@ Options:
           A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
   -l, --log-level <LOG_LEVEL>
           The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
-      --ipc-socket-path <IPC_SOCKET_PATH>
-          A UNIX socket path to read IPC data from
       --query-interval <QUERY_INTERVAL>
           Interval (in seconds) in which to query from the Bitcoin Core IPC interface [default: 10]
   -h, --help

--- a/extractors/ipc/build.rs
+++ b/extractors/ipc/build.rs
@@ -1,0 +1,18 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    capnpc::CompilerCommand::new()
+        .file("capnp/mp/proxy.capnp")
+        .file("capnp/common.capnp")
+        .file("capnp/echo.capnp")
+        .file("capnp/mining.capnp")
+        .file("capnp/init.capnp")
+        .default_parent_module(vec![String::from("ipc")])
+        .run()?;
+
+    println!("cargo:rerun-if-changed=capnp/mp/proxy.capnp");
+    println!("cargo:rerun-if-changed=capnp/common.capnp");
+    println!("cargo:rerun-if-changed=capnp/echo.capnp");
+    println!("cargo:rerun-if-changed=capnp/mining.capnp");
+    println!("cargo:rerun-if-changed=capnp/init.capnp");
+
+    Ok(())
+}

--- a/extractors/ipc/capnp/common.capnp
+++ b/extractors/ipc/capnp/common.capnp
@@ -1,0 +1,16 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xcd2c6232cb484a28;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "./mp/proxy.capnp";
+$Proxy.includeTypes("ipc/capnp/common-types.h");
+
+struct BlockRef $Proxy.wrap("interfaces::BlockRef") {
+    hash @0 :Data;
+    height @1 :Int32;
+}

--- a/extractors/ipc/capnp/echo.capnp
+++ b/extractors/ipc/capnp/echo.capnp
@@ -1,0 +1,17 @@
+# Copyright (c) 2021-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0x888b4f7f51e691f7;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "./mp/proxy.capnp";
+$Proxy.include("interfaces/echo.h");
+$Proxy.includeTypes("ipc/capnp/echo-types.h");
+
+interface Echo $Proxy.wrap("interfaces::Echo") {
+    destroy @0 (context :Proxy.Context) -> ();
+    echo @1 (context :Proxy.Context, echo: Text) -> (result :Text);
+}

--- a/extractors/ipc/capnp/init.capnp
+++ b/extractors/ipc/capnp/init.capnp
@@ -1,0 +1,26 @@
+# Copyright (c) 2021-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xf2c5cfa319406aa6;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "./mp/proxy.capnp";
+$Proxy.include("interfaces/echo.h");
+$Proxy.include("interfaces/init.h");
+$Proxy.include("interfaces/mining.h");
+$Proxy.includeTypes("ipc/capnp/init-types.h");
+
+using Echo = import "echo.capnp";
+using Mining = import "mining.capnp";
+
+interface Init $Proxy.wrap("interfaces::Init") {
+    construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
+    makeEcho @1 (context :Proxy.Context) -> (result :Echo.Echo);
+    makeMining @3 (context :Proxy.Context) -> (result :Mining.Mining);
+
+    # DEPRECATED: no longer supported; server returns an error.
+    makeMiningOld2 @2 () -> ();
+}

--- a/extractors/ipc/capnp/mining.capnp
+++ b/extractors/ipc/capnp/mining.capnp
@@ -1,0 +1,67 @@
+# Copyright (c) 2024-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xc77d03df6a41b505;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Common = import "common.capnp";
+using Proxy = import "./mp/proxy.capnp";
+$Proxy.include("interfaces/mining.h");
+$Proxy.includeTypes("ipc/capnp/mining-types.h");
+
+const maxMoney :Int64 = 2100000000000000;
+const maxDouble :Float64 = 1.7976931348623157e308;
+const defaultBlockReservedWeight :UInt32 = 8000;
+const defaultCoinbaseOutputMaxAdditionalSigops :UInt32 = 400;
+
+interface Mining $Proxy.wrap("interfaces::Mining") {
+    isTestChain @0 (context :Proxy.Context) -> (result: Bool);
+    isInitialBlockDownload @1 (context :Proxy.Context) -> (result: Bool);
+    getTip @2 (context :Proxy.Context) -> (result: Common.BlockRef, hasResult: Bool);
+    waitTipChanged @3 (context :Proxy.Context, currentTip: Data, timeout: Float64 = .maxDouble) -> (result: Common.BlockRef);
+    createNewBlock @4 (context :Proxy.Context, options: BlockCreateOptions, cooldown: Bool = true) -> (result: BlockTemplate);
+    checkBlock @5 (context :Proxy.Context, block: Data, options: BlockCheckOptions) -> (reason: Text, debug: Text, result: Bool);
+    interrupt @6 () -> ();
+}
+
+interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
+    destroy @0 (context :Proxy.Context) -> ();
+    getBlockHeader @1 (context: Proxy.Context) -> (result: Data);
+    getBlock @2 (context: Proxy.Context) -> (result: Data);
+    getTxFees @3 (context: Proxy.Context) -> (result: List(Int64));
+    getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
+    getCoinbaseTx @5 (context: Proxy.Context) -> (result: CoinbaseTx);
+    getCoinbaseMerklePath @6 (context: Proxy.Context) -> (result: List(Data));
+    submitSolution @7 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Bool);
+    waitNext @8 (context: Proxy.Context, options: BlockWaitOptions) -> (result: BlockTemplate);
+    interruptWait @9() -> ();
+}
+
+struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {
+    useMempool @0 :Bool = true $Proxy.name("use_mempool");
+    blockReservedWeight @1 :UInt64 = .defaultBlockReservedWeight $Proxy.name("block_reserved_weight");
+    coinbaseOutputMaxAdditionalSigops @2 :UInt64 = .defaultCoinbaseOutputMaxAdditionalSigops $Proxy.name("coinbase_output_max_additional_sigops");
+}
+
+struct BlockWaitOptions $Proxy.wrap("node::BlockWaitOptions") {
+    timeout @0 : Float64 = .maxDouble $Proxy.name("timeout");
+    feeThreshold @1 : Int64 = .maxMoney $Proxy.name("fee_threshold");
+}
+
+struct BlockCheckOptions $Proxy.wrap("node::BlockCheckOptions") {
+    checkMerkleRoot @0 :Bool = true $Proxy.name("check_merkle_root");
+    checkPow @1 :Bool = true $Proxy.name("check_pow");
+}
+
+struct CoinbaseTx $Proxy.wrap("node::CoinbaseTx") {
+    version @0 :UInt32 $Proxy.name("version");
+    sequence @1 :UInt32 $Proxy.name("sequence");
+    scriptSigPrefix @2 :Data $Proxy.name("script_sig_prefix");
+    witness @3 :Data $Proxy.name("witness");
+    blockRewardRemaining @4 :Int64 $Proxy.name("block_reward_remaining");
+    requiredOutputs @5 :List(Data) $Proxy.name("required_outputs");
+    lockTime @6 :UInt32 $Proxy.name("lock_time");
+}

--- a/extractors/ipc/capnp/mp/proxy.capnp
+++ b/extractors/ipc/capnp/mp/proxy.capnp
@@ -1,0 +1,65 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xcc316e3f71a040fb;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("mp");
+
+annotation include(file): Text;
+annotation includeTypes(file): Text;
+# Extra include paths to add to generated files.
+
+annotation wrap(interface, struct): Text;
+# Wrap capnp interface generating ProxyClient / ProxyServer C++ classes that
+# forward calls to a C++ interface with same methods and parameters. Text
+# string should be the name of the C++ interface.
+# If applied to struct rather than an interface, this will generate a ProxyType
+# struct with get methods for introspection and copying fields between C++ and
+# capnp structs.
+
+annotation count(param, struct, interface): Int32;
+# Indicate how many C++ method parameters there are corresponding to one capnp
+# parameter (default is 1). If not 1, multiple C++ method arguments will be
+# condensed into a single capnp parameter by the client and then expanded by
+# the server by CustomReadField/CustomBuildField overloads which need to be
+# provided separately. An example would be a capnp Text parameter initialized
+# from C++ char* and size arguments. Can be 0 to fill an implicit capnp
+# parameter from client or server side context. If annotation is applied to an
+# interface or struct type it will apply to all parameters of that type.
+
+annotation exception(param): Text;
+# Indicate that a result parameter corresponds to a C++ exception. Text string
+# should be the name of a C++ exception type that the generated server class
+# will catch and the client class will rethrow.
+
+annotation name(field, method): Text;
+# Name of the C++ method or field corresponding to a capnp method or field.
+
+annotation skip(field): Void;
+# Synonym for count(0).
+
+interface ThreadMap $count(0) {
+    # Interface letting clients control which thread a method call should
+    # execute on. Clients create and name threads and pass the thread handle as
+    # a call parameter.
+    makeThread @0 (name :Text) -> (result :Thread);
+}
+
+interface Thread {
+    # Thread handle returned by makeThread corresponding to one server thread.
+
+    getName @0 () -> (result: Text);
+}
+
+struct Context $count(0) {
+   # Execution context passed as a parameter from the client class to the server class.
+
+   thread @0 : Thread;
+   # Handle of the server thread the current method call should execute on.
+
+   callbackThread @1 : Thread;
+   # Handle of the client thread that is calling the current method, and that
+   # any callbacks made by the server thread should be made on.
+}

--- a/extractors/ipc/src/error.rs
+++ b/extractors/ipc/src/error.rs
@@ -1,14 +1,17 @@
-use shared::async_nats::ConnectErrorKind;
+use shared::async_nats::{self, ConnectErrorKind};
 use shared::log::SetLoggerError;
 use std::error;
 use std::fmt;
 use std::io;
+use std::time::SystemTimeError;
 
 #[derive(Debug)]
 pub enum RuntimeError {
     SetLogger(SetLoggerError),
     Io(io::Error),
-    NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+    SystemTime(SystemTimeError),
+    NatsConnect(async_nats::error::Error<ConnectErrorKind>),
+    NatsPublish(async_nats::error::Error<async_nats::client::PublishErrorKind>),
 }
 
 impl fmt::Display for RuntimeError {
@@ -16,7 +19,9 @@ impl fmt::Display for RuntimeError {
         match self {
             RuntimeError::SetLogger(e) => write!(f, "set logger error {}", e),
             RuntimeError::Io(e) => write!(f, "IO error {}", e),
+            RuntimeError::SystemTime(e) => write!(f, "system time error {}", e),
             RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::NatsPublish(e) => write!(f, "NATS publish error {}", e),
         }
     }
 }
@@ -26,7 +31,9 @@ impl error::Error for RuntimeError {
         match *self {
             RuntimeError::SetLogger(ref e) => Some(e),
             RuntimeError::Io(ref e) => Some(e),
+            RuntimeError::SystemTime(ref e) => Some(e),
             RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::NatsPublish(ref e) => Some(e),
         }
     }
 }
@@ -43,8 +50,20 @@ impl From<io::Error> for RuntimeError {
     }
 }
 
-impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
-    fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
+impl From<SystemTimeError> for RuntimeError {
+    fn from(e: SystemTimeError) -> Self {
+        RuntimeError::SystemTime(e)
+    }
+}
+
+impl From<async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
+    fn from(e: async_nats::error::Error<ConnectErrorKind>) -> Self {
         RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<async_nats::error::Error<async_nats::client::PublishErrorKind>> for RuntimeError {
+    fn from(e: async_nats::error::Error<async_nats::client::PublishErrorKind>) -> Self {
+        RuntimeError::NatsPublish(e)
     }
 }

--- a/extractors/ipc/src/error.rs
+++ b/extractors/ipc/src/error.rs
@@ -9,6 +9,7 @@ use std::time::SystemTimeError;
 pub enum RuntimeError {
     SetLogger(SetLoggerError),
     Io(io::Error),
+    IpcCall(capnp::Error),
     SystemTime(SystemTimeError),
     NatsConnect(async_nats::error::Error<ConnectErrorKind>),
     NatsPublish(async_nats::error::Error<async_nats::client::PublishErrorKind>),
@@ -19,6 +20,7 @@ impl fmt::Display for RuntimeError {
         match self {
             RuntimeError::SetLogger(e) => write!(f, "set logger error {}", e),
             RuntimeError::Io(e) => write!(f, "IO error {}", e),
+            RuntimeError::IpcCall(e) => write!(f, "IPC error {}", e),
             RuntimeError::SystemTime(e) => write!(f, "system time error {}", e),
             RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
             RuntimeError::NatsPublish(e) => write!(f, "NATS publish error {}", e),
@@ -31,10 +33,17 @@ impl error::Error for RuntimeError {
         match *self {
             RuntimeError::SetLogger(ref e) => Some(e),
             RuntimeError::Io(ref e) => Some(e),
+            RuntimeError::IpcCall(ref e) => Some(e),
             RuntimeError::SystemTime(ref e) => Some(e),
             RuntimeError::NatsConnect(ref e) => Some(e),
             RuntimeError::NatsPublish(ref e) => Some(e),
         }
+    }
+}
+
+impl From<capnp::Error> for RuntimeError {
+    fn from(e: capnp::Error) -> Self {
+        RuntimeError::IpcCall(e)
     }
 }
 

--- a/extractors/ipc/src/error.rs
+++ b/extractors/ipc/src/error.rs
@@ -1,0 +1,50 @@
+use shared::async_nats::ConnectErrorKind;
+use shared::log::SetLoggerError;
+use std::error;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    SetLogger(SetLoggerError),
+    Io(io::Error),
+    NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::SetLogger(e) => write!(f, "set logger error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::SetLogger(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<SetLoggerError> for RuntimeError {
+    fn from(e: SetLoggerError) -> Self {
+        RuntimeError::SetLogger(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
+        RuntimeError::NatsConnect(e)
+    }
+}

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -1,0 +1,81 @@
+#[allow(dead_code)]
+mod generated {
+    capnp::generated_code!(pub mod proxy_capnp, "capnp/mp/proxy_capnp.rs");
+    capnp::generated_code!(pub mod common_capnp, "capnp/common_capnp.rs");
+    capnp::generated_code!(pub mod mining_capnp, "capnp/mining_capnp.rs");
+    capnp::generated_code!(pub mod echo_capnp, "capnp/echo_capnp.rs");
+    capnp::generated_code!(pub mod init_capnp, "capnp/init_capnp.rs");
+}
+use generated::*;
+
+use init_capnp::init::Client as InitClient;
+use mining_capnp::mining::Client as MiningClient;
+use proxy_capnp::thread::Client as ThreadClient;
+
+use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
+use shared::{
+    futures::AsyncReadExt,
+    protobuf::ipc_extractor::BlockTip,
+    tokio::{self, net::UnixStream, task::JoinHandle},
+};
+
+use crate::error::RuntimeError;
+
+pub struct IpcClient {
+    pub mining: MiningClient,
+    pub thread: ThreadClient,
+    pub rpc_task: JoinHandle<Result<(), capnp::Error>>,
+}
+
+impl IpcClient {
+    pub async fn init(stream: UnixStream) -> Result<Self, crate::error::RuntimeError> {
+        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+        let network = Box::new(twoparty::VatNetwork::new(
+            reader,
+            writer,
+            rpc_twoparty_capnp::Side::Client,
+            Default::default(),
+        ));
+
+        let mut rpc_system = RpcSystem::new(network, None);
+        let init: InitClient = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+        let rpc_task = tokio::task::spawn_local(rpc_system);
+
+        let response = init.construct_request().send().promise.await?;
+        let thread_map = response.get()?.get_thread_map()?;
+
+        let response = thread_map.make_thread_request().send().promise.await?;
+        let thread = response.get()?.get_result()?;
+
+        let mut req = init.make_mining_request();
+        set_context(req.get().get_context()?, &thread);
+
+        let response = req.send().promise.await?;
+        let mining = response.get()?.get_result()?;
+
+        Ok(Self {
+            rpc_task,
+            thread,
+            mining,
+        })
+    }
+
+    pub async fn get_tip(&self) -> Result<BlockTip, RuntimeError> {
+        let mut req = self.mining.get_tip_request();
+        set_context(req.get().get_context()?, &self.thread);
+
+        let response = req.send().promise.await?;
+        let tip = response.get()?.get_result()?;
+
+        let height = tip.get_height();
+        let mut hash = tip.get_hash()?.to_vec();
+        hash.reverse();
+
+        Ok(BlockTip { height, hash })
+    }
+}
+
+fn set_context(mut ctx: proxy_capnp::context::Builder<'_>, thread: &ThreadClient) {
+    ctx.set_thread(thread.clone());
+    ctx.set_callback_thread(thread.clone());
+}

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -1,0 +1,85 @@
+#[allow(dead_code)]
+mod generated {
+    capnp::generated_code!(pub mod proxy_capnp, "capnp/mp/proxy_capnp.rs");
+    capnp::generated_code!(pub mod common_capnp, "capnp/common_capnp.rs");
+    capnp::generated_code!(pub mod mining_capnp, "capnp/mining_capnp.rs");
+    capnp::generated_code!(pub mod echo_capnp, "capnp/echo_capnp.rs");
+    capnp::generated_code!(pub mod init_capnp, "capnp/init_capnp.rs");
+}
+use generated::*;
+
+use init_capnp::init::Client as InitClient;
+use mining_capnp::mining::Client as MiningClient;
+use proxy_capnp::thread::Client as ThreadClient;
+
+use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
+use shared::{
+    futures::AsyncReadExt,
+    protobuf::ipc_extractor::BlockTip,
+    tokio::{self, net::UnixStream, task::JoinHandle},
+};
+
+use crate::error::RuntimeError;
+
+pub struct IpcClient {
+    pub mining: MiningClient,
+    pub thread: ThreadClient,
+    pub rpc_task: JoinHandle<Result<(), capnp::Error>>,
+}
+
+impl IpcClient {
+    pub async fn init(stream: UnixStream) -> Result<Self, crate::error::RuntimeError> {
+        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+        let network = Box::new(twoparty::VatNetwork::new(
+            reader,
+            writer,
+            rpc_twoparty_capnp::Side::Client,
+            Default::default(),
+        ));
+
+        let mut rpc_system = RpcSystem::new(network, None);
+        let init: InitClient = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+        let rpc_task = tokio::task::spawn_local(rpc_system);
+
+        let response = init.construct_request().send().promise.await?;
+        let thread_map = response.get()?.get_thread_map()?;
+
+        let response = thread_map.make_thread_request().send().promise.await?;
+        let thread = response.get()?.get_result()?;
+
+        let mut req = init.make_mining_request();
+        set_context(req.get().get_context()?, &thread);
+
+        let response = req.send().promise.await?;
+        let mining = response.get()?.get_result()?;
+
+        Ok(Self {
+            rpc_task,
+            thread,
+            mining,
+        })
+    }
+
+    pub async fn get_tip(&self) -> Result<Option<BlockTip>, RuntimeError> {
+        let mut req = self.mining.get_tip_request();
+        set_context(req.get().get_context()?, &self.thread);
+
+        let response = req.send().promise.await?;
+
+        let has_result = response.get()?.get_has_result();
+        if !has_result {
+            return Ok(None);
+        }
+
+        let tip = response.get()?.get_result()?;
+        let height = tip.get_height();
+        let hash = tip.get_hash()?.to_vec();
+
+        Ok(Some(BlockTip { height, hash }))
+    }
+}
+
+fn set_context(mut ctx: proxy_capnp::context::Builder<'_>, thread: &ThreadClient) {
+    ctx.set_thread(thread.clone());
+    ctx.set_callback_thread(thread.clone());
+}

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -96,9 +96,14 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     loop {
         tokio::select! {
             _ = interval.tick() => {
+                 if ipc_session.rpc_task.is_finished() {
+                    log::error!("Lost connection to IPC socket. Exiting.");
+                    break;
+                }
+
                 if let Err(e) = get_tip(&ipc_session, &nats_client).await {
-                        log::error!("Could not fetch and publish 'getHeight': {}", e)
-                    }
+                        log::error!("Could not fetch and publish 'BlockTip': {}", e)
+                }
             }
             res = shutdown_rx.changed() => {
                 match res {

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -1,16 +1,28 @@
-use shared::clap::{self, Parser};
-use shared::nats_subjects::Subject;
-use shared::nats_util::{self, NatsArgs};
-use shared::prost::Message;
-use shared::protobuf::event::{Event, event::PeerObserverEvent};
-use shared::protobuf::ipc_extractor::{self, BlockTip};
-use shared::tokio::sync::watch;
-use shared::tokio::time::{self, Duration};
-use shared::{async_nats, log};
+use shared::{
+    async_nats,
+    clap::{self, Parser},
+    log,
+    nats_subjects::Subject,
+    nats_util::{self, NatsArgs},
+    prost::Message,
+    protobuf::{
+        event::{Event, event::PeerObserverEvent},
+        ipc_extractor,
+    },
+    tokio::{
+        self,
+        net::UnixStream,
+        sync::watch,
+        time::{self, Duration},
+    },
+};
+use std::io;
 
 mod error;
-
 use error::RuntimeError;
+
+mod ipc;
+use ipc::IpcClient;
 
 /// The peer-observer ipc-extractor periodically queries data from the
 /// Bitcoin Core IPC interface and publishes the results as events into
@@ -27,8 +39,8 @@ pub struct Args {
     #[arg(short, long, default_value_t = log::Level::Debug)]
     pub log_level: log::Level,
 
-    /// A UNIX socket path to read IPC data from.
-    #[arg(long)]
+    /// A path to an UNIX socket to read IPC data from.
+    #[arg(short, long)]
     pub ipc_socket_path: String,
 
     /// Interval (in seconds) in which to query from the Bitcoin Core IPC interface.
@@ -59,6 +71,21 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .await?;
     log::info!("Connected to NATS server at {}", &args.nats.address);
 
+    let stream = UnixStream::connect(&args.ipc_socket_path)
+        .await
+        .map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "could not connect to IPC socket at --ipc-socket-path '{}': {}",
+                    &args.ipc_socket_path, e
+                ),
+            )
+        })?;
+    log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
+
+    let ipc_session = IpcClient::init(stream).await?;
+
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);
     log::info!(
@@ -67,9 +94,9 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     );
 
     loop {
-        shared::tokio::select! {
+        tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = get_height(&nats_client).await {
+                if let Err(e) = get_tip(&ipc_session, &nats_client).await {
                         log::error!("Could not fetch and publish 'getHeight': {}", e)
                     }
             }
@@ -78,12 +105,14 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                     Ok(_) => {
                         if *shutdown_rx.borrow() {
                             log::info!("ipc_extractor received shutdown signal.");
+                            ipc_session.rpc_task.abort();
                             break;
                         }
                     }
                     Err(_) => {
                         // all senders dropped -> treat as shutdown
                         log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        ipc_session.rpc_task.abort();
                         break;
                     }
                 }
@@ -93,15 +122,14 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     Ok(())
 }
 
-async fn get_height(nats_client: &async_nats::Client) -> Result<(), RuntimeError> {
-    let height = 1; // TODO: replace with IPC fetcher
-    let hash = vec![0x00, 0x00, 0x00, 0x00];
+async fn get_tip(
+    ipc_client: &IpcClient,
+    nats_client: &async_nats::Client,
+) -> Result<(), RuntimeError> {
+    let tip = ipc_client.get_tip().await?;
 
     let proto = Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
-        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(BlockTip {
-            height,
-            hash,
-        })),
+        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(tip)),
     }))?;
 
     nats_client

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -1,0 +1,94 @@
+use shared::clap::{self, Parser};
+use shared::log;
+use shared::nats_util::{self, NatsArgs};
+use shared::tokio::sync::watch;
+use shared::tokio::time::{self, Duration};
+
+mod error;
+
+use error::RuntimeError;
+
+/// The peer-observer ipc-extractor periodically queries data from the
+/// Bitcoin Core IPC interface and publishes the results as events into
+/// a NATS pub-sub queue.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Arguments for the connection to the NATS server.
+    #[command(flatten)]
+    pub nats: nats_util::NatsArgs,
+
+    /// The log level the extractor should run with. Valid log levels are "trace",
+    /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html.
+    #[arg(short, long, default_value_t = log::Level::Debug)]
+    pub log_level: log::Level,
+
+    /// A UNIX socket path to read IPC data from.
+    #[arg(long)]
+    pub ipc_socket_path: String,
+
+    /// Interval (in seconds) in which to query from the Bitcoin Core IPC interface.
+    #[arg(long, default_value_t = 10)]
+    pub query_interval: u64,
+}
+
+impl Args {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        nats: NatsArgs,
+        log_level: log::Level,
+        ipc_socket_path: String,
+        query_interval: u64,
+    ) -> Args {
+        Self {
+            nats,
+            log_level,
+            ipc_socket_path,
+            query_interval,
+        }
+    }
+}
+
+pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    // let nats_client = nats_util::prepare_connection(&args.nats)?
+    //     .connect(&args.nats.address)
+    //     .await?;
+    log::info!("Connected to NATS server at {}", &args.nats.address);
+
+    let duration_sec = Duration::from_secs(args.query_interval);
+    let mut interval = time::interval(duration_sec);
+    log::info!(
+        "Querying the Bitcoin Core IPC interface every {:?}.",
+        duration_sec
+    );
+
+    loop {
+        shared::tokio::select! {
+            _ = interval.tick() => {
+                if let Err(e) = foo(/* &nats_client */).await {
+                        log::error!("Could not fetch and publish 'foo': {}", e)
+                    }
+            }
+            res = shutdown_rx.changed() => {
+                match res {
+                    Ok(_) => {
+                        if *shutdown_rx.borrow() {
+                            log::info!("ipc_extractor received shutdown signal.");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        // all senders dropped -> treat as shutdown
+                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn foo() -> Result<(), RuntimeError> {
+    Ok(())
+}

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -1,8 +1,12 @@
 use shared::clap::{self, Parser};
-use shared::log;
+use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};
+use shared::prost::Message;
+use shared::protobuf::event::{Event, event::PeerObserverEvent};
+use shared::protobuf::ipc_extractor::{self, BlockTip};
 use shared::tokio::sync::watch;
 use shared::tokio::time::{self, Duration};
+use shared::{async_nats, log};
 
 mod error;
 
@@ -50,9 +54,9 @@ impl Args {
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
-    // let nats_client = nats_util::prepare_connection(&args.nats)?
-    //     .connect(&args.nats.address)
-    //     .await?;
+    let nats_client = nats_util::prepare_connection(&args.nats)?
+        .connect(&args.nats.address)
+        .await?;
     log::info!("Connected to NATS server at {}", &args.nats.address);
 
     let duration_sec = Duration::from_secs(args.query_interval);
@@ -65,8 +69,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     loop {
         shared::tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = foo(/* &nats_client */).await {
-                        log::error!("Could not fetch and publish 'foo': {}", e)
+                if let Err(e) = get_height(&nats_client).await {
+                        log::error!("Could not fetch and publish 'getHeight': {}", e)
                     }
             }
             res = shutdown_rx.changed() => {
@@ -89,6 +93,19 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     Ok(())
 }
 
-async fn foo() -> Result<(), RuntimeError> {
+async fn get_height(nats_client: &async_nats::Client) -> Result<(), RuntimeError> {
+    let height = 1; // TODO: replace with IPC fetcher
+    let hash = vec![0x00, 0x00, 0x00, 0x00];
+
+    let proto = Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(BlockTip {
+            height,
+            hash,
+        })),
+    }))?;
+
+    nats_client
+        .publish(Subject::Ipc.to_string(), proto.encode_to_vec().into())
+        .await?;
     Ok(())
 }

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -1,16 +1,28 @@
-use shared::clap::{self, Parser};
-use shared::nats_subjects::Subject;
-use shared::nats_util::{self, NatsArgs};
-use shared::prost::Message;
-use shared::protobuf::event::{Event, event::PeerObserverEvent};
-use shared::protobuf::ipc_extractor::{self, BlockTip};
-use shared::tokio::sync::watch;
-use shared::tokio::time::{self, Duration};
-use shared::{async_nats, log};
+use shared::{
+    async_nats,
+    clap::{self, Parser},
+    log,
+    nats_subjects::Subject,
+    nats_util::{self, NatsArgs},
+    prost::Message,
+    protobuf::{
+        event::{Event, event::PeerObserverEvent},
+        ipc_extractor,
+    },
+    tokio::{
+        self,
+        net::UnixStream,
+        sync::watch,
+        time::{self, Duration},
+    },
+};
+use std::io;
 
 mod error;
-
 use error::RuntimeError;
+
+mod ipc;
+use ipc::IpcClient;
 
 /// The peer-observer ipc-extractor periodically queries data from the
 /// Bitcoin Core IPC interface and publishes the results as events into
@@ -27,8 +39,8 @@ pub struct Args {
     #[arg(short, long, default_value_t = log::Level::Debug)]
     pub log_level: log::Level,
 
-    /// A UNIX socket path to read IPC data from.
-    #[arg(long)]
+    /// A path to an UNIX socket to read IPC data from.
+    #[arg(short, long)]
     pub ipc_socket_path: String,
 
     /// Interval (in seconds) in which to query from the Bitcoin Core IPC interface.
@@ -59,6 +71,21 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .await?;
     log::info!("Connected to NATS server at {}", &args.nats.address);
 
+    let stream = UnixStream::connect(&args.ipc_socket_path)
+        .await
+        .map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "could not connect to IPC socket at --ipc-socket-path '{}': {}",
+                    &args.ipc_socket_path, e
+                ),
+            )
+        })?;
+    log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
+
+    let ipc_session = IpcClient::init(stream).await?;
+
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);
     log::info!(
@@ -67,9 +94,9 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     );
 
     loop {
-        shared::tokio::select! {
+        tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = get_height(&nats_client).await {
+                if let Err(e) = get_tip(&ipc_session, &nats_client).await {
                         log::error!("Could not fetch and publish 'getHeight': {}", e)
                     }
             }
@@ -78,12 +105,14 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                     Ok(_) => {
                         if *shutdown_rx.borrow() {
                             log::info!("ipc_extractor received shutdown signal.");
+                            ipc_session.rpc_task.abort();
                             break;
                         }
                     }
                     Err(_) => {
                         // all senders dropped -> treat as shutdown
                         log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        ipc_session.rpc_task.abort();
                         break;
                     }
                 }
@@ -93,15 +122,17 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     Ok(())
 }
 
-async fn get_height(nats_client: &async_nats::Client) -> Result<(), RuntimeError> {
-    let height = 1; // TODO: replace with IPC fetcher
-    let hash = vec![0x00, 0x00, 0x00, 0x00];
+async fn get_tip(
+    ipc_client: &IpcClient,
+    nats_client: &async_nats::Client,
+) -> Result<(), RuntimeError> {
+    let tip = match ipc_client.get_tip().await? {
+        Some(t) => t,
+        None => return Ok(()), // the node has no tip loaded yet, skip NATS publish
+    };
 
     let proto = Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
-        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(BlockTip {
-            height,
-            hash,
-        })),
+        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(tip)),
     }))?;
 
     nats_client

--- a/extractors/ipc/src/main.rs
+++ b/extractors/ipc/src/main.rs
@@ -1,0 +1,29 @@
+use ipc_extractor::Args;
+use shared::log;
+use shared::tokio::{self, signal, sync::watch};
+use shared::{clap::Parser, simple_logger};
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("ipc extractor error: {}", e);
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let ipc_handle = tokio::spawn(ipc_extractor::run(args, shutdown_rx));
+
+    tokio::select! {
+        _ = signal::ctrl_c() => {
+            log::info!("Received Ctrl+C. Stopping...");
+            let _ = shutdown_tx.send(true);
+        }
+        result = ipc_handle => {
+            match result.unwrap() {
+                Ok(_) => log::info!("ipc-extractor task completed."),
+                Err(e) => log::error!("ipc-extractor task failed: {e}"),
+            }
+        }
+    }
+}

--- a/extractors/ipc/src/main.rs
+++ b/extractors/ipc/src/main.rs
@@ -1,9 +1,11 @@
 use ipc_extractor::Args;
-use shared::log;
-use shared::tokio::{self, signal, sync::watch};
-use shared::{clap::Parser, simple_logger};
+use shared::{
+    clap::Parser,
+    log, simple_logger,
+    tokio::{self, signal, sync::watch, task::LocalSet},
+};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args = Args::parse();
 
@@ -11,19 +13,28 @@ async fn main() {
         eprintln!("ipc extractor error: {}", e);
     }
 
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let ipc_handle = tokio::spawn(ipc_extractor::run(args, shutdown_rx));
+    LocalSet::new()
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            let run_future = ipc_extractor::run(args, shutdown_rx);
+            tokio::pin!(run_future);
 
-    tokio::select! {
-        _ = signal::ctrl_c() => {
-            log::info!("Received Ctrl+C. Stopping...");
-            let _ = shutdown_tx.send(true);
-        }
-        result = ipc_handle => {
-            match result.unwrap() {
-                Ok(_) => log::info!("ipc-extractor task completed."),
-                Err(e) => log::error!("ipc-extractor task failed: {e}"),
+            tokio::select! {
+                _ = signal::ctrl_c() => {
+                    log::info!("Received Ctrl+C. Stopping...");
+                    let _ = shutdown_tx.send(true);
+                    match run_future.await {
+                        Ok(_) => log::info!("ipc-extractor task completed."),
+                        Err(e) => log::error!("ipc-extractor task failed: {e}"),
+                    }
+                }
+                result = &mut run_future => {
+                    match result {
+                        Ok(_) => log::info!("ipc-extractor task completed."),
+                        Err(e) => log::error!("ipc-extractor task failed: {e}"),
+                    }
+                }
             }
-        }
-    }
+        })
+        .await;
 }

--- a/extractors/ipc/src/main.rs
+++ b/extractors/ipc/src/main.rs
@@ -1,7 +1,9 @@
 use ipc_extractor::Args;
-use shared::log;
-use shared::tokio::{self, signal, sync::watch};
-use shared::{clap::Parser, simple_logger};
+use shared::{
+    clap::Parser,
+    log, simple_logger,
+    tokio::{self, signal, sync::watch, task::LocalSet},
+};
 
 #[tokio::main]
 async fn main() {
@@ -11,19 +13,28 @@ async fn main() {
         eprintln!("ipc extractor error: {}", e);
     }
 
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let ipc_handle = tokio::spawn(ipc_extractor::run(args, shutdown_rx));
+    LocalSet::new()
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            let run_future = ipc_extractor::run(args, shutdown_rx);
+            tokio::pin!(run_future);
 
-    tokio::select! {
-        _ = signal::ctrl_c() => {
-            log::info!("Received Ctrl+C. Stopping...");
-            let _ = shutdown_tx.send(true);
-        }
-        result = ipc_handle => {
-            match result.unwrap() {
-                Ok(_) => log::info!("ipc-extractor task completed."),
-                Err(e) => log::error!("ipc-extractor task failed: {e}"),
+            tokio::select! {
+                _ = signal::ctrl_c() => {
+                    log::info!("Received Ctrl+C. Stopping...");
+                    let _ = shutdown_tx.send(true);
+                    match run_future.await {
+                        Ok(_) => log::info!("ipc-extractor task completed."),
+                        Err(e) => log::error!("ipc-extractor task failed: {e}"),
+                    }
+                }
+                result = &mut run_future => {
+                    match result {
+                        Ok(_) => log::info!("ipc-extractor task completed."),
+                        Err(e) => log::error!("ipc-extractor task failed: {e}"),
+                    }
+                }
             }
-        }
-    }
+        })
+        .await;
 }

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -1,8 +1,155 @@
-use shared::tokio;
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+use ipc_extractor::{self, Args};
+use shared::{
+    async_nats,
+    bitcoin::hex::DisplayHex,
+    corepc_node,
+    futures::StreamExt,
+    log::{self, info},
+    nats_util::NatsArgs,
+    prost::Message,
+    protobuf::{
+        event::{Event, event::PeerObserverEvent},
+        ipc_extractor::ipc::IpcEvent::BlockTip,
+    },
+    simple_logger::SimpleLogger,
+    testing::nats_server::NatsServerForTesting,
+    tokio::{self, sync::watch, task::LocalSet, time::sleep},
+};
+use std::sync::Once;
+use std::time::Duration;
+
+pub const QUERY_INTERVAL_SECONDS: u64 = 1;
+
+// 5 second check() timeout.
+const TEST_TIMEOUT_SECONDS: u64 = 5;
+
+pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
+    Args::new(
+        NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        log::Level::Trace,
+        ipc_socket_path,
+        QUERY_INTERVAL_SECONDS,
+    )
+}
+
+static INIT: Once = Once::new();
+
+pub fn setup() {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+    });
+}
+
+pub fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+    info!(
+        "env BITCOIN_NODE_EXE={:?}",
+        std::env::var("BITCOIN_NODE_EXE")
+    );
+    let exe_path = std::env::var("BITCOIN_NODE_EXE").unwrap();
+
+    info!("Using bitcoin-node at '{}'", exe_path);
+    corepc_node::Node::with_conf(exe_path, &conf).unwrap()
+}
+
+fn configure_node() -> corepc_node::Node {
+    let mut node_conf = corepc_node::Conf::default();
+    node_conf.args = vec!["-regtest", "-ipcbind=unix"];
+    // enabling this is useful for debugging, but enabling this by default will
+    // be quite spammy.
+    node_conf.view_stdout = false;
+    // node_conf.wallet is `true` by default, but since `bitcoin-node` binary doesn't
+    // have wallet capabilities we disable it
+    node_conf.wallet = None;
+
+    setup_node(node_conf)
+}
+
+async fn check(check_expected: fn(PeerObserverEvent) -> ()) {
+    setup();
+    let node = configure_node();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+
+    let ipc_socket_path = node
+        .workdir()
+        .as_path()
+        .join("regtest")
+        .join("node.sock")
+        .to_str()
+        .unwrap()
+        .into();
+
+    let args = make_test_args(nats_server.port, ipc_socket_path);
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone());
+            tokio::pin!(ipc_extractor_future);
+
+            let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
+                .await
+                .unwrap();
+            let mut sub = nc.subscribe("*").await.unwrap();
+
+            tokio::select! {
+                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
+                    panic!("timed out waiting for check() to complete");
+                }
+                msg = sub.next() => {
+                    if let Some(msg) = msg {
+                        let unwrapped = Event::decode(msg.payload).unwrap();
+                        if let Some(event) = unwrapped.peer_observer_event {
+                            check_expected(event);
+                        }
+                    } else {
+                        panic!("subscription ended");
+                    }
+                }
+                result = &mut ipc_extractor_future => {
+                    panic!("ipc_extractor stopped unexpectedly: {:?}", result);
+                }
+            }
+
+            shutdown_tx.send(true).unwrap();
+            ipc_extractor_future.await.unwrap();
+        })
+        .await;
+}
 
 #[tokio::test]
-async fn test_integration_ipc_foo() {
-    println!("test that we receive foo IPC events");
+async fn test_integration_ipc() {
+    println!("test that we receive BlockTip IPC events");
 
-    assert_eq!(1, 1)
+    check(|event| match event {
+        PeerObserverEvent::IpcExtractor(i) => {
+            if let Some(ref e) = i.ipc_event {
+                match e {
+                    BlockTip(t) => {
+                        assert_eq!(t.height, 0);
+                        assert_eq!(t.hash.len(), 32);
+                        assert_eq!(
+                            t.hash.to_lower_hex_string(),
+                            // genesis blockhash in Regtest
+                            "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+                        );
+                    }
+                }
+            }
+        }
+        _ => panic!("unexpected event {:?}", event),
+    })
+    .await;
 }

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -1,0 +1,8 @@
+use shared::tokio;
+
+#[tokio::test]
+async fn test_integration_ipc_foo() {
+    println!("test that we receive foo IPC events");
+
+    assert_eq!(1, 1)
+}

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -1,8 +1,166 @@
-use shared::tokio;
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+use ipc_extractor::{self, Args};
+use shared::{
+    async_nats,
+    bitcoin::{self, hashes::Hash},
+    bitcoind,
+    futures::StreamExt,
+    log::{self, info},
+    nats_util::NatsArgs,
+    prost::Message,
+    protobuf::{
+        event::{Event, event::PeerObserverEvent},
+        ipc_extractor::ipc::IpcEvent::BlockTip,
+    },
+    simple_logger::SimpleLogger,
+    testing::nats_server::NatsServerForTesting,
+    tokio::{self, sync::watch, task::LocalSet, time::sleep},
+};
+use std::sync::Once;
+use std::time::Duration;
+
+pub const QUERY_INTERVAL_SECONDS: u64 = 1;
+
+// 5 second check() timeout.
+const TEST_TIMEOUT_SECONDS: u64 = 5;
+
+pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
+    Args::new(
+        NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        log::Level::Trace,
+        ipc_socket_path,
+        QUERY_INTERVAL_SECONDS,
+    )
+}
+
+static INIT: Once = Once::new();
+
+pub fn setup() {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+    });
+}
+
+fn bitcoin_node_exe_path() -> String {
+    if let Ok(p) = std::env::var("BITCOIN_NODE_EXE") {
+        return p;
+    }
+    let bitcoind_path =
+        std::path::PathBuf::from(bitcoind::downloaded_exe_path().expect("downloaded_exe_path"));
+    bitcoind_path
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("unexpected bitcoind path layout")
+        .join("libexec")
+        .join("bitcoin-node")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
+    let exe_path = bitcoin_node_exe_path();
+    info!("Using bitcoin-node at '{}'", exe_path);
+    bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap()
+}
+
+fn configure_node() -> bitcoind::BitcoinD {
+    let mut node_conf = bitcoind::Conf::default();
+    node_conf.args = vec!["-regtest", "-ipcbind=unix"];
+    // enabling this is useful for debugging, but enabling this by default will
+    // be quite spammy.
+    node_conf.view_stdout = false;
+    // node_conf.wallet is `true` by default, but since `bitcoin-node` binary doesn't
+    // have wallet capabilities we disable it
+    node_conf.wallet = None;
+
+    setup_node(node_conf)
+}
+
+async fn check(check_expected: fn(PeerObserverEvent) -> ()) {
+    setup();
+    let node = configure_node();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+
+    let ipc_socket_path = node
+        .workdir()
+        .as_path()
+        .join("regtest")
+        .join("node.sock")
+        .to_str()
+        .unwrap()
+        .into();
+
+    let args = make_test_args(nats_server.port, ipc_socket_path);
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone());
+            tokio::pin!(ipc_extractor_future);
+
+            let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
+                .await
+                .unwrap();
+            let mut sub = nc.subscribe("*").await.unwrap();
+
+            tokio::select! {
+                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
+                    panic!("timed out waiting for check() to complete");
+                }
+                msg = sub.next() => {
+                    if let Some(msg) = msg {
+                        let unwrapped = Event::decode(msg.payload).unwrap();
+                        if let Some(event) = unwrapped.peer_observer_event {
+                            check_expected(event);
+                        }
+                    } else {
+                        panic!("subscription ended");
+                    }
+                }
+                result = &mut ipc_extractor_future => {
+                    panic!("ipc_extractor stopped unexpectedly: {:?}", result);
+                }
+            }
+
+            shutdown_tx.send(true).unwrap();
+            ipc_extractor_future.await.unwrap();
+        })
+        .await;
+}
 
 #[tokio::test]
-async fn test_integration_ipc_foo() {
-    println!("test that we receive foo IPC events");
+async fn test_integration_ipc() {
+    println!("test that we receive BlockTip IPC events");
 
-    assert_eq!(1, 1)
+    check(|event| match event {
+        PeerObserverEvent::IpcExtractor(i) => {
+            if let Some(ref e) = i.ipc_event {
+                match e {
+                    BlockTip(t) => {
+                        assert_eq!(t.height, 0);
+                        assert_eq!(t.hash.len(), 32);
+                        assert_eq!(
+                            bitcoin::BlockHash::from_slice(&t.hash).unwrap().to_string(),
+                            // genesis blockhash in Regtest
+                            "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+                        );
+                    }
+                }
+            }
+        }
+        _ => panic!("unexpected event {:?}", event),
+    })
+    .await;
 }

--- a/protobuf/event.proto
+++ b/protobuf/event.proto
@@ -6,13 +6,15 @@ import "ebpf_extractor.proto";
 import "rpc_extractor.proto";
 import "p2p_extractor.proto";
 import "log_extractor.proto";
+import "ipc_extractor.proto";
 
 message Event {
-  required uint64  timestamp = 10;  // Timestamp (milliseconds since UNIX epoch) when the event was constructed.
+  required uint64  timestamp = 10; // Timestamp (milliseconds since UNIX epoch) when the event was constructed.
   oneof peer_observer_event {
     ebpf_extractor.ebpf         ebpf_extractor  = 1;
     rpc_extractor.rpc           rpc_extractor   = 2;
     p2p_extractor.p2p           p2p_extractor   = 3;
     log_extractor.log           log_extractor   = 4;
+    ipc_extractor.ipc           ipc_extractor   = 5;
   }
 }

--- a/protobuf/ipc_extractor.proto
+++ b/protobuf/ipc_extractor.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package ipc_extractor;
+
+message ipc {
+  oneof ipc_event {
+    BlockTip block_tip = 1;
+  }
+}
+
+message BlockTip {
+  required int32 height = 1;
+  required bytes hash   = 2;
+}

--- a/shared/src/nats_subjects.rs
+++ b/shared/src/nats_subjects.rs
@@ -5,6 +5,7 @@ const NATS_SUBJECT_NETMSG: &str = "netmsg";
 const NATS_SUBJECT_NETCONN: &str = "netconn";
 const NATS_SUBJECT_VALIDATION: &str = "validation";
 const NATS_SUBJECT_RPC: &str = "rpc";
+const NATS_SUBJECT_IPC: &str = "ipc";
 const NATS_SUBJECT_P2P_EXTRACTOR: &str = "p2p-extractor";
 const NATS_SUBJECT_LOG_EXTRACTOR: &str = "log-extractor";
 
@@ -14,6 +15,7 @@ pub enum Subject {
     NetConn,
     Validation,
     Rpc,
+    Ipc,
     P2PExtractor,
     LogExtractor,
 }
@@ -26,6 +28,7 @@ impl fmt::Display for Subject {
             Subject::NetMsg => write!(f, "{}", NATS_SUBJECT_NETMSG),
             Subject::Validation => write!(f, "{}", NATS_SUBJECT_VALIDATION),
             Subject::Rpc => write!(f, "{}", NATS_SUBJECT_RPC),
+            Subject::Ipc => write!(f, "{}", NATS_SUBJECT_IPC),
             Subject::P2PExtractor => write!(f, "{}", NATS_SUBJECT_P2P_EXTRACTOR),
             Subject::LogExtractor => write!(f, "{}", NATS_SUBJECT_LOG_EXTRACTOR),
         }

--- a/shared/src/protobuf/ipc_extractor.rs
+++ b/shared/src/protobuf/ipc_extractor.rs
@@ -1,0 +1,24 @@
+use bitcoin::hex::DisplayHex;
+use std::fmt;
+
+// structs are generated via the ipc_extractor.proto file
+include!(concat!(env!("OUT_DIR"), "/ipc_extractor.rs"));
+
+impl fmt::Display for ipc::IpcEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ipc::IpcEvent::BlockTip(tip) => write!(f, "{}", tip),
+        }
+    }
+}
+
+impl fmt::Display for BlockTip {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BlockTip(height={}, hash={})",
+            self.height,
+            self.hash.to_lower_hex_string()
+        )
+    }
+}

--- a/shared/src/protobuf/ipc_extractor.rs
+++ b/shared/src/protobuf/ipc_extractor.rs
@@ -1,0 +1,24 @@
+use crate::bitcoin::hashes::Hash;
+use std::fmt;
+
+// structs are generated via the ipc_extractor.proto file
+include!(concat!(env!("OUT_DIR"), "/ipc_extractor.rs"));
+
+impl fmt::Display for ipc::IpcEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ipc::IpcEvent::BlockTip(tip) => write!(f, "{}", tip),
+        }
+    }
+}
+
+impl fmt::Display for BlockTip {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BlockTip(height={}, hash={})",
+            self.height,
+            bitcoin::BlockHash::from_slice(&self.hash).unwrap()
+        )
+    }
+}

--- a/shared/src/protobuf/mod.rs
+++ b/shared/src/protobuf/mod.rs
@@ -13,5 +13,8 @@ pub mod p2p_extractor;
 /// Protobuf types for rpc-extractor events.
 pub mod rpc_extractor;
 
+/// Protobuf types for ipc-extractor events.
+pub mod ipc_extractor;
+
 /// Protobuf types for log-extractor events.
 pub mod log_extractor;

--- a/shell.nix
+++ b/shell.nix
@@ -44,6 +44,7 @@ pkgs.mkShell {
       # use the nix one instead
       export BITCOIND_SKIP_DOWNLOAD=1
       export BITCOIND_EXE=${pkgs.bitcoind}/bin/bitcoind
+      export BITCOIN_NODE_EXE=${pkgs.bitcoind}/libexec/bitcoin-node
 
       # set the path of the Linux kernel headers. These are needed in
       # build.rs of the ebpf-extractor on Nix.

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,8 @@ pkgs.mkShell {
 
       pkgs.bpftools
 
+      pkgs.capnproto
+
       # libbpf CO-RE pkgs
       #
       # use the unwrapped clang:

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,8 @@ pkgs.mkShell {
 
       pkgs.bpftools
 
+      pkgs.capnproto
+
       # libbpf CO-RE pkgs
       #
       # use the unwrapped clang:

--- a/shell.nix
+++ b/shell.nix
@@ -47,6 +47,7 @@ pkgs.mkShell {
       # use the nix one instead
       export BITCOIND_SKIP_DOWNLOAD=1
       export BITCOIND_EXE=${pkgs.bitcoind}/bin/bitcoind
+      export BITCOIN_NODE_EXE=${pkgs.bitcoind}/libexec/bitcoin-node
 
       # set the path of the Linux kernel headers. These are needed in
       # build.rs of the ebpf-extractor on Nix.

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -95,6 +95,8 @@ Options:
           If passed, archive p2p-extractor events
       --log-extractor
           If passed, archive log-extractor events
+      --ipc-extractor
+          If passed, archive ipc-extractor events
       --compression-level <COMPRESSION_LEVEL>
           Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra) [default: 22]
   -h, --help

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -329,6 +329,10 @@ pub struct Args {
     #[arg(long)]
     pub log_extractor: bool,
 
+    /// If passed, archive ipc-extractor events.
+    #[arg(long)]
+    pub ipc_extractor: bool,
+
     /// Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra).
     #[arg(long, default_value_t = 22)]
     pub compression_level: u32,
@@ -343,7 +347,8 @@ impl Args {
             || self.validation
             || self.rpc
             || self.p2p_extractor
-            || self.log_extractor)
+            || self.log_extractor
+            || self.ipc_extractor)
     }
 }
 
@@ -359,6 +364,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         log::info!("archiving rpc events:           {}", args.rpc);
         log::info!("archiving p2p_extractor events: {}", args.p2p_extractor);
         log::info!("archiving log_extractor events: {}", args.log_extractor);
+        log::info!("archiving ipc_extractor events: {}", args.ipc_extractor);
     }
 
     let nc = nats_util::prepare_connection(&args.nats)?
@@ -480,6 +486,7 @@ fn should_archive(event: &Event, args: &Args) -> bool {
         Some("rpc") => args.rpc,
         Some("p2p_extractor") => args.p2p_extractor,
         Some("log_extractor") => args.log_extractor,
+        Some("ipc_extractor") => args.ipc_extractor,
         _ => false,
     }
 }
@@ -495,6 +502,7 @@ fn event_type_name(event: &Event) -> Option<&'static str> {
         PeerObserverEvent::RpcExtractor(_) => "rpc",
         PeerObserverEvent::P2pExtractor(_) => "p2p_extractor",
         PeerObserverEvent::LogExtractor(_) => "log_extractor",
+        PeerObserverEvent::IpcExtractor(_) => "ipc_extractor",
     };
     Some(name)
 }

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -18,6 +18,7 @@ use shared::{
             Ebpf,
         },
         event::{event::PeerObserverEvent, Event},
+        ipc_extractor::{self, BlockTip},
         log_extractor::{self, LogDebugCategory},
         p2p_extractor, rpc_extractor,
     },
@@ -67,6 +68,7 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         rpc: false,
         p2p_extractor: false,
         log_extractor: false,
+        ipc_extractor: false,
         compression_level: 3,
     }
 }
@@ -179,6 +181,17 @@ fn make_all_event_types() -> Vec<(Event, &'static str)> {
             .unwrap(),
             "log_extractor",
         ),
+        // 9. ipc_extractor
+        (
+            Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+                ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(BlockTip {
+                    height: 0,
+                    hash: vec![0u8; 32],
+                })),
+            }))
+            .unwrap(),
+            "ipc_extractor",
+        ),
     ];
 
     // Compile-time check: if a new PeerObserverEvent variant is added,
@@ -193,6 +206,7 @@ fn make_all_event_types() -> Vec<(Event, &'static str)> {
         PeerObserverEvent::RpcExtractor(_) => (),
         PeerObserverEvent::P2pExtractor(_) => (),
         PeerObserverEvent::LogExtractor(_) => (),
+        PeerObserverEvent::IpcExtractor(_) => (),
     }
 
     events
@@ -220,6 +234,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
             "rpc" => args.rpc = true,
             "p2p_extractor" => args.p2p_extractor = true,
             "log_extractor" => args.log_extractor = true,
+            "ipc_extractor" => args.ipc_extractor = true,
             _ => {} // archive_all
         }
         archiver::run(args, shutdown_rx).await.unwrap();
@@ -269,7 +284,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
 
 #[tokio::test]
 async fn test_filter_all() {
-    run_filter_test("all", 7).await;
+    run_filter_test("all", 8).await;
 }
 
 #[tokio::test]
@@ -305,6 +320,11 @@ async fn test_filter_p2p_extractor() {
 #[tokio::test]
 async fn test_filter_log_extractor() {
     run_filter_test("log_extractor", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_ipc() {
+    run_filter_test("ipc_extractor", 1).await;
 }
 
 #[tokio::test]
@@ -400,7 +420,7 @@ async fn test_file_rotation_with_compression() {
     println!("total events:  {}", total_events);
     println!("===================================\n");
 
-    assert_eq!(total_events, 7);
+    assert_eq!(total_events, 8);
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }

--- a/tools/logger/README.md
+++ b/tools/logger/README.md
@@ -79,6 +79,8 @@ Options:
           If passed, show validation events
       --rpc
           If passed, show RPC events
+      --ipc
+          If passed, show IPC events
       --p2p-extractor
           If passed, show p2p-extractor events
       --log-extractor

--- a/tools/logger/src/lib.rs
+++ b/tools/logger/src/lib.rs
@@ -56,6 +56,10 @@ pub struct Args {
     #[arg(long)]
     pub rpc: bool,
 
+    /// If passed, show IPC events
+    #[arg(long)]
+    pub ipc: bool,
+
     /// If passed, show p2p-extractor events
     #[arg(long)]
     pub p2p_extractor: bool,
@@ -72,6 +76,7 @@ impl Args {
             || self.mempool
             || self.validation
             || self.rpc
+            || self.ipc
             || self.p2p_extractor
             || self.log_extractor)
     }
@@ -85,6 +90,7 @@ impl Args {
         mempool: bool,
         validation: bool,
         rpc: bool,
+        ipc: bool,
         p2p_extractor: bool,
         log_extractor: bool,
     ) -> Self {
@@ -96,6 +102,7 @@ impl Args {
             mempool,
             validation,
             rpc,
+            ipc,
             p2p_extractor,
             log_extractor,
         }
@@ -112,6 +119,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         log::info!("logging mempool events:       {}", args.mempool);
         log::info!("logging validation events:    {}", args.validation);
         log::info!("logging rpc events:           {}", args.rpc);
+        log::info!("logging ipc events:           {}", args.ipc);
         log::info!("logging p2p_extractor events: {}", args.p2p_extractor);
         log::info!("logging log_extractor events: {}", args.log_extractor);
     }
@@ -181,6 +189,11 @@ fn log_event(event: Event, args: Args) {
         PeerObserverEvent::RpcExtractor(r) => {
             if log_all || args.rpc {
                 log::info!("rpc: {}", r.rpc_event.unwrap());
+            }
+        }
+        PeerObserverEvent::IpcExtractor(i) => {
+            if log_all || args.ipc {
+                log::info!("ipc: {}", i.ipc_event.unwrap());
             }
         }
         PeerObserverEvent::P2pExtractor(p) => {

--- a/tools/logger/tests/integration.rs
+++ b/tools/logger/tests/integration.rs
@@ -17,6 +17,7 @@ use shared::{
             Ebpf,
         },
         event::{event::PeerObserverEvent, Event},
+        ipc_extractor::{self, BlockTip},
         log_extractor::{self, LogDebugCategory},
         p2p_extractor,
         rpc_extractor::{self, PeerInfo, PeerInfos},
@@ -75,6 +76,7 @@ fn make_test_args(
     rpc: bool,
     p2p_extractor: bool,
     log_extractor: bool,
+    ipc_extractor: bool,
 ) -> Args {
     Args::new(
         nats_util::NatsArgs {
@@ -91,6 +93,7 @@ fn make_test_args(
         rpc,
         p2p_extractor,
         log_extractor,
+        ipc_extractor,
     )
 }
 
@@ -120,7 +123,17 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let logger_handle = tokio::spawn(async move {
-        let args = make_test_args(nats_server.port, true, true, true, true, true, true, true);
+        let args = make_test_args(
+            nats_server.port,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+        );
         logger::run(args, shutdown_rx.clone()).await.unwrap();
     });
     // allow the logger tool to start
@@ -163,7 +176,7 @@ async fn test_integration_logger_fail_if_no_nats() {
     let logger_handle = tokio::spawn(async move {
         let args = make_test_args(
             65535, // There shouln't be a NATS server running on this port..
-            true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true,
         );
         match logger::run(args, shutdown_rx.clone()).await {
             Ok(_) => panic!("We should fail when no NATS server is reachable."),
@@ -445,6 +458,28 @@ async fn test_integration_logger_rpc_peerinfo() {
         Subject::Rpc,
         r#"
         rpc: PeerInfos([PeerInfo(id=1), PeerInfo(id=2), PeerInfo(id=2)])
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_logger_ipc_mining_get_tip() {
+    println!("test that IPC events are logged");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+                ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(BlockTip {
+                    height: 111,
+                    hash: ([0xff; 32]).to_vec(),
+                })),
+            }))
+            .unwrap(),
+        ],
+        Subject::Ipc,
+        r#"
+        ipc: BlockTip(height=111, hash=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
         "#,
     )
     .await;

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -19,6 +19,7 @@ use shared::protobuf::{
         validation::validation_event,
     },
     event::{event::PeerObserverEvent, Event},
+    ipc_extractor,
     log_extractor::{log, Log, LogDebugCategory, LogLevel},
     p2p_extractor::p2p,
     rpc_extractor::{rpc, Addrman, AddrmanBucket, FeeEstimateMode},
@@ -164,6 +165,11 @@ fn handle_event(
             }
             PeerObserverEvent::LogExtractor(l) => {
                 handle_log_event(&l, metrics);
+            }
+            PeerObserverEvent::IpcExtractor(ipc) => {
+                if let Some(e) = ipc.ipc_event {
+                    handle_ipc_event(&e, metrics);
+                }
             }
         }
     }
@@ -1462,6 +1468,14 @@ fn handle_log_event(log: &Log, metrics: metrics::Metrics) {
                     .with_label_values(&[&block.state])
                     .inc();
             }
+        }
+    }
+}
+
+fn handle_ipc_event(e: &ipc_extractor::ipc::IpcEvent, metrics: metrics::Metrics) {
+    match e {
+        ipc_extractor::ipc::IpcEvent::BlockTip(tip) => {
+            metrics.ipc_block_tip_height.set(tip.height as i64);
         }
     }
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -232,6 +232,9 @@ pub struct Metrics {
     pub validation_block_connected_latest_transactions: IntGauge,
     pub validation_block_connected_connection_time: IntCounter,
 
+    // IPC-extractor
+    pub ipc_block_tip_height: IntGauge,
+
     // RPC-extractor
     // getpeeinfo
     pub rpc_peer_info_list_peers_gmax_ban: IntGauge,
@@ -447,6 +450,9 @@ impl Metrics {
         ig!(validation_block_connected_latest_transactions, "Last connected block transactions.", registry);
         ic!(validation_block_connected_connection_time, "Last connected block connection time in µs", registry);
 
+        // IPC-extractor
+        ig!(ipc_block_tip_height, "Tip height from IPC extractor.", registry);
+
         // RPC-extractor
         // getpeerinfo
         ig!(rpc_peer_info_list_peers_gmax_ban, "Number of peers connected to us that are on the 2018 ban list by gmax.", registry);
@@ -658,6 +664,9 @@ impl Metrics {
             validation_block_connected_latest_inputs,
             validation_block_connected_latest_transactions,
             validation_block_connected_connection_time,
+
+            // IPC-extractor
+            ipc_block_tip_height,
 
             // RPC-extractor
             // getpeerinfo

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -25,6 +25,7 @@ use shared::{
             Ebpf,
         },
         event::{event::PeerObserverEvent, Event},
+        ipc_extractor,
         log_extractor::{self, LogDebugCategory},
         p2p_extractor,
         rpc_extractor::{
@@ -3764,6 +3765,30 @@ async fn test_integration_metrics_rpc_estimatesmartfee() {
         r#"
             peerobserver_rpc_estimatesmartfee_feerate{mode="CONSERVATIVE",target_block="6"} 0.777
             peerobserver_rpc_estimatesmartfee_feerate{mode="ECONOMICAL",target_block="144"} 1.08
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_ipc_block_tip() {
+    println!("test that the IPC block tip metric works");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+                ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(
+                    ipc_extractor::BlockTip {
+                        height: 867530,
+                        hash: vec![0x00, 0x01, 0x02, 0x03],
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::Ipc,
+        r#"
+        peerobserver_ipc_block_tip_height 867530
         "#,
     )
     .await;

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -44,6 +44,9 @@ fn main() {
                         Some(PeerObserverEvent::LogExtractor(l)) => {
                             println!("[{n}] ts={ts} log: {}", l.log_event.as_ref().unwrap())
                         }
+                        Some(PeerObserverEvent::IpcExtractor(i)) => {
+                            println!("[{n}] ts={ts} ipc: {}", i.ipc_event.as_ref().unwrap())
+                        }
                         None => println!("[{n}] ts={ts} <unknown>"),
                     }
                 }

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -71,6 +71,7 @@ pub struct ClientSubscriptions {
     pub p2p: bool,
     pub log: bool,
     pub rpc: bool,
+    pub ipc: bool,
 }
 
 struct Client {
@@ -254,6 +255,7 @@ async fn broadcast_to_clients(event: &PeerObserverEvent, clients: &Clients) {
             PeerObserverEvent::RpcExtractor(_) => client.subscriptions.rpc,
             PeerObserverEvent::P2pExtractor(_) => client.subscriptions.p2p,
             PeerObserverEvent::LogExtractor(_) => client.subscriptions.log,
+            PeerObserverEvent::IpcExtractor(_) => client.subscriptions.ipc,
         };
 
         if !is_subscribed {

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -41,6 +41,7 @@ const SUBSCRIBE_NONE: ClientSubscriptions = ClientSubscriptions {
     p2p: false,
     log: false,
     rpc: false,
+    ipc: false,
 };
 
 const SUBSCRIBE_ALL: ClientSubscriptions = ClientSubscriptions {
@@ -53,6 +54,7 @@ const SUBSCRIBE_ALL: ClientSubscriptions = ClientSubscriptions {
     p2p: true,
     log: true,
     rpc: true,
+    ipc: true,
 };
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description

This PR introduces an experimental IPC extractor, designed to interface with a [Core v31.0](https://github.com/bitcoin/bitcoin/tree/v31.0) `bitcoin-node` process over a Unix Socket (generated by passing `-ipcbind=unix`) and Cap 'n Proto. 

## Context

Bitcoin Core has an on-going [Process Separation](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Process-Separation) project, which aims to split `bitcoind` into smaller and manageable processes that communicate together through Unix Sockets. Within this architecture, `bitcoin-node` ([introduced in Core 30.0](https://bitcoincore.org/en/releases/30.0/#install-changes)) exposes multiple interfaces that external processes can consume by leveraging Cap 'n Proto RPC system.

As `bitcoin-node` keeps expanding its interfaces (e.g bitcoin/bitcoin#29409 adds a wrapper for the Chain interface), this extractor will facilitate reviewing and testing on IPC-related PRs in Core.

## Key changes

- Add new binary crate `ipc-extractor`.
- Add new Github Action for verifying and installing `bitcoin-node` (for Ubuntu tests).
- Vendor `.capnp` files from [Bitcoin Core v31.0](https://github.com/bitcoin/bitcoin/tree/v31.0).
- Add new dependencies to integrate Cap 'n Proto (`capnpc`, `capnp-rpc` and `capnp`).
- Add Protocol Buffer schema and NATS subject for IPC events.
- Update tools to enable inspecting IPC events.
- Update `README.md` with documentation for the new extractor.

## How to use

1. Download and compile the code at https://github.com/bitcoin/bitcoin/tree/v31.0
2. Launch a `bitcoin-node` process: `./build/bin/bitcoin-node -regtest -ipcbind=unix OR ./build/bin/bitcoin -m node -regtest -ipcbind=unix`
3. Start the NATS server: `nats-server`
4. Run the logger tool: `cargo run --bin logger -- --ipc`
5. Run the extractor: `cargo run --bin ipc-extractor -- --ipc-socket-path="path/to/node.sock"`
6. Observe `BlockTip(height=404, hash=...)` events being published to NATS.
<img width="2924" height="866" alt="image" src="https://github.com/user-attachments/assets/0dc48018-af4a-40ff-924f-12600203e1c8" />


Closes #370 