### PR TITLE
Alerts tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "alerts"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
   "tools/connectivity-check",
   "tools/archiver",
   "tools/replayer",
+  "tools/alerts",
 ]

--- a/tools/alerts/Cargo.toml
+++ b/tools/alerts/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "alerts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+shared = { path = "../../shared" }
+
+[features]
+# Treat warnings as a build error.
+strict = []
+# Run integration tests needing a NATS server.
+nats_integration_tests = []

--- a/tools/alerts/README.md
+++ b/tools/alerts/README.md
@@ -1,0 +1,100 @@
+# alerts
+
+A peer-observer tool that subscribes to NATS events and emits alerts when anomalous
+peer behavior is detected.
+
+## Heuristics
+
+### PingSpammer
+
+Detects peers that send more than `--ping-threshold` inbound `ping` messages within a
+`--ping-window-secs` second sliding window.
+
+Alert format (as rendered by `LoggingAlerter`):
+```
+PingSpammer | peer_id=<id> addr=<addr> | <count> pings in last <secs>s (threshold: <threshold>)
+```
+
+### AddrSpammer
+
+Detects peers that send more than `--addr-threshold` inbound `addr` or `addrv2` messages
+within an `--addr-window-secs` second sliding window. Both message types are counted in
+the same window.
+
+Alert format (as rendered by `LoggingAlerter`):
+```
+AddrSpammer | peer_id=<id> addr=<addr> | <count> addr/addrv2 messages in last <secs>s (threshold: <threshold>)
+```
+
+Each peer/kind combination fires at most one alert per session (one-shot).
+
+## Peer lifecycle
+
+When a previously flagged peer disconnects (either via a `ConnectionEvent::Close`
+or by being evicted after `--peer-stale-secs` of inactivity), the same `Alerter`
+emits a `PeerDisconnected` alert with the duration of the spamming episode:
+
+```
+PeerDisconnected | peer_id=<id> addr=<addr> | active=<duration>s
+```
+
+Non-flagged peers disconnect silently (no alert is emitted).
+
+## Usage
+
+```
+cargo run -p alerts -- [OPTIONS]
+```
+
+## Options
+
+```
+Arguments for the connection the the NATS server that each extractor and tool needs
+
+Usage: alerts [OPTIONS]
+
+Options:
+  -a, --nats-address <ADDRESS>
+          The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
+  -u, --nats-username <USERNAME>
+          The NATS username the extractor/tool should try to authentificate to the NATS server with
+  -p, --nats-password <PASSWORD>
+          The NATS password the extractor/tool should try to authentificate to the NATS server with
+  -f, --nats-password-file <PASSWORD_FILE>
+          A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
+      --ping-threshold <PING_THRESHOLD>
+          Number of pings in the window before alerting [default: 3]
+      --ping-window-secs <PING_WINDOW_SECS>
+          Sliding window size for ping detection (seconds) [default: 120]
+      --addr-threshold <ADDR_THRESHOLD>
+          Number of addr/addrv2 messages in the window before alerting [default: 6]
+      --addr-window-secs <ADDR_WINDOW_SECS>
+          Sliding window size for addr detection (seconds) [default: 60]
+  -l, --log-level <LOG_LEVEL>
+          [default: DEBUG]
+      --peer-stale-secs <PEER_STALE_SECS>
+          Remove peers not seen for this many seconds (prevents OOM on missed Close events) [default: 300]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```
+
+## Example
+
+```bash
+# Use low thresholds for testing
+cargo run -p alerts -- \
+  --nats-address nats://localhost:4222 \
+  --ping-threshold 3 \
+  --ping-window-secs 30 \
+  --addr-threshold 2 \
+  --addr-window-secs 60
+```
+
+Example output:
+```
+INFO  [alerts::alerter] PingSpammer | peer_id=42 addr=1.2.3.4:8333 | 4 pings in last 30s (threshold: 3)
+INFO  [alerts::alerter] AddrSpammer | peer_id=7 addr=5.6.7.8:8333 | 3 addr/addrv2 messages in last 60s (threshold: 2)
+INFO  [alerts::alerter] PeerDisconnected | peer_id=42 addr=1.2.3.4:8333 | active=47s
+```

