### PR TITLE
add(rpc-extractor, metrics): estimatesmartfee metric

### DIFF
--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -69,6 +69,8 @@ Options:
           Disable querying and publishing of `getorphantxs` data
       --disable-getrawaddrman
           Disable querying and publishing of `getrawaddrman` data
+      --disable-estimatesmartfee
+          Disable querying and publishing of `estimatesmartfee` data
   -h, --help
           Print help
   -V, --version
@@ -95,3 +97,4 @@ low polling frequency: interval controlled with `--query-interval-less-frequent`
 | [`getblockchaininfo`](https://developer.bitcoin.org/reference/rpc/getblockchaininfo.html) | low | Returns various state info regarding blockchain processing. |
 | [`getorphantxs`](https://github.com/bitcoin/bitcoin/pull/30793) | high | (EXPERIMENTAL) Shows transactions in the tx orphanage. |
 | [`getrawaddrman`](https://github.com/bitcoin/bitcoin/pull/28523) | low | (EXPERIMENTAL) Returns information on all address manager entries for the new and tried tables. |
+| [`estimatesmartfee`](https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html) | high | Returns fee estimates for transactions within a specified number of blocks. |

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,6 +1,7 @@
 use shared::clap::{ArgGroup, Parser};
 use shared::corepc_client::client_sync::Auth;
 use shared::corepc_client::client_sync::v30::Client;
+use shared::corepc_client::types::v30::EstimateSmartFee as RPCEstimateSmartFee;
 use shared::corepc_node::mtype::{
     GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
 };
@@ -9,7 +10,7 @@ use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
-use shared::protobuf::rpc_extractor;
+use shared::protobuf::rpc_extractor::{self, EstimateSmartFee, FeeEstimateMode};
 use shared::tokio::sync::watch;
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
@@ -116,6 +117,10 @@ pub struct Args {
     /// Disable querying and publishing of `getrawaddrman` data.
     #[arg(long, default_value_t = false)]
     pub disable_getrawaddrman: bool,
+
+    /// Disable querying and publishing of `estimatesmartfee` data.
+    #[arg(long, default_value_t = false)]
+    pub disable_estimatesmartfee: bool,
 }
 
 impl Args {
@@ -139,6 +144,7 @@ impl Args {
         disable_getblockchaininfo: bool,
         disable_getorphantxs: bool,
         disable_getrawaddrman: bool,
+        disable_estimatesmartfee: bool,
     ) -> Args {
         Self {
             nats,
@@ -161,6 +167,7 @@ impl Args {
             disable_getblockchaininfo,
             disable_getorphantxs,
             disable_getrawaddrman,
+            disable_estimatesmartfee,
             // when adding more disable_* args, make sure to update the disable_all below
         }
     }
@@ -243,6 +250,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         "Querying getrawaddrman enabled: {}",
         !args.disable_getrawaddrman
     );
+    log::info!(
+        "Querying estimatesmartfee enabled: {}",
+        !args.disable_estimatesmartfee
+    );
     // check if we have at least one RPC to query
     let disable_all = args.disable_getpeerinfo
         && args.disable_getmempoolinfo
@@ -254,7 +265,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         && args.disable_getnetworkinfo
         && args.disable_getblockchaininfo
         && args.disable_getorphantxs
-        && args.disable_getrawaddrman;
+        && args.disable_getrawaddrman
+        && args.disable_estimatesmartfee;
     if disable_all {
         log::warn!("No RPC configured to be queried!");
     }
@@ -293,6 +305,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                 if !args.disable_getorphantxs
                     && let Err(e) = getorphantxs(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getorphantxs': {}", e)
+                }
+                if !args.disable_estimatesmartfee
+                    && let Err(e) = estimatesmartfee(&rpc_client, &nats_client, &metrics).await {
+                        log::error!("Could not fetch and publish 'estimatesmartfee': {}", e)
                 }
             }
             _ = less_frequent_interval.tick() => {
@@ -629,5 +645,52 @@ async fn getrawaddrman(
                 .with_label_values(&["getrawaddrman"])
                 .inc();
         })?;
+    Ok(())
+}
+
+async fn estimatesmartfee(
+    rpc_client: &Client,
+    nats_client: &async_nats::Client,
+    metrics: &Metrics,
+) -> Result<(), FetchOrPublishError> {
+    const BLOCKS_10MIN: u32 = 1;
+    const BLOCKS_1HOUR: u32 = 6;
+    const BLOCKS_1DAY: u32 = 144;
+    const BLOCK_TARGETS: [u32; 3] = [BLOCKS_10MIN, BLOCKS_1HOUR, BLOCKS_1DAY];
+
+    const MODES: [FeeEstimateMode; 2] =
+        [FeeEstimateMode::Economical, FeeEstimateMode::Conservative];
+
+    for target in BLOCK_TARGETS {
+        for mode in MODES {
+            let estimate: RPCEstimateSmartFee =
+                measure_rpc_call("estimatesmartfee", metrics, || {
+                    // TODO: when https://github.com/rust-bitcoin/corepc/pull/531 gets released
+                    // use estimate_smart_fee_with_mode instead of the generic call
+                    rpc_client.call::<RPCEstimateSmartFee>(
+                        "estimatesmartfee",
+                        &[target.into(), mode.to_string().into()],
+                    )
+                })?;
+            let estimate = estimate.into_model().unwrap();
+
+            let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
+                    EstimateSmartFee::from_rpc(estimate, target, mode),
+                )),
+            }))?;
+
+            nats_client
+                .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
+                .await
+                .inspect_err(|_| {
+                    metrics
+                        .nats_publish_errors
+                        .with_label_values(&["estimatesmartfee"])
+                        .inc();
+                })?;
+        }
+    }
+
     Ok(())
 }

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -46,6 +46,7 @@ pub struct EnabledRPCsInTest {
     pub getblockchaininfo: bool,
     pub getorphantxs: bool,
     pub getrawaddrman: bool,
+    pub estimatesmartfee: bool,
 }
 
 #[allow(dead_code)]
