### PR TITLE
rpc-extractor: update corepc to v0.12 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,8 +231,8 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitreq"
-version = "0.3.1"
-source = "git+https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa7160c7b97e1e845e771953a158233660cd"
+version = "0.3.4"
+source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
 dependencies = [
  "rustls 0.21.12",
  "rustls-webpki 0.101.7",
@@ -440,8 +440,8 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.11.0"
-source = "git+https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa7160c7b97e1e845e771953a158233660cd"
+version = "0.12.0"
+source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -453,8 +453,8 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.11.0"
-source = "git+https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa7160c7b97e1e845e771953a158233660cd"
+version = "0.12.0"
+source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -471,8 +471,8 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.11.0"
-source = "git+https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa7160c7b97e1e845e771953a158233660cd"
+version = "0.12.0"
+source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.19.0"
-source = "git+https://github.com/0xb10c/corepc?rev=b777fa7160c7b97e1e845e771953a158233660cd#b777fa7160c7b97e1e845e771953a158233660cd"
+source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,7 +1,6 @@
 use shared::clap::{ArgGroup, Parser};
 use shared::corepc_client::client_sync::Auth;
-use shared::corepc_client::client_sync::v30::Client;
-use shared::corepc_client::types::v30::EstimateSmartFee as RPCEstimateSmartFee;
+use shared::corepc_client::client_sync::v30::{Client, FeeEstimateMode};
 use shared::corepc_node::mtype::{
     GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
 };
@@ -10,7 +9,7 @@ use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
-use shared::protobuf::rpc_extractor::{self, EstimateSmartFee, FeeEstimateMode};
+use shared::protobuf::rpc_extractor::{self, EstimateSmartFee};
 use shared::tokio::sync::watch;
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
@@ -663,20 +662,14 @@ async fn estimatesmartfee(
 
     for target in BLOCK_TARGETS {
         for mode in MODES {
-            let estimate: RPCEstimateSmartFee =
-                measure_rpc_call("estimatesmartfee", metrics, || {
-                    // TODO: when https://github.com/rust-bitcoin/corepc/pull/531 gets released
-                    // use estimate_smart_fee_with_mode instead of the generic call
-                    rpc_client.call::<RPCEstimateSmartFee>(
-                        "estimatesmartfee",
-                        &[target.into(), mode.to_string().into()],
-                    )
-                })?;
+            let estimate = measure_rpc_call("estimatesmartfee", metrics, || {
+                rpc_client.estimate_smart_fee_with_mode(target, mode)
+            })?;
             let estimate = estimate.into_model().unwrap();
 
             let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
                 rpc_event: Some(rpc_extractor::rpc::RpcEvent::EstimateSmartFee(
-                    EstimateSmartFee::from_rpc(estimate, target, mode),
+                    EstimateSmartFee::from_rpc(estimate, target, mode.into()),
                 )),
             }))?;
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 clap = { version = "4.6.0", features = ["derive"] }
 simple_logger = "5.2.0"
 log = "0.4"
-async-nats = { version = "0.47.0", default-features = false } 
+async-nats = { version = "0.47.0", default-features = false }
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
 tokio = { version = "1.51.0", features = ["rt-multi-thread", "process", "signal"] }
@@ -24,12 +24,11 @@ regex = "1.12"
 
 # Use custom commit to support:
 # - cpu_load and inv_to_send in getpeerinfo
-# - and master has the fix https://github.com/rust-bitcoin/corepc/pull/483
-# (branch 2026-02-v0.11-peer-observer-custom)
+# (branch 2026-04-corepc-0.12+custom-peer-observer-patches)
 # When updating the Bitcoin Core version used, grep for CORE_VERSION_GREP
 # and update the corepc_client::types::v* to the new version.
-corepc-node = { git = "https://github.com/0xb10c/corepc", rev = "b777fa7160c7b97e1e845e771953a158233660cd", features = ["download", "30_2"] }
-corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "b777fa7160c7b97e1e845e771953a158233660cd", features = ["client-sync"]}
+corepc-node = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["download", "30_2"] }
+corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["client-sync"]}
 
 [build-dependencies]
 prost-build = "0.14"

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -3,6 +3,7 @@ use bitcoin::FeeRate;
 // Types that don't have a generic model type in corepc (yet).
 // Once they have a model, move them down to the mtypes!
 // CORE_VERSION_GREP: When updating the corepc node crate version, bump this too.
+use corepc_client::client_sync::v30::FeeEstimateMode as RPCFeeEstimateMode;
 use corepc_client::types::v30::{
     AddrManInfoNetwork as RPCAddrManInfoNetwork, GetAddrManInfo as RPCGetAddrManInfo,
     GetMemoryInfoStats as RPCGetMemoryInfoStats, GetNetTotals as RPCGetNetTotals,
@@ -564,6 +565,16 @@ impl fmt::Display for EstimateSmartFee {
 impl fmt::Display for FeeEstimateMode {
     fn fmt(&self, estimate: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(estimate, "{}", self.as_str_name())
+    }
+}
+
+impl From<RPCFeeEstimateMode> for FeeEstimateMode {
+    fn from(mode: RPCFeeEstimateMode) -> Self {
+        match mode {
+            RPCFeeEstimateMode::Unset => FeeEstimateMode::Unset,
+            RPCFeeEstimateMode::Economical => FeeEstimateMode::Economical,
+            RPCFeeEstimateMode::Conservative => FeeEstimateMode::Conservative,
+        }
     }
 }
 


### PR DESCRIPTION
and use `estimate_smart_fee_with_mode()` instead of a raw `call()` to fix #411 