--- a/tools/alerts/src/alerter.rs
+++ b/tools/alerts/src/alerter.rs
@@ -1,0 +1,101 @@
+use shared::log;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SpammerKind {
+    Ping,
+    Addr,
+}
+
+/// Every observation the alerts tool publishes flows through this enum
+/// `Spammer` is emitted when a peer crosses a configured threshold once
+/// `PeerDisconnected` is emitted when a previously-flagged peer disconnects
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Alert {
+    Spammer {
+        kind: SpammerKind,
+        peer_id: u64,
+        addr: String,
+        count: usize,
+        window_secs: u64,
+        threshold: usize,
+    },
+    PeerDisconnected {
+        peer_id: u64,
+        addr: String,
+        active_secs: u64,
+    },
+}
+
+impl std::fmt::Display for Alert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Alert::Spammer {
+                kind,
+                peer_id,
+                addr,
+                count,
+                window_secs,
+                threshold,
+            } => {
+                let (name, unit) = match kind {
+                    SpammerKind::Ping => ("PingSpammer", "pings"),
+                    SpammerKind::Addr => ("AddrSpammer", "addr/addrv2 messages"),
+                };
+                write!(
+                    f,
+                    "{} | peer_id={} addr={} | {} {} in last {}s (threshold: {})",
+                    name, peer_id, addr, count, unit, window_secs, threshold
+                )
+            }
+            Alert::PeerDisconnected {
+                peer_id,
+                addr,
+                active_secs,
+            } => write!(
+                f,
+                "PeerDisconnected | peer_id={} addr={} | active={}s",
+                peer_id, addr, active_secs
+            ),
+        }
+    }
+}
+
+/// Output sink for alerts. Implementations decide how alerts are published
+///
+/// `emit` is called from the event loop and must not block. Sinks that do I/O
+/// (HTTP, NATS publish, Prometheus push, etc.) must own a background task and
+/// hand off the alert through a channel — do the network work there, not here
+pub trait Alerter: Send + Sync {
+    fn emit(&self, alert: Alert);
+}
+
+/// Default alerter: writes each alert to the logger at `info!` level
+pub struct LoggingAlerter;
+
+impl Alerter for LoggingAlerter {
+    fn emit(&self, alert: Alert) {
+        log::info!("{}", alert);
+    }
+}
+
+/// Alerter that pushes each emitted alert through an mpsc channel
+/// Lets tests assert on structured alerts instead of parsing log output
+#[cfg(any(test, feature = "nats_integration_tests"))]
+pub struct IntegrationTestAlerter {
+    tx: shared::tokio::sync::mpsc::UnboundedSender<Alert>,
+}
+
+#[cfg(any(test, feature = "nats_integration_tests"))]
+impl IntegrationTestAlerter {
+    pub fn new() -> (Self, shared::tokio::sync::mpsc::UnboundedReceiver<Alert>) {
+        let (tx, rx) = shared::tokio::sync::mpsc::unbounded_channel();
+        (Self { tx }, rx)
+    }
+}
+
+#[cfg(any(test, feature = "nats_integration_tests"))]
+impl Alerter for IntegrationTestAlerter {
+    fn emit(&self, alert: Alert) {
+        let _ = self.tx.send(alert);
+    }
+}