@@ -64,6 +65,7 @@ impl EnabledRPCsInTest {
             getblockchaininfo: true,
             getorphantxs: true,
             getrawaddrman: true,
+            estimatesmartfee: true,
         }
     }
 
@@ -104,6 +106,9 @@ impl EnabledRPCsInTest {
         if self.getrawaddrman {
             methods.push("getrawaddrman");
         }
+        if self.estimatesmartfee {
+            methods.push("estimatesmartfee");
+        }
         methods
     }
 }
@@ -139,6 +144,7 @@ pub fn make_test_args(
         !rpcs.getblockchaininfo,
         !rpcs.getorphantxs,
         !rpcs.getrawaddrman,
+        !rpcs.estimatesmartfee,
     )
 }
 

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -18,9 +18,12 @@ use shared::{
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
-        rpc_extractor::rpc::RpcEvent::{
-            Addrman, AddrmanInfo, BlockchainInfo, ChainTxStats, MemoryInfo, MempoolInfo, NetTotals,
-            NetworkInfo, OrphanTxs, PeerInfos, Uptime,
+        rpc_extractor::{
+            FeeEstimateMode,
+            rpc::RpcEvent::{
+                Addrman, AddrmanInfo, BlockchainInfo, ChainTxStats, EstimateSmartFee, MemoryInfo,
+                MempoolInfo, NetTotals, NetworkInfo, OrphanTxs, PeerInfos, Uptime,
+            },
         },
     },
     testing::nats_server::NatsServerForTesting,
@@ -585,6 +588,75 @@ async fn test_integration_rpc_testsshouldtimeout() {
         |event| match event {
             PeerObserverEvent::RpcExtractor(_) => {
                 panic!("We should never receive an event here.")
+            }
+            _ => panic!("unexpected event {:?}", event),
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_rpc_estimatesmartfee() {
+    println!("test that we receive estimatesmartfee RPC events");
+
+    check(
+        EnabledRPCsInTest {
+            estimatesmartfee: true,
+            ..Default::default()
+        },
+        |node1, node2| {
+            let miner_address = node1
+                .client
+                .new_address()
+                .expect("failed to get new address");
+            node1
+                .client
+                .generate_to_address(101, &miner_address)
+                .expect("failed to generate to address");
+
+            // generate some transactions to create enough data for fee estimation
+            for _ in 0..20 {
+                let address = node2
+                    .client
+                    .new_address()
+                    .expect("failed to get new address");
+                node1
+                    .client
+                    .call::<String>("sendtoaddress", &[address.to_string().into(), "1".into()])
+                    .expect("failed to send to address");
+
+                node1
+                    .client
+                    .generate_to_address(1, &miner_address)
+                    .expect("failed to generate to address");
+            }
+        },
+        |event| match event {
+            PeerObserverEvent::RpcExtractor(r) => {
+                if let Some(ref e) = r.rpc_event {
+                    match e {
+                        EstimateSmartFee(result) => {
+                            // Fee rate most of the time is 0.0001_0000 on this scenario, but sometimes is greater
+                            assert!(result.fee_rate >= Some(10.0));
+                            assert!(result.fee_rate < Some(10.1));
+
+                            let expected_combinations = [
+                                (1, FeeEstimateMode::Economical as i32),
+                                (1, FeeEstimateMode::Conservative as i32),
+                                (6, FeeEstimateMode::Economical as i32),
+                                (6, FeeEstimateMode::Conservative as i32),
+                                (144, FeeEstimateMode::Economical as i32),
+                                (144, FeeEstimateMode::Conservative as i32),
+                            ];
+                            let found = expected_combinations.iter().any(|(blocks, mode)| {
+                                *blocks == result.requested_blocks && *mode == result.mode
+                            });
+
+                            assert!(found);
+                        }
+                        _ => panic!("unexpected RPC data {:?}", r.rpc_event),
+                    }
+                }
             }
             _ => panic!("unexpected event {:?}", event),
         },

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -148,10 +148,9 @@ async fn test_integration_rpc_getmempoolinfo() {
                             assert_eq!(info.bytes, 0);
                             assert_eq!(info.total_fee, 0.0);
                             assert_eq!(info.max_mempool, 300000000);
-                            // These will change between v29 and v30, so don't hardcode something here.
-                            assert!(info.mempoolminfee > 0.0);
-                            assert!(info.minrelaytxfee > 0.0);
-                            assert!(info.incrementalrelayfee > 0.0);
+                            assert_eq!(info.mempoolminfee, 0.1);
+                            assert_eq!(info.minrelaytxfee, 0.1);
+                            assert_eq!(info.incrementalrelayfee, 0.1);
 
                             assert_eq!(info.unbroadcastcount, 0);
                             assert!(info.fullrbf);

--- a/protobuf/rpc_extractor.proto
+++ b/protobuf/rpc_extractor.proto
@@ -17,6 +17,7 @@ message rpc {
     BlockchainInfo blockchain_info = 9;
     OrphanTxs orphan_txs = 10;
     Addrman addrman = 11;
+    EstimateSmartFee estimate_smart_fee = 12;
   }
 }
 
@@ -239,4 +240,18 @@ message AddrmanEntry {
   required string source_network        = 7;    // The network (ipv4, ipv6, onion, i2p, cjdns) of the source address
   optional uint32 mapped_as             = 8;    // Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying peer selection (only displayed if the -asmap config option is set)
   optional uint32 source_mapped_as      = 9;    // Mapped AS (Autonomous System) number at the end of the BGP route to the source, used for diversifying peer selection (only displayed if the -asmap config option is set)
+}
+
+enum FeeEstimateMode {
+  UNSET = 0;
+  ECONOMICAL = 1;
+  CONSERVATIVE = 2;
+}
+
+message EstimateSmartFee {
+  optional double fee_rate = 1; // The estimated fee rate in sat/vB, if the estimation succeeded
+  required uint32 blocks = 2; // The target number of blocks for confirmation returned by Bitcoin Core (may differ from the requested target, if not enough data is available for estimation)
+  required uint32 requested_blocks = 3; // The requested target number of blocks for confirmation
+  required FeeEstimateMode mode = 4;
+  repeated string errors = 5; // Errors encountered during processing (if any)
 }

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -12,8 +12,9 @@ use corepc_client::types::v30::{
 
 // Ideally, all type imports should use the generic mtype types.
 use corepc_node::mtype::{
-    GetBlockchainInfo, GetChainTxStats, GetMempoolInfo, GetNetworkInfo, GetNetworkInfoAddress,
-    GetNetworkInfoNetwork, GetOrphanTxsVerboseTwo, GetOrphanTxsVerboseTwoEntry,
+    EstimateSmartFee as RPCEstimateSmartFee, GetBlockchainInfo, GetChainTxStats, GetMempoolInfo,
+    GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetOrphanTxsVerboseTwo,
+    GetOrphanTxsVerboseTwoEntry,
 };
 
 use std::collections::BTreeMap;
@@ -68,6 +69,7 @@ impl fmt::Display for rpc::RpcEvent {
             rpc::RpcEvent::BlockchainInfo(info) => write!(f, "{}", info),
             rpc::RpcEvent::OrphanTxs(orphans) => write!(f, "{}", orphans),
             rpc::RpcEvent::Addrman(addrman) => write!(f, "{}", addrman),
+            rpc::RpcEvent::EstimateSmartFee(fee) => write!(f, "{}", fee),
         }
     }
 }
@@ -534,6 +536,49 @@ impl From<GetRawAddrMan> for Addrman {
         Addrman {
             new: table_to_addrman_buckets(&addrman.new),
             tried: table_to_addrman_buckets(&addrman.tried),
+        }
+    }
+}
+
+impl fmt::Display for EstimateSmartFee {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mode = FeeEstimateMode::try_from(self.mode)
+            .expect("Estimate mode must be a valid FeeEstimateMode enum variant");
+
+        let Some(fee_rate) = self.fee_rate else {
+            return write!(
+                f,
+                "EstimateSmartFee(estimation failed, blocks={}, mode={}, errors={:?})",
+                self.blocks, mode, self.errors
+            );
+        };
+
+        write!(
+            f,
+            "EstimateSmartFee(fee_rate={}sat/vB, blocks={}, mode={})",
+            fee_rate, self.blocks, mode,
+        )
+    }
+}
+
+impl fmt::Display for FeeEstimateMode {
+    fn fmt(&self, estimate: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(estimate, "{}", self.as_str_name())
+    }
+}
+
+impl EstimateSmartFee {
+    pub fn from_rpc(estimate: RPCEstimateSmartFee, target: u32, mode: FeeEstimateMode) -> Self {
+        let fee_rate_sat_per_vb = estimate
+            .fee_rate
+            .map(|fee_rate_btc_per_kvb| fee_rate_btc_per_kvb.to_sat_per_vb_f64());
+
+        EstimateSmartFee {
+            fee_rate: fee_rate_sat_per_vb,
+            blocks: estimate.blocks,
+            errors: estimate.errors.unwrap_or_default(),
+            requested_blocks: target,
+            mode: mode.into(),
         }
     }
 }

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -27,7 +27,7 @@ pub trait FeeRateExt {
 
 impl FeeRateExt for bitcoin::FeeRate {
     fn to_sat_per_vb_f64(self) -> f64 {
-        self.to_sat_per_kwu() as f64 / 1000.0 / 4.0
+        self.to_sat_per_kwu() as f64 / (1000.0 / 4.0)
     }
 }
 

--- a/tools/metrics/dashboards/fees-estimatesmartfee.json
+++ b/tools/metrics/dashboards/fees-estimatesmartfee.json
@@ -1,0 +1,612 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"1\", mode=\"CONSERVATIVE\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "1 block Conservative (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"6\", mode=\"CONSERVATIVE\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "6 blocks Conservative (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"144\", mode=\"CONSERVATIVE\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "144 blocks Conservative (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"1\", mode=\"ECONOMICAL\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "1 block Economical (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"6\", mode=\"ECONOMICAL\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "6 blocks Economical (sat/vB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "expr": "peerobserver_rpc_estimatesmartfee_feerate{target_block=\"144\", mode=\"ECONOMICAL\"}",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "144 blocks Economical (sat/vB)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "[fees] Fee Rate Estimates",
+  "uid": "ad72ms8",
+  "version": 15,
+  "weekStart": ""
+}

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -22,7 +22,7 @@ use shared::protobuf::{
     event::{event::PeerObserverEvent, Event},
     log_extractor::{log, Log, LogDebugCategory, LogLevel},
     p2p_extractor::p2p,
-    rpc_extractor::{rpc, Addrman, AddrmanBucket},
+    rpc_extractor::{rpc, Addrman, AddrmanBucket, FeeEstimateMode},
 };
 use shared::tokio::sync::watch;
 use shared::util::{self, is_on_linkinglion_banlist};
@@ -980,6 +980,18 @@ fn handle_rpc_event(e: &rpc::RpcEvent, state_arc: Arc<Mutex<State>>, metrics: me
                     .inc_by(tried_changes.changed_timestamp);
             }
             state.addrman = addrman.clone();
+        }
+        rpc::RpcEvent::EstimateSmartFee(estimate) => {
+            if let Some(fee_rate) = estimate.fee_rate {
+                let mode = FeeEstimateMode::try_from(estimate.mode)
+                    .expect("Invalid fee estimate mode")
+                    .to_string();
+
+                metrics
+                    .rpc_estimatesmartfee_feerate
+                    .with_label_values(&[&estimate.requested_blocks.to_string(), &mode])
+                    .set(fee_rate);
+            };
         }
     }
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -1,10 +1,12 @@
 use shared::prometheus::{
-    register_gauge_with_registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, HistogramOpts, Opts,
-    Registry,
+    register_gauge_vec_with_registry, register_gauge_with_registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, HistogramOpts, Opts, Registry,
 };
-use shared::prometheus::{Gauge, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+use shared::prometheus::{
+    Gauge, GaugeVec, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
 
 const NAMESPACE: &str = "peerobserver";
 
@@ -108,6 +110,16 @@ macro_rules! g {
         let $name: Gauge =
             register_gauge_with_registry!(Opts::new(stringify!($name), $desc), $registry)
                 .expect(concat!("Could not create metric '", stringify!($name), "'"));
+    };
+}
+macro_rules! gv {
+    ($name:ident, $desc:expr, $labels:expr, $registry:expr) => {
+        let $name: GaugeVec = register_gauge_vec_with_registry!(
+            Opts::new(stringify!($name), $desc),
+            &$labels,
+            $registry
+        )
+        .expect(concat!("Could not create metric '", stringify!($name), "'"));
     };
 }
 
@@ -354,6 +366,9 @@ pub struct Metrics {
     pub rpc_getrawaddrman_changed_services: IntCounterVec,
     pub rpc_getrawaddrman_changed_timestamps: IntCounterVec,
 
+    // estimatesmartfee
+    pub rpc_estimatesmartfee_feerate: GaugeVec,
+
     // P2P-extractor
     pub p2pextractor_ping_duration_nanoseconds: IntGauge,
     pub p2pextractor_addrv2relay_addresses: IntCounterVec,
@@ -568,6 +583,9 @@ impl Metrics {
         icv!(rpc_getrawaddrman_changed_services, "Number of entries where the services changed since the last fetch to the addrman by table.", ["table"], registry);
         icv!(rpc_getrawaddrman_changed_timestamps, "Number of entries where the timestamp changed since the last fetch to the addrman by table.", ["table"], registry);
 
+        // estimatesmartfee
+        gv!(rpc_estimatesmartfee_feerate, "The feerate estimate in sat/vB by target block and mode.", ["target_block", "mode"], registry);
+
         // P2P-extractor
         ig!(p2pextractor_ping_duration_nanoseconds, "The time it takes for a connected Bitcoin node to respond to a ping with a pong in nanoseconds.", registry);
         icv!(p2pextractor_addrv2relay_addresses, "The total number of addresses relayed to the p2p-extractor by the node, per network", ["network"], registry);
@@ -778,6 +796,9 @@ impl Metrics {
             rpc_getrawaddrman_replaced_entry,
             rpc_getrawaddrman_changed_timestamps,
             rpc_getrawaddrman_changed_services,
+
+            // estimatesmartfee
+            rpc_estimatesmartfee_feerate,
 
             // p2p-extractor
             p2pextractor_ping_duration_nanoseconds,

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -30,8 +30,9 @@ use shared::{
         p2p_extractor,
         rpc_extractor::{
             self, AddrManInfo, AddrManInfoNetwork, Addrman, AddrmanBucket, AddrmanEntry,
-            BlockchainInfo, ChainTxStats, MemoryInfo, MempoolInfo, NetTotals, NetworkInfo,
-            NetworkInfoNetwork, OrphanTx, OrphanTxs, PeerInfo, PeerInfos, UploadTarget,
+            BlockchainInfo, ChainTxStats, EstimateSmartFee, FeeEstimateMode, MemoryInfo,
+            MempoolInfo, NetTotals, NetworkInfo, NetworkInfoNetwork, OrphanTx, OrphanTxs, PeerInfo,
+            PeerInfos, UploadTarget,
         },
     },
     rand::{self, Rng},
@@ -3767,6 +3768,46 @@ async fn test_integration_metrics_log_line_bytes() {
         Subject::LogExtractor,
         r#"
         peerobserver_log_bytes{category="unknown",level="info"} 12
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_rpc_estimatesmartfee() {
+    println!("test that the estimatesmartfee metrics work");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
+                    EstimateSmartFee {
+                        fee_rate: Some(1.08),
+                        blocks: 12,
+                        requested_blocks: 144,
+                        mode: FeeEstimateMode::Economical.into(),
+                        errors: vec![],
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
+                    EstimateSmartFee {
+                        fee_rate: Some(0.777),
+                        blocks: 2,
+                        requested_blocks: 6,
+                        mode: FeeEstimateMode::Conservative.into(),
+                        errors: vec![],
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::Rpc,
+        r#"
+            peerobserver_rpc_estimatesmartfee_feerate{mode="CONSERVATIVE",target_block="6"} 0.777
+            peerobserver_rpc_estimatesmartfee_feerate{mode="ECONOMICAL",target_block="144"} 1.08
         "#,
     )
     .await;


### PR DESCRIPTION
Add `estimatesmartfee` calls that watch how the feerate values move for the combinations of target (1, 6, 144) and mode (economical, conservative).

This PR touches rpc-extractor and metrics tool.

<img width="1604" height="835" alt="Image" src="https://github.com/user-attachments/assets/20d7eaf4-fe2b-42d8-8b32-681e078c451a" />

closes #362 