### PR TITLE
ebpf-extractor: Reload eBPF objects when bitcoind process is restarted

### DIFF
--- a/extractors/ebpf/src/error.rs
+++ b/extractors/ebpf/src/error.rs
@@ -16,6 +16,7 @@ pub enum RuntimeError {
     SystemTime(SystemTimeError),
     SetLogger(SetLoggerError),
     NatsConnection(NatsError<ConnectErrorKind>),
+    NoPidFile((String, IoError)),
 }
 
 impl fmt::Display for RuntimeError {
@@ -33,6 +34,9 @@ impl fmt::Display for RuntimeError {
             RuntimeError::NatsConnection(e) => {
                 write!(f, "could not connect to NATS server {}", e)
             }
+            RuntimeError::NoPidFile((path, e)) => {
+                write!(f, "could not read pid file \"{}\": {}", path, e)
+            }
         }
     }
 }
@@ -48,6 +52,7 @@ impl error::Error for RuntimeError {
             RuntimeError::NatsConnection(ref e) => Some(e),
             RuntimeError::NoSuchBPFMap(_) => None,
             RuntimeError::NoSuchBPFProg(_) => None,
+            RuntimeError::NoPidFile((_, ref e)) => Some(e),
         }
     }
 }

--- a/extractors/ebpf/src/error.rs
+++ b/extractors/ebpf/src/error.rs
@@ -16,6 +16,7 @@ pub enum RuntimeError {
     SystemTime(SystemTimeError),
     SetLogger(SetLoggerError),
     NatsConnection(NatsError<ConnectErrorKind>),
+    NoProcessWithPid(i32),
     NoPidFile((String, IoError)),
 }
 
@@ -37,6 +38,7 @@ impl fmt::Display for RuntimeError {
             RuntimeError::NoPidFile((path, e)) => {
                 write!(f, "could not read pid file \"{}\": {}", path, e)
             }
+            RuntimeError::NoProcessWithPid(e) => write!(f, "could not find process with PID {}", e),
         }
     }
 }
@@ -52,6 +54,7 @@ impl error::Error for RuntimeError {
             RuntimeError::NatsConnection(ref e) => Some(e),
             RuntimeError::NoSuchBPFMap(_) => None,
             RuntimeError::NoSuchBPFProg(_) => None,
+            RuntimeError::NoProcessWithPid(_) => None,
             RuntimeError::NoPidFile((_, ref e)) => Some(e),
         }
     }

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -337,6 +337,7 @@ fn try_get_running_process_pid(args: &Args) -> Result<i32, RuntimeError> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn init_bpf_listener<'a, 'b>(
     args: &Args,
     pid: i32,

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -264,7 +264,7 @@ fn bitcoind_pid(args: &Args) -> Result<i32, RuntimeError> {
         path
     );
 
-    let file = File::open(&path)?;
+    let file = File::open(&path).map_err(|e| RuntimeError::NoPidFile((path.clone(), e)))?;
     let mut reader = BufReader::new(file);
     let mut content = String::new();
     reader.read_to_string(&mut content)?;

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -2,7 +2,7 @@
 
 use error::RuntimeError;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
-use libbpf_rs::{Link, Map, MapCore, Object, ProgramMut, RingBufferBuilder, RingBuffer};
+use libbpf_rs::{Link, Map, MapCore, Object, ProgramMut, RingBuffer, RingBufferBuilder};
 use shared::clap::Parser;
 use shared::log::{self, error};
 use shared::nats_subjects::Subject;
@@ -301,7 +301,20 @@ fn try_get_running_process_pid(args: &Args) -> Result<i32, RuntimeError> {
     }
 }
 
-fn init_bpf_listener<'a, 'b>(args: &Args, pid: i32, nc: &'a async_nats::Client, obj_container: &'b mut MaybeUninit<libbpf_rs::OpenObject>) -> Result<(i32, tracing::TracingSkel<'b>, RingBuffer<'a>, Vec<Link>), RuntimeError> {
+fn init_bpf_listener<'a, 'b>(
+    args: &Args,
+    pid: i32,
+    nc: &'a async_nats::Client,
+    obj_container: &'b mut MaybeUninit<libbpf_rs::OpenObject>,
+) -> Result<
+    (
+        i32,
+        tracing::TracingSkel<'b>,
+        RingBuffer<'a>,
+        Vec<Link>,
+    ),
+    RuntimeError,
+> {
     let mut skel_builder = tracing::TracingSkelBuilder::default();
     skel_builder.obj_builder.debug(args.libbpf_debug);
     log::info!("Opening BPF skeleton with debug={}..", args.libbpf_debug);
@@ -426,7 +439,8 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
     let mut obj_container = MaybeUninit::uninit();
     // Keeping _loaded_obj and _links alive is important. Dropping them triggers deleletion from the
     // kernel space of the corresponding bpf maps.
-    let (_, mut _loaded_obj, ring_buffers, _links) = init_bpf_listener(&args, pid, &nc, &mut obj_container)?;
+    let (mut pid, mut _loaded_obj, mut ring_buffers, mut _links) =
+        init_bpf_listener(&args, pid, &nc, &mut obj_container)?;
 
     let mut last_event_timestamp = SystemTime::now();
     let mut has_warned_about_no_events = false;
@@ -467,6 +481,32 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
                 }
             }
         };
