### PR TITLE
fix(shared): remove glob from rerun condition in build.rs

### DIFF
--- a/shared/build.rs
+++ b/shared/build.rs
@@ -12,7 +12,7 @@ fn main() {
         println!("Error while compiling protos: {}", e);
         panic!("Failed to code-gen the Rust structs from the Protobuf definitions");
     }
-    println!("cargo:rerun-if-changed=../protobuf/*");
+    println!("cargo:rerun-if-changed=../protobuf/");
 
     // Generate check functions for IP addresses
     gen_ip_match_fn(


### PR DESCRIPTION
The build command for crates that depend on the local `shared` crate always triggered the build of `shared`, even if nothing was modified. The issue came from the usage of `rerun_if_changed`, which was given the `../protobuf/*` path. It doesn't support globs, and it treated `*` like a file name. And, when a path is not found, cargo just triggers the build every time.

This also improves the runtime of github workflows.

This is very easy to test:
- Run `cargo build` twice in a row, on a crate that depends on `shared`.
- Observe the difference in compile times between the two builds. Second time should be under 1s.
- Modify something in `protobuf/` (example `protobuf/README.md`), and run `cargo build` again
- Observe that `shared` gets recompiled

---

**Before:**
```
cd extractors/p2p/ && cargo build
cargo build
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.60s
```

**After:**
```
cd extractors/p2p/ && cargo build
cargo build
...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
```

---

Documentation reference: https://docs.rs/cargo-build/latest/cargo_build/fn.rerun_if_changed.html
> // Always rerun when non-existent file chosen