### PR TITLE
docs(rpc-extractor): document what RPCs are currently being used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,21 @@ jobs:
         else
           echo "✅ All help outputs are documented correctly."
         fi
+    - name: Check the RPC methods table of rpc-extractor
+      run: |
+        set -e
+
+        EXPECTED_METHODS=$(head -c 100000 extractors/rpc/src/lib.rs | awk 'match($0, /pub disable_([A-Za-z0-9]+)/, m) { print m[1] }' | sort)
+        DOCUMENTED_METHODS=$(head -c 100000 extractors/rpc/README.md | awk '/Supported RPCs/ { state = 1; next } state && match($0, /\[`([a-zA-Z0-9]+)`\]/, m) { print m[1] }' | sort)
+
+        if cmp <(echo "$EXPECTED_METHODS") <(echo "$DOCUMENTED_METHODS"); then
+          echo "✅ All the RPCs are documented."
+        else
+          echo "❌ Not all the supported RPCs are documented."
+          echo "Expected methods:\n$EXPECTED_METHODS"
+          echo "Documented methods:\n$DOCUMENTED_METHODS"
+          exit 1
+        fi
 
   ubuntu-check-and-fmt:
     runs-on: ubuntu-latest

--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -74,3 +74,24 @@ Options:
   -V, --version
           Print version
 ```
+
+## Supported RPCs
+
+The `rpc` extractor currently supports the following Bitcoin Core RPC methods.
+
+high polling frequency: interval controlled with `--query-interval`
+low polling frequency: interval controlled with `--query-interval-less-frequent`
+
+| method | polling frequency | description |
+| --- | --- | --- |
+| [`getpeerinfo`](https://developer.bitcoin.org/reference/rpc/getpeerinfo.html) | high | Returns data about each connected node. |
+| [`getmempoolinfo`](https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html) | high | Returns details on the active state of the TX memory pool. |
+| [`uptime`](https://developer.bitcoin.org/reference/rpc/uptime.html) | high | Returns the total uptime of the server. |
+| [`getnettotals`](https://developer.bitcoin.org/reference/rpc/getnettotals.html) | high | Returns information about network traffic, including bytes in, bytes out, and current time. |
+| [`getmemoryinfo`](https://developer.bitcoin.org/reference/rpc/getmemoryinfo.html) | high | Returns information about memory usage. |
+| [`getaddrmaninfo`](https://github.com/bitcoin/bitcoin/pull/27511) | high | Returns the number of addresses in the `new` and `tried` tables and their sum for all networks. |
+| [`getchaintxstats`](https://developer.bitcoin.org/reference/rpc/getchaintxstats.html) | low | Compute statistics about the total number and rate of transactions in the chain. |
+| [`getnetworkinfo`](https://developer.bitcoin.org/reference/rpc/getnetworkinfo.html) | high | Returns various state info regarding P2P networking. |
+| [`getblockchaininfo`](https://developer.bitcoin.org/reference/rpc/getblockchaininfo.html) | low | Returns various state info regarding blockchain processing. |
+| [`getorphantxs`](https://github.com/bitcoin/bitcoin/pull/30793) | high | (EXPERIMENTAL) Shows transactions in the tx orphanage. |
+| [`getrawaddrman`](https://github.com/bitcoin/bitcoin/pull/28523) | low | (EXPERIMENTAL) Returns information on all address manager entries for the new and tried tables. |


### PR DESCRIPTION
Documented the methods that are used in the RPC extractor. Added links to individual documentations or PRs if the documentation is not available.

I took the descriptions from bitcoin-core's help messages, and summarized them if possible,

- getpeerinfo
- getmempoolinfo
- uptime
- getnettotals
- getmemoryinfo
- getaddrmaninfo
- getchaintxstats
- getnetworkinfo
- getblockchaininfo
- getorphantxs
- getrawaddrman.

Closes https://github.com/peer-observer/peer-observer/issues/314