+
+        if pid == 0 || !process_exists(pid) {
+            if pid != 0 {
+                log::info!("The bitcoind process with pid {} exited", pid);
+                pid = 0;
+            }
+
+            match try_get_running_process_pid(&args) {
+                Ok(new_pid) => {
+                    // The order in which we drop matters. Doing it the other way can cause a
+                    // use-after-free in libbpf.
+                    drop(_links);
+                    drop(_loaded_obj);
+                    (pid, _loaded_obj, ring_buffers, _links) =
+                        init_bpf_listener(&args, new_pid, &nc, &mut obj_container).unwrap();
+                    last_event_timestamp = SystemTime::now();
+                    has_warned_about_no_events = false;
+                }
+                // Restarting the bitcoind process can take some time
+                Err(RuntimeError::NoProcessWithPid(_) | RuntimeError::NoPidFile(_)) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+
         let duration_since_last_event = SystemTime::now().duration_since(last_event_timestamp)?;
         if duration_since_last_event >= NO_EVENTS_ERROR_DURATION {
             log::error!(

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -22,6 +22,7 @@ use shared::{async_nats, clap, nats_util, tokio};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -225,6 +226,40 @@ impl Args {
     }
 }
 
+struct LogDropCall<T: Sized> {
+    name: String,
+    inner: T,
+}
+
+impl<T> LogDropCall<T> {
+    fn new(name: &str, inner: T) -> Self {
+        Self {
+            name: name.to_string(),
+            inner,
+        }
+    }
+}
+
+impl<T> Deref for LogDropCall<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for LogDropCall<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> Drop for LogDropCall<T> {
+    fn drop(&mut self) {
+        log::info!("Dropped {}", self.name);
+    }
+}
+
 /// Queries procfs to see if the process with the given pid exists
 fn process_exists(pid: i32) -> bool {
     Path::new(&format!("/proc/{}/stat", pid)).exists()
@@ -310,9 +345,9 @@ fn init_bpf_listener<'a, 'b>(
 ) -> Result<
     (
         i32,
-        tracing::TracingSkel<'b>,
-        RingBuffer<'a>,
-        Vec<Link>,
+        LogDropCall<tracing::TracingSkel<'b>>,
+        LogDropCall<RingBuffer<'a>>,
+        LogDropCall<Vec<Link>>,
     ),
     RuntimeError,
 > {
@@ -421,7 +456,12 @@ fn init_bpf_listener<'a, 'b>(
         args.bitcoind_path
     );
 
-    Ok((pid, skel, ring_buffers, links))
+    Ok((
+        pid,
+        LogDropCall::new("loaded skel", skel),
+        LogDropCall::new("ring buffers", ring_buffers),
+        LogDropCall::new("links vector", links),
+    ))
 }
 
 pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -214,6 +214,14 @@ impl Args {
             no_idle_exit: false,
         }
     }
+
+    fn no_tracepoints_enabled(&self) -> bool {
+        self.no_p2pmsg_tracepoints
+            && self.no_connection_tracepoints
+            && self.no_validation_tracepoints
+            && self.no_mempool_tracepoints
+            && !self.addrman_tracepoints
+    }
 }
 
 /// Find the BPF program with the given name
@@ -266,6 +274,11 @@ fn bitcoind_pid(args: &Args) -> Result<i32, RuntimeError> {
 }
 
 pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    if args.no_tracepoints_enabled() {
+        log::error!("No tracepoints enabled.");
+        return Ok(());
+    }
+
     let pid = bitcoind_pid(&args)?;
 
     let mut skel_builder = tracing::TracingSkelBuilder::default();
@@ -352,11 +365,6 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         ringbuff_builder
             .add(&map_addrman_insert_new, |data| { handle_addrman_new(data, &nc) })?
             .add(&map_addrman_insert_tried, |data| { handle_addrman_tried(data, &nc) })?;
-    }
-
-    if active_tracepoints.is_empty() {
-        log::error!("No tracepoints enabled.");
-        return Ok(());
     }
 
     // attach tracepoints

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -22,6 +22,7 @@ use shared::{async_nats, clap, nats_util, tokio};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::mem::MaybeUninit;
+use std::path::Path;
 use std::time::Duration;
 use std::time::SystemTime;
 
@@ -224,6 +225,11 @@ impl Args {
     }
 }
 