--- a/tools/alerts/src/error.rs
+++ b/tools/alerts/src/error.rs
@@ -1,0 +1,50 @@
+use shared::async_nats;
+use shared::async_nats::ConnectError;
+use std::error;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    NatsSubscribe(async_nats::client::SubscribeError),
+    NatsConnect(ConnectError),
+    Io(io::Error),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::NatsSubscribe(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<async_nats::client::SubscribeError> for RuntimeError {
+    fn from(e: async_nats::client::SubscribeError) -> Self {
+        RuntimeError::NatsSubscribe(e)
+    }
+}
+
+impl From<ConnectError> for RuntimeError {
+    fn from(e: ConnectError) -> Self {
+        RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}

--- a/tools/alerts/src/lib.rs
+++ b/tools/alerts/src/lib.rs
@@ -1,0 +1,470 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
+use shared::clap;
+use shared::clap::Parser;
+use shared::futures::stream::StreamExt;
+use shared::log;
+use shared::nats_subjects::Subject;
+use shared::nats_util;
+use shared::nats_util::NatsArgs;
+use shared::prost::Message;
+use shared::protobuf::ebpf_extractor::connection::connection_event;
+use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::ebpf_extractor::message::message_event::Msg;
+use shared::protobuf::event::Event;
+use shared::tokio::sync::watch;
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use crate::error::RuntimeError;
+
+pub mod alerter;
+pub mod error;
+
+pub use crate::alerter::{Alert, Alerter, LoggingAlerter, SpammerKind};
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Arguments for the connection to the NATS server
+    #[command(flatten)]
+    pub nats: NatsArgs,
+
+    /// Number of pings in the window before alerting
+    #[arg(long, default_value_t = 3)]
+    pub ping_threshold: usize,
+
+    /// Sliding window size for ping detection (seconds)
+    #[arg(long, default_value_t = 120)]
+    pub ping_window_secs: u64,
+
+    /// Number of addr/addrv2 messages in the window before alerting
+    #[arg(long, default_value_t = 6)]
+    pub addr_threshold: usize,
+
+    /// Sliding window size for addr detection (seconds)
+    #[arg(long, default_value_t = 60)]
+    pub addr_window_secs: u64,
+
+    #[arg(short, long, default_value_t = shared::log::Level::Debug)]
+    pub log_level: shared::log::Level,
+
+    /// Remove peers not seen for this many seconds (prevents OOM on missed Close events)
+    #[arg(long, default_value_t = 300)]
+    pub peer_stale_secs: u64,
+}
+
+#[derive(Default)]
+struct AlertTypeState {
+    timestamps: VecDeque<Instant>,
+    alerted_at: Option<Instant>,
+}
+
+struct PeerState {
+    ping: AlertTypeState,
+    addr: AlertTypeState,
+    last_seen: Instant,
+    peer_addr: String,
+}
+
+impl PeerState {
+    fn new(peer_addr: String, now: Instant) -> Self {
+        PeerState {
+            ping: AlertTypeState::default(),
+            addr: AlertTypeState::default(),
+            last_seen: now,
+            peer_addr,
+        }
+    }
+
+    /// Records a hit for `kind` and returns an `Alert` the first time the
+    /// threshold is exceeded. After alerting once, subsequent hits are dropped
+    /// and the function returns `None` without growing the sliding window
+    fn check(
+        &mut self,
+        kind: SpammerKind,
+        peer_id: u64,
+        now: Instant,
+        args: &Args,
+    ) -> Option<Alert> {
+        let (state, window_secs, threshold) = match kind {
+            SpammerKind::Ping => (&mut self.ping, args.ping_window_secs, args.ping_threshold),
+            SpammerKind::Addr => (&mut self.addr, args.addr_window_secs, args.addr_threshold),
+        };
+
+        if state.alerted_at.is_some() {
+            return None;
+        }
+
+        state.timestamps.push_back(now);
+        let window = Duration::from_secs(window_secs);
+        while state
+            .timestamps
+            .front()
+            .is_some_and(|t| now.duration_since(*t) > window)
+        {
+            state.timestamps.pop_front();
+        }
+        if state.timestamps.len() <= threshold {
+            return None;
+        }
+        let count = state.timestamps.len();
+        state.alerted_at = Some(now);
+
+        Some(Alert::Spammer {
+            kind,
+            peer_id,
+            addr: self.peer_addr.clone(),
+            count,
+            window_secs,
+            threshold,
+        })
+    }
+}
+
+struct AlertState {
+    peers: HashMap<u64, PeerState>,
+}
+
+impl AlertState {
+    fn new() -> Self {
+        AlertState {
+            peers: HashMap::new(),
+        }
+    }
+}
+
+/// Builds a `PeerDisconnected` alert for peers that were previously flagged as
+/// spammers, including how long they were active. Returns `None` for peers
+/// that were never flagged so non-flagged disconnects stay silent
+fn disconnect_alert(peer_id: u64, peer: &PeerState, now: Instant) -> Option<Alert> {
+    let first_alerted = [peer.ping.alerted_at, peer.addr.alerted_at]
+        .into_iter()
+        .flatten()
+        .min()?;
+    Some(Alert::PeerDisconnected {
+        peer_id,
+        addr: peer.peer_addr.clone(),
+        active_secs: now.duration_since(first_alerted).as_secs(),
+    })
+}
+
+/// Removes peers that haven't sent any message in `stale_after`
+/// Emits a `PeerDisconnected` alert for any flagged peers evicted this way
+fn cleanup_stale_peers(
+    state: &mut AlertState,
+    stale_after: Duration,
+    now: Instant,
+    alerter: &impl Alerter,
+) {
+    let stale: Vec<u64> = state
+        .peers
+        .iter()
+        .filter(|(_, p)| now.duration_since(p.last_seen) > stale_after)
+        .map(|(id, _)| *id)
+        .collect();
+    for peer_id in stale {
+        if let Some(peer) = state.peers.remove(&peer_id) {
+            if let Some(alert) = disconnect_alert(peer_id, &peer, now) {
+                alerter.emit(alert);
+            }
+        }
+    }
+}
+
+/// Connects to NATS, subscribes to all subjects, and dispatches each
+/// received event to `handle_event`. Alerts are emitted through `alerter`
+pub async fn run<A: Alerter>(
+    args: Args,
+    alerter: A,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Result<(), RuntimeError> {
+    log::info!("starting alerts with {:?}", args);
+
+    let nc = nats_util::prepare_connection(&args.nats)?
+        .connect(&args.nats.address)
+        .await?;
+
+    let netmsg_sub = nc.subscribe(Subject::NetMsg.to_string()).await?;
+    let netconn_sub = nc.subscribe(Subject::NetConn.to_string()).await?;
+    let mut sub = shared::futures::stream::select(netmsg_sub, netconn_sub);
+    log::info!("Connected to NATS-server at {}", args.nats.address);
+
+    let mut state = AlertState::new();
+
+    let stale_after = Duration::from_secs(args.peer_stale_secs);
+    let mut cleanup_interval = shared::tokio::time::interval(stale_after);
+    cleanup_interval.tick().await;
+
+    loop {
+        shared::tokio::select! {
+            maybe_msg = sub.next() => {
+                match maybe_msg {
+                    Some(msg) => match Event::decode(msg.payload) {
+                        Ok(event) => handle_event(event, &mut state, &args, &alerter),
+                        Err(e) => log::warn!("dropping undecodable NATS payload: {e}"),
+                    },
+                    None => break,
+                }
+            }
+            _ = cleanup_interval.tick() => {
+                cleanup_stale_peers(&mut state, stale_after, Instant::now(), &alerter);
+            }
+            res = shutdown_rx.changed() => {
+                match res {
+                    Ok(_) => {
+                        if *shutdown_rx.borrow() {
+                            log::info!("alerts tool received shutdown signal.");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Routes a NATS event to the appropriate handler
+fn handle_event(event: Event, state: &mut AlertState, args: &Args, alerter: &impl Alerter) {
+    let now = Instant::now();
+    if let Some(shared::protobuf::event::event::PeerObserverEvent::EbpfExtractor(ebpf)) =
+        event.peer_observer_event
+    {
+        match ebpf.ebpf_event {
+            Some(ebpf::EbpfEvent::Message(msg)) => handle_message(msg, state, args, alerter, now),
+            Some(ebpf::EbpfEvent::Connection(conn)) => handle_connection(conn, state, now, alerter),
+            _ => {}
+        }
+    }
+}
+
+/// Processes an inbound P2P message. Drops outbound messages and dispatches
+/// to ping or addr spammer detection based on the message type
+fn handle_message(
+    msg: shared::protobuf::ebpf_extractor::message::MessageEvent,
+    state: &mut AlertState,
+    args: &Args,
+    alerter: &impl Alerter,
+    now: Instant,
+) {
+    if !msg.meta.inbound {
+        return;
+    }
+
+    let peer_id = msg.meta.peer_id;
+    let addr = &msg.meta.addr;
+
+    let peer = state
+        .peers
+        .entry(peer_id)
+        .or_insert_with(|| PeerState::new(addr.clone(), now));
+    peer.last_seen = now;
+
+    let kind = match msg.msg {
+        Some(Msg::Ping(_)) => SpammerKind::Ping,
+        Some(Msg::Addr(_)) | Some(Msg::Addrv2(_)) => SpammerKind::Addr,
+        _ => return,
+    };
+
+    if let Some(alert) = peer.check(kind, peer_id, now, args) {
+        alerter.emit(alert);
+    }
+}
+
+/// Cleans up peer state when a connection closes and emits a
+/// `PeerDisconnected` alert if the peer was previously flagged
+fn handle_connection(
+    conn: shared::protobuf::ebpf_extractor::connection::ConnectionEvent,
+    state: &mut AlertState,
+    now: Instant,
+    alerter: &impl Alerter,
+) {
+    if let Some(connection_event::Event::Closed(c)) = conn.event {
+        let peer_id = c.conn.peer_id;
+        if let Some(peer) = state.peers.remove(&peer_id) {
+            if let Some(alert) = disconnect_alert(peer_id, &peer, now) {
+                alerter.emit(alert);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_args(ping_threshold: usize, addr_threshold: usize, window_secs: u64) -> Args {
+        Args {
+            nats: NatsArgs {
+                address: "127.0.0.1:4222".to_string(),
+                username: None,
+                password: None,
+                password_file: None,
+            },
+            ping_threshold,
+            ping_window_secs: window_secs,
+            addr_threshold,
+            addr_window_secs: window_secs,
+            log_level: shared::log::Level::Trace,
+            peer_stale_secs: 300,
+        }
+    }
+
+    fn make_peer(now: Instant) -> PeerState {
+        PeerState::new("1.2.3.4:8333".to_string(), now)
+    }
+
+    fn unwrap_spammer(alert: Alert) -> (SpammerKind, u64, usize, u64, usize) {
+        match alert {
+            Alert::Spammer {
+                kind,
+                peer_id,
+                count,
+                window_secs,
+                threshold,
+                ..
+            } => (kind, peer_id, count, window_secs, threshold),
+            other => panic!("expected Alert::Spammer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn below_threshold_no_alert() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // threshold=3 means "more than 3"; 3 hits must not fire
+        for i in 0..3 {
+            let now = t0 + Duration::from_millis(i);
+            assert!(peer.check(SpammerKind::Ping, 1, now, &args).is_none());
+        }
+    }
+
+    #[test]
+    fn above_threshold_fires_once() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        for i in 0..3 {
+            peer.check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args);
+        }
+        let alert = peer
+            .check(SpammerKind::Ping, 1, t0 + Duration::from_millis(4), &args)
+            .expect("4th hit over threshold=3 must emit an alert");
+        let (kind, peer_id, count, _, threshold) = unwrap_spammer(alert);
+        assert_eq!(kind, SpammerKind::Ping);
+        assert_eq!(peer_id, 1);
+        assert_eq!(count, 4);
+        assert_eq!(threshold, 3);
+    }
+
+    #[test]
+    fn one_shot_no_retrigger() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // Cross the threshold
+        for i in 0..4 {
+            peer.check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args);
+        }
+        assert!(peer.ping.alerted_at.is_some());
+        let len_at_alert = peer.ping.timestamps.len();
+
+        // 10 more hits — none should alert, and the deque must not grow
+        for i in 4..14 {
+            assert!(peer
+                .check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args)
+                .is_none());
+        }
+        assert_eq!(
+            peer.ping.timestamps.len(),
+            len_at_alert,
+            "deque must not grow after the one-shot alert fires"
+        );
+    }
+
+    #[test]
+    fn out_of_window_hits_dropped() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // Two hits at t0
+        peer.check(SpammerKind::Ping, 1, t0, &args);
+        peer.check(SpammerKind::Ping, 1, t0 + Duration::from_secs(1), &args);
+
+        // Advance past the window (60s) so the first two fall out
+        let later = t0 + Duration::from_secs(90);
+        for i in 0..3 {
+            assert!(peer
+                .check(
+                    SpammerKind::Ping,
+                    1,
+                    later + Duration::from_millis(i),
+                    &args
+                )
+                .is_none());
+        }
+        assert_eq!(
+            peer.ping.timestamps.len(),
+            3,
+            "only the 3 recent hits should remain in the sliding window"
+        );
+    }
+
+    #[test]
+    fn separate_counters_per_kind() {
+        let args = test_args(3, 10, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // 4 addr messages — below addr_threshold=10 — must not alert
+        for i in 0..4 {
+            assert!(peer
+                .check(SpammerKind::Addr, 1, t0 + Duration::from_millis(i), &args)
+                .is_none());
+        }
+
+        // 4 pings — above ping_threshold=3 — the 4th one must alert
+        let mut ping_alerted = false;
+        for i in 1..=4 {
+            if peer
+                .check(SpammerKind::Ping, 1, t0 + Duration::from_secs(i), &args)
+                .is_some()
+            {
+                ping_alerted = true;
+            }
+        }
+        assert!(ping_alerted, "4 pings with threshold=3 must alert");
+
+        // Addr counter must still not have fired
+        assert!(peer.addr.alerted_at.is_none());
+    }
+
+    #[test]
+    fn addr_alert_carries_addr_window_fields() {
+        let args = test_args(100, 2, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        for i in 0..2 {
+            peer.check(SpammerKind::Addr, 7, t0 + Duration::from_millis(i), &args);
+        }
+        let alert = peer
+            .check(SpammerKind::Addr, 7, t0 + Duration::from_millis(3), &args)
+            .expect("3rd hit with addr_threshold=2 must alert");
+        let (kind, _, count, window_secs, threshold) = unwrap_spammer(alert);
+        assert_eq!(kind, SpammerKind::Addr);
+        assert_eq!(window_secs, args.addr_window_secs);
+        assert_eq!(threshold, args.addr_threshold);
+        assert_eq!(count, 3);
+    }
+}

--- a/tools/alerts/src/main.rs
+++ b/tools/alerts/src/main.rs
@@ -1,0 +1,29 @@
+use alerts::{Args, LoggingAlerter};
+use shared::log;
+use shared::tokio::{self, signal, sync::watch};
+use shared::{clap::Parser, simple_logger};
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("alerts tool error: {}", e);
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let alerts_handle = tokio::spawn(alerts::run(args, LoggingAlerter, shutdown_rx));
+
+    tokio::select! {
+        _ = signal::ctrl_c() => {
+            log::info!("Received Ctrl+C. Stopping...");
+            let _ = shutdown_tx.send(true);
+        }
+        result = alerts_handle => {
+            match result.unwrap() {
+                Ok(_) => log::info!("alerts task completed."),
+                Err(e) => log::error!("alerts task failed: {e}"),
+            }
+        }
+    }
+}

--- a/tools/alerts/tests/integration.rs
+++ b/tools/alerts/tests/integration.rs
@@ -1,0 +1,498 @@
+#![cfg(feature = "nats_integration_tests")]
+
+use alerts::{alerter::IntegrationTestAlerter, error::RuntimeError, Alert, Args, SpammerKind};
+
+use shared::{
+    log,
+    nats_subjects::Subject,
+    nats_util,
+    prost::Message,
+    protobuf::{
+        ebpf_extractor::{
+            connection::{self, ClosedConnection, Connection, ConnectionEvent},
+            ebpf,
+            message::{self, message_event::Msg, Addr, AddrV2, Metadata, Ping},
+            Ebpf,
+        },
+        event::{event::PeerObserverEvent, Event},
+    },
+    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
+    tokio::{
+        self,
+        sync::{mpsc::UnboundedReceiver, watch},
+        time::{sleep, timeout},
+    },
+};
+
+use std::time::Duration;
+
+/// Builds an `Args` instance pointing at the given NATS server
+fn make_test_args(
+    nats_port: u16,
+    ping_threshold: usize,
+    ping_window_secs: u64,
+    addr_threshold: usize,
+    addr_window_secs: u64,
+    peer_stale_secs: u64,
+) -> Args {
+    Args {
+        nats: nats_util::NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        ping_threshold,
+        ping_window_secs,
+        addr_threshold,
+        addr_window_secs,
+        log_level: log::Level::Trace,
+        peer_stale_secs,
+    }
+}
+
+/// Waits up to `d` for the next alert; panics if none arrives
+async fn recv_alert(rx: &mut UnboundedReceiver<Alert>, d: Duration) -> Alert {
+    timeout(d, rx.recv())
+        .await
+        .expect("timed out waiting for alert")
+        .expect("alerter channel closed unexpectedly")
+}
+
+/// Returns true iff no alert arrives within `d`
+async fn expect_no_alert(rx: &mut UnboundedReceiver<Alert>, d: Duration) -> bool {
+    timeout(d, rx.recv()).await.is_err()
+}
+
+/// Destructures `Alert::Spammer` for assertions; panics on any other variant
+fn unwrap_spammer(alert: Alert) -> (SpammerKind, u64, usize, usize) {
+    match alert {
+        Alert::Spammer {
+            kind,
+            peer_id,
+            count,
+            threshold,
+            ..
+        } => (kind, peer_id, count, threshold),
+        other => panic!("expected Alert::Spammer, got {other:?}"),
+    }
+}
+
+/// Publishes the same protobuf event `n` times on the given NATS subject
+async fn publish_n(publisher: &NatsPublisherForTesting, subject: &str, event: &Event, n: usize) {
+    let payload = event.encode_to_vec();
+    for _ in 0..n {
+        publisher
+            .publish(subject.to_string(), payload.clone())
+            .await;
+    }
+}
+
+/// Constructs a protobuf `Event` wrapping a `Ping` message for the given peer
+/// `inbound` controls whether the message appears as received from the peer
+fn make_ping_event(peer_id: u64, addr: &str, inbound: bool) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "ping".to_string(),
+                inbound,
+                size: 8,
+            },
+            msg: Some(Msg::Ping(Ping { value: 42 })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Constructs an inbound `Addr` message event for the given peer
+fn make_addr_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "addr".to_string(),
+                inbound: true,
+                size: 30,
+            },
+            msg: Some(Msg::Addr(Addr { addresses: vec![] })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Constructs an inbound `AddrV2` message event for the given peer
+fn make_addrv2_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "addrv2".to_string(),
+                inbound: true,
+                size: 30,
+            },
+            msg: Some(Msg::Addrv2(AddrV2 { addresses: vec![] })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Builds a ClosedConnection event for the given peer/addr
+fn make_closed_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Connection(ConnectionEvent {
+            event: Some(connection::connection_event::Event::Closed(
+                ClosedConnection {
+                    conn: Connection {
+                        peer_id,
+                        addr: addr.to_string(),
+                        conn_type: 1,
+                        network: 1,
+                    },
+                    time_established: 0,
+                },
+            )),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Boilerplate-collecting harness for integration tests.
+/// Spins up a NATS server + publisher, an `IntegrationTestAlerter`, and the
+/// `alerts::run` task. `shutdown` cleanly stops the task at the end of a test
+struct TestHarness {
+    publisher: NatsPublisherForTesting,
+    rx: UnboundedReceiver<Alert>,
+    shutdown_tx: watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<Result<(), RuntimeError>>,
+    _server: NatsServerForTesting,
+}
+
+impl TestHarness {
+    /// `mk_args` receives the NATS port and returns the `Args` to pass to `run`
+    /// so each test can pin its own thresholds while reusing the harness setup
+    async fn new(mk_args: impl FnOnce(u16) -> Args) -> Self {
+        let server = NatsServerForTesting::new(&[]).await;
+        let publisher = NatsPublisherForTesting::new(server.port).await;
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (alerter, rx) = IntegrationTestAlerter::new();
+        let args = mk_args(server.port);
+        let handle = tokio::spawn(alerts::run(args, alerter, shutdown_rx));
+        sleep(Duration::from_secs(1)).await;
+        Self {
+            publisher,
+            rx,
+            shutdown_tx,
+            handle,
+            _server: server,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.shutdown_tx.send(true).unwrap();
+        self.handle.await.unwrap().unwrap();
+    }
+}
+
+/// Verifies the PingSpammer threshold boundary: exactly `threshold` pings stay
+/// silent; the (threshold + 1)-th ping fires the alert
+#[tokio::test]
+async fn test_ping_spammer() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(1, "1.2.3.4:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 1);
+    assert_eq!(count, ping_threshold + 1);
+    assert_eq!(threshold, ping_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Verifies the AddrSpammer threshold boundary with addr messages: exactly
+/// `threshold` addrs stay silent; the (threshold + 1)-th fires the alert
+#[tokio::test]
+async fn test_addr_spammer() {
+    let addr_threshold = 2;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+
+    let event = make_addr_event(2, "5.6.7.8:8333");
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold addrs must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Addr);
+    assert_eq!(peer_id, 2);
+    assert_eq!(count, addr_threshold + 1);
+    assert_eq!(threshold, addr_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Same boundary test as `test_addr_spammer` but with addrv2 messages,
+/// verifying both message types share the same counter
+#[tokio::test]
+async fn test_addrv2_spammer() {
+    let addr_threshold = 2;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+
+    let event = make_addrv2_event(3, "9.10.11.12:8333");
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold addrv2 messages must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Addr);
+    assert_eq!(peer_id, 3);
+    assert_eq!(count, addr_threshold + 1);
+    assert_eq!(threshold, addr_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Verifies that outbound pings are silently dropped and never trigger an alert
+#[tokio::test]
+async fn test_ping_spammer_outbound_ignored() {
+    let mut harness = TestHarness::new(|port| make_test_args(port, 3, 60, 5, 60, 3600)).await;
+
+    for _ in 0..4 {
+        harness
+            .publisher
+            .publish(
+                Subject::NetMsg.to_string(),
+                make_ping_event(4, "99.99.99.99:8333", false).encode_to_vec(),
+            )
+            .await;
+    }
+
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "outbound pings must never produce alerts"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Confirms that `run` returns a `NatsConnect` error when no NATS server is reachable
+#[tokio::test]
+async fn test_integration_alerts_fail_if_no_nats() {
+    let (_, shutdown_rx) = watch::channel(false);
+    let (alerter, _rx) = IntegrationTestAlerter::new();
+    let alerts_handle = tokio::spawn(async move {
+        let args = make_test_args(65535, 10, 60, 5, 60, 3600);
+        match alerts::run(args, alerter, shutdown_rx.clone()).await {
+            Ok(_) => panic!("We should fail when no NATS server is reachable."),
+            Err(e) => match e {
+                RuntimeError::NatsConnect(_) => (),
+                _ => panic!("Expected NatsConnect error since the NATS server isn't reachable."),
+            },
+        };
+    });
+
+    alerts_handle.await.unwrap();
+}
+
+/// Exercises the Close path for a non-spammer peer: cleanup happens silently
+/// (no alert), confirming `log_disconnect` is guarded by `first_alerted`
+#[tokio::test]
+async fn test_closed_connection_cleans_state() {
+    // threshold=10 so peer 99 never becomes a spammer
+    let mut harness = TestHarness::new(|port| make_test_args(port, 10, 60, 5, 60, 3600)).await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_ping_event(99, "1.1.1.1:8333", true).encode_to_vec(),
+        )
+        .await;
+
+    sleep(Duration::from_millis(50)).await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(99, "1.1.1.1:8333").encode_to_vec(),
+        )
+        .await;
+
+    // No alerts at all for this peer — neither spammer nor disconnect-of-flagged
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "non-spammer peer closing must not produce any alert"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Verifies one-shot suppression: the alert fires when the threshold is
+/// crossed and stays silent for any further hits on the same peer/kind
+#[tokio::test]
+async fn test_ping_spammer_fires_only_once() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(10, "20.21.22.23:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 10);
+
+    // 6 more hits — none should re-alert
+    publish_n(&harness.publisher, &subject, &event, 6).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "one-shot flag must suppress further PingSpammer alerts for the same peer"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a flagged peer's Close event emits a `PeerDisconnected`
+/// alert through the `Alerter` channel as spam alerts
+#[tokio::test]
+async fn test_flagged_peer_disconnect_emits_disconnect_alert() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(50, "50.51.52.53:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 50);
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(50, "50.51.52.53:8333").encode_to_vec(),
+        )
+        .await;
+
+    // Flagged peer's Close emits a `PeerDisconnected` alert through the same channel
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    match disconnect {
+        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 50),
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// Verifies that stale peers are evicted by the cleanup interval, and that
+/// the eviction of a flagged peer emits a `PeerDisconnected` alert
+#[tokio::test]
+async fn test_stale_peer_cleanup_emits_disconnect_alert() {
+    let ping_threshold = 3;
+    // peer_stale_secs=1 so the cleanup tick evicts peer 60 quickly
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 1)).await;
+
+    let event = make_ping_event(60, "60.61.62.63:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 60);
+
+    // Wait for the cleanup interval to evict peer 60 (interval = peer_stale_secs = 1s)
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(5)).await;
+    match disconnect {
+        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 60),
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a malformed (undecodable) NATS payload does not kill the
+/// run loop: the tool must keep processing subsequent valid events
+#[tokio::test]
+async fn test_undecodable_payload_does_not_kill_tool() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    // Garbage payload first — must be logged and skipped, not propagated
+    harness
+        .publisher
+        .publish(Subject::NetMsg.to_string(), b"not a protobuf".to_vec())
+        .await;
+
+    sleep(Duration::from_millis(100)).await;
+
+    // Then a valid spam burst — alert must still fire, proving the loop survived
+    let event = make_ping_event(77, "7.7.7.7:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold + 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 77);
+
+    harness.shutdown().await;
+}


### PR DESCRIPTION
This PR implements the initial `tools/alerts` crate, the first step towards resolving [#185 — Implement `alerts` tool that logs when a heuristic is triggered](https://github.com/peer-observer/peer-observer/issues/185).

The `alerts` tool subscribes to NATS events published by `ebpf-extractor` and applies sliding-window counters to detect peers that send anomalously high rates of specific P2P message types. Alerts are emitted at `WARN` level with a structured `[ALERT]` prefix so they can be grepped, piped, or forwarded to any log-aggregation system.

---

## Heuristics implemented

### PingSpammer
Fires when a peer sends more than `--ping-threshold` inbound `ping` messages within a `--ping-window-secs` sliding window.

**Default:** `> 3 pings / 120 s`

### AddrSpammer
Fires when a peer sends more than `--addr-threshold` inbound `addr` or `addrv2` messages within a `--addr-window-secs` sliding window. Both message types share one counter.

**Default:** `> 6 addr/addrv2 messages / 60 s`

## Other features

| Feature | Detail |
|---|---|
| One-shot flag | Each peer/type pair fires at most one alert per session |
| Outbound ignored | Only inbound messages are counted |
| SpammerGone alert | Emitted on disconnect/stale-eviction of a flagged peer; logs spamming duration |
| Connection cleanup | Per-peer state is freed when a `ConnectionEvent::Close` is received |
| Inactivity cleanup | --peer-stale-secs (default 300 s) evicts idle peer state to prevent memory leaks |
| All thresholds are CLI flags | No recompilation required when tuning sensitivity |