+/// Queries procfs to see if the process with the given pid exists
+fn process_exists(pid: i32) -> bool {
+    Path::new(&format!("/proc/{}/stat", pid)).exists()
+}
+
 /// Find the BPF program with the given name
 pub fn find_prog_mut<'obj>(
     object: &'obj Object,
@@ -273,13 +279,40 @@ fn bitcoind_pid(args: &Args) -> Result<i32, RuntimeError> {
     Ok(pid)
 }
 
+/// Returns true if the pid returned by the `bitcoin_pid` function
+/// comes from a bitcoin pid file.
+fn pid_comes_from_file(args: &Args) -> bool {
+    args.bitcoind_pid.is_none() && args.bitcoind_pid_file.is_some()
+}
+
+/// Returns the pid of the bitcoind process, by deriving it from the args. It also checks
+/// that the process with that pid exists.
+fn try_get_running_process_pid(args: &Args) -> Result<i32, RuntimeError> {
+    let pid = bitcoind_pid(args)?;
+
+    if process_exists(pid) {
+        if pid_comes_from_file(args) {
+            log::info!(
+                "Using bitcoind PID={} read from {}",
+                pid,
+                args.bitcoind_pid_file.as_ref().unwrap()
+            );
+        } else {
+            log::info!("Using bitcoind PID={}", pid);
+        }
+        Ok(pid)
+    } else {
+        Err(RuntimeError::NoProcessWithPid(pid))
+    }
+}
+
 pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
     if args.no_tracepoints_enabled() {
         log::error!("No tracepoints enabled.");
         return Ok(());
     }
 
-    let pid = bitcoind_pid(&args)?;
+    let pid = try_get_running_process_pid(&args)?;
 
     let mut skel_builder = tracing::TracingSkelBuilder::default();
     skel_builder.obj_builder.debug(args.libbpf_debug);

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -265,17 +265,12 @@ fn bitcoind_pid(args: &Args) -> Result<i32, RuntimeError> {
         .bitcoind_pid_file
         .clone()
         .expect("pid file path should be set");
-    log::info!(
-        "Reading bitcoind PID file '{}' specified via command line option",
-        path
-    );
 
     let file = File::open(&path).map_err(|e| RuntimeError::NoPidFile((path.clone(), e)))?;
     let mut reader = BufReader::new(file);
     let mut content = String::new();
     reader.read_to_string(&mut content)?;
     let pid: i32 = content.trim().parse()?;
-    log::info!("Using bitcoind PID={} read from {}", pid, path);
     Ok(pid)
 }
 

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -249,6 +249,7 @@ pub fn find_map<'obj>(object: &'obj Object, name: &str) -> Result<Map<'obj>, Run
     }
 }
 
+/// Returns the bitcoind pid from the args or from the file supplied in the args
 fn bitcoind_pid(args: &Args) -> Result<i32, RuntimeError> {
     // The clap arg group "pid" takes care that one of bitcoind_pid or
     // bitcoind_pid_file is set

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -2,7 +2,7 @@
 
 use error::RuntimeError;
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
-use libbpf_rs::{Map, MapCore, Object, ProgramMut, RingBufferBuilder};
+use libbpf_rs::{Link, Map, MapCore, Object, ProgramMut, RingBufferBuilder, RingBuffer};
 use shared::clap::Parser;
 use shared::log::{self, error};
 use shared::nats_subjects::Subject;
@@ -301,28 +301,14 @@ fn try_get_running_process_pid(args: &Args) -> Result<i32, RuntimeError> {
     }
 }
 
-pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
-    if args.no_tracepoints_enabled() {
-        log::error!("No tracepoints enabled.");
-        return Ok(());
-    }
-
-    let pid = try_get_running_process_pid(&args)?;
-
+fn init_bpf_listener<'a, 'b>(args: &Args, pid: i32, nc: &'a async_nats::Client, obj_container: &'b mut MaybeUninit<libbpf_rs::OpenObject>) -> Result<(i32, tracing::TracingSkel<'b>, RingBuffer<'a>, Vec<Link>), RuntimeError> {
     let mut skel_builder = tracing::TracingSkelBuilder::default();
     skel_builder.obj_builder.debug(args.libbpf_debug);
-
-    let mut uninit = MaybeUninit::uninit();
     log::info!("Opening BPF skeleton with debug={}..", args.libbpf_debug);
-    let open_skel: tracing::OpenTracingSkel = skel_builder.open(&mut uninit)?;
+    let open_skel: tracing::OpenTracingSkel = skel_builder.open(obj_container)?;
     log::info!("Loading BPF functions and maps into kernel..");
     let skel: tracing::TracingSkel = open_skel.load()?;
     let obj = skel.object();
-
-    let nc = nats_util::prepare_connection(&args.nats)?
-        .connect(&args.nats.address)
-        .await?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
 
     // Update the ebpf-extractor docs in the README.md when editing the active_tracepoints.
     let mut active_tracepoints = vec![];
@@ -337,10 +323,10 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         active_tracepoints.extend(&TRACEPOINTS_NET_MESSAGE);
         #[rustfmt::skip]
         ringbuff_builder
-            .add(&map_net_msg_small,    |data| { handle_net_message(data, &nc) })?
-            .add(&map_net_msg_medium,   |data| { handle_net_message(data, &nc) })?
-            .add(&map_net_msg_large,    |data| { handle_net_message(data, &nc) })?
-            .add(&map_net_msg_huge,     |data| { handle_net_message(data, &nc) })?;
+            .add(&map_net_msg_small,    |data| { handle_net_message(data, nc) })?
+            .add(&map_net_msg_medium,   |data| { handle_net_message(data, nc) })?
+            .add(&map_net_msg_large,    |data| { handle_net_message(data, nc) })?
+            .add(&map_net_msg_huge,     |data| { handle_net_message(data, nc) })?;
     }
 
     // P2P connection tracepoints
@@ -353,11 +339,11 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         active_tracepoints.extend(&TRACEPOINTS_NET_CONN);
         #[rustfmt::skip]
         ringbuff_builder
-            .add(&map_net_conn_inbound,         |data| { handle_net_conn_inbound(data, &nc) })?
-            .add(&map_net_conn_outbound,        |data| { handle_net_conn_outbound(data, &nc) })?
-            .add(&map_net_conn_closed,          |data| { handle_net_conn_closed(data, &nc) })?
-            .add(&map_net_conn_inbound_evicted, |data| { handle_net_conn_inbound_evicted(data, &nc) })?
-            .add(&map_net_conn_misbehaving,     |data| { handle_net_conn_misbehaving(data, &nc) })?;
+            .add(&map_net_conn_inbound,         |data| { handle_net_conn_inbound(data, nc) })?
+            .add(&map_net_conn_outbound,        |data| { handle_net_conn_outbound(data, nc) })?
+            .add(&map_net_conn_closed,          |data| { handle_net_conn_closed(data, nc) })?
+            .add(&map_net_conn_inbound_evicted, |data| { handle_net_conn_inbound_evicted(data, nc) })?
+            .add(&map_net_conn_misbehaving,     |data| { handle_net_conn_misbehaving(data, nc) })?;
     }
 
     // validation tracepoints
@@ -365,7 +351,7 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
     if !args.no_validation_tracepoints {
         active_tracepoints.extend(&TRACEPOINTS_VALIDATION);
         ringbuff_builder.add(&map_validation_block_connected, |data| {
-            handle_validation_block_connected(data, &nc)
+            handle_validation_block_connected(data, nc)
         })?;
     }
 
@@ -378,10 +364,10 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         active_tracepoints.extend(&TRACEPOINTS_MEMPOOL);
         #[rustfmt::skip]
         ringbuff_builder
-            .add(&map_mempool_added,    |data| { handle_mempool_added(data, &nc) })?
-            .add(&map_mempool_removed,  |data| { handle_mempool_removed(data, &nc) })?
-            .add(&map_mempool_rejected, |data| { handle_mempool_rejected(data, &nc) })?
-            .add(&map_mempool_replaced, |data| { handle_mempool_replaced(data, &nc) })?;
+            .add(&map_mempool_added,    |data| { handle_mempool_added(data, nc) })?
+            .add(&map_mempool_removed,  |data| { handle_mempool_removed(data, nc) })?
+            .add(&map_mempool_rejected, |data| { handle_mempool_rejected(data, nc) })?
+            .add(&map_mempool_replaced, |data| { handle_mempool_replaced(data, nc) })?;
     }
 
     // addrman tracepoints
@@ -391,15 +377,15 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         active_tracepoints.extend(&TRACEPOINTS_ADDRMAN);
         #[rustfmt::skip]
         ringbuff_builder
-            .add(&map_addrman_insert_new, |data| { handle_addrman_new(data, &nc) })?
-            .add(&map_addrman_insert_tried, |data| { handle_addrman_tried(data, &nc) })?;
+            .add(&map_addrman_insert_new, |data| { handle_addrman_new(data, nc) })?
+            .add(&map_addrman_insert_tried, |data| { handle_addrman_tried(data, nc) })?;
     }
 
     // attach tracepoints
-    let mut _links = Vec::new();
+    let mut links = Vec::new();
     for tracepoint in active_tracepoints {
         let prog = find_prog_mut(obj, tracepoint.function)?;
-        _links.push(prog.attach_usdt(
+        links.push(prog.attach_usdt(
             pid,
             &args.bitcoind_path,
             tracepoint.context,
@@ -420,6 +406,28 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
         "Startup successful. Starting to extract events from '{}'..",
         args.bitcoind_path
     );
+
+    Ok((pid, skel, ring_buffers, links))
+}
+
+pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    if args.no_tracepoints_enabled() {
+        log::error!("No tracepoints enabled.");
+        return Ok(());
+    }
+
+    let pid = try_get_running_process_pid(&args)?;
+
+    let nc = nats_util::prepare_connection(&args.nats)?
+        .connect(&args.nats.address)
+        .await?;
+    log::info!("Connected to NATS server at {}", &args.nats.address);
+
+    let mut obj_container = MaybeUninit::uninit();
+    // Keeping _loaded_obj and _links alive is important. Dropping them triggers deleletion from the
+    // kernel space of the corresponding bpf maps.
+    let (_, mut _loaded_obj, ring_buffers, _links) = init_bpf_listener(&args, pid, &nc, &mut obj_container)?;
+
     let mut last_event_timestamp = SystemTime::now();
     let mut has_warned_about_no_events = false;
     loop {

--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -256,7 +256,7 @@ impl<T> DerefMut for LogDropCall<T> {
 
 impl<T> Drop for LogDropCall<T> {
     fn drop(&mut self) {
-        log::info!("Dropped {}", self.name);
+        log::debug!("Dropped {}", self.name);
     }
 }
 
@@ -532,10 +532,11 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<(), R
 
             match try_get_running_process_pid(&args) {
                 Ok(new_pid) => {
-                    // The order in which we drop matters. Doing it the other way can cause a
+                    // The order in which we drop matters. Doing it the other way might cause a
                     // use-after-free in libbpf.
                     drop(_links);
                     drop(_loaded_obj);
+                    drop(ring_buffers);
                     (pid, _loaded_obj, ring_buffers, _links) =
                         init_bpf_listener(&args, new_pid, &nc, &mut obj_container).unwrap();
                     last_event_timestamp = SystemTime::now();


### PR DESCRIPTION
Closes https://github.com/peer-observer/peer-observer/issues/398.

This turned out to take more time than expected because when Rust silently dropped objects, that triggered some undesired behavior in libbpf.

This PR can be manually tested using this branch: https://github.com/RazorBest/peer-observer/pull/2.

- The structs from `libbpf-rs` handle memory by implementing the `Drop` trait.
- It's not enough to keep the ring buffers in scope. The concepts of programs and ring buffers are detached, even if we define both of them in the same file `tracing.bpf.c`. As a consequence, it is possible to unlink a program (which is a type of a special map), but keep the ring buffers allocated. We don't need that to happen.
- From my experimenting, it first seemed to be enough to keep alive the `Vec<Link>` and the ring buffers. However, there's a pointer in `libbpf` that links the `Link` and the `Object` owned by `TracingSkel`. Calling `Object::drop` frees that pointer. However, `Link` still has an indirect reference to it. So, when `Link::drop` is called, a use-after-free is triggered. This sometimes caused segfaults in my program, and I traced it with valgrind. The quick fix is to explicitly call drop such that `Link::drop` is called before `Object::drop`.
- The issue above is also explained here: https://github.com/libbpf/libbpf-rs/issues/1381
- As a bandage for this, I also added `LogDropCall` in f251b7912ed07830ca99008c90e34b7a2a70811c, which logs the drops of these unsafe objects. This helps with debugging when such a behavior is encountered again. I'm ok with removing this, if it's not needed.

The new behavior is: when the process stops, `ebpf-extractor` detects this within one second. Then, it periodically reads the pidfile and checks if the process with that pid is alive. When these conditions are met, the eBPF objects are reloaded. If the pidfile is not provided, the previous behavior is preserved (except that the process kill event is logged). The `NO_EVENTS_WARN_DURATION` and `NO_EVENTS_ERROR_DURATION` trigger just like before.