### PR TITLE
Adding lazylock initializer for regtest address in tests

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -4,7 +4,7 @@
 use log_extractor::Args;
 use shared::{
     async_nats,
-    bitcoin::{self, Block, consensus::Decodable, hashes::Hash, hex::FromHex},
+    bitcoin::{Block, consensus::Decodable, hashes::Hash, hex::FromHex},
     corepc_node,
     futures::StreamExt,
     log::{Level, LevelFilter, info},
@@ -15,7 +15,7 @@ use shared::{
         log_extractor::{LogDebugCategory, log},
     },
     simple_logger::SimpleLogger,
-    testing::nats_server::NatsServerForTesting,
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
     tokio::{
         self, select,
         sync::watch,
@@ -23,7 +23,6 @@ use shared::{
     },
 };
 use std::io::Write;
-use std::str::FromStr;
 use std::sync::Once;
 
 static INIT: Once = Once::new();
@@ -328,12 +327,7 @@ async fn test_integration_logextractor_block_connected() {
     check(
         vec!["-debug=validation"],
         |node1| {
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-            node1.generate_to_address(1, &address).unwrap();
+            node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
             match event {
@@ -389,12 +383,7 @@ async fn test_integration_logextractor_extralogging() {
             "-logtimemicros=1",
         ],
         |node1| {
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-            node1.generate_to_address(1, &address).unwrap();
+            node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
             match event {
@@ -422,12 +411,7 @@ async fn test_integration_logextractor_block_checked() {
     check(
         vec!["-debug=validation"],
         |node1| {
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-            node1.generate_to_address(1, &address).unwrap();
+            node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
             match event {
@@ -455,14 +439,8 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
     check(
         vec!["-debug=validation"],
         |node1| {
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-
             let block = node1
-                .generate_block(&address.to_string(), &[], false)
+                .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
             let block_hex = block.hex.unwrap();
             let block_bytes: Vec<u8> = FromHex::from_hex(&block_hex).unwrap();
@@ -509,14 +487,8 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
     check(
         vec!["-debug=validation"],
         |node1| {
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-
             let block = node1
-                .generate_block(&address.to_string(), &[], false)
+                .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
             let block_hex = block.hex.unwrap();
             let block_bytes: Vec<u8> = FromHex::from_hex(&block_hex).unwrap();

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -17,7 +17,7 @@ use shared::{
         },
     },
     simple_logger::SimpleLogger,
-    testing::nats_server::NatsServerForTesting,
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
     tokio::{
         self, select,
         sync::{oneshot, watch},
@@ -25,7 +25,6 @@ use shared::{
     },
     util,
 };
-use std::str::FromStr;
 use std::sync::Once;
 
 use p2p_extractor::{Args, Network};
@@ -248,12 +247,9 @@ async fn test_integration_p2pextractor_addr_annoucement() {
         |node| {
             // To self-announce our address, we need to be out ouf initial block download
             // Mine a block to get out of initial block download
-            let address: bitcoin::address::Address =
-                bitcoin::address::Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
-                    .unwrap()
-                    .require_network(bitcoin::Network::Regtest)
-                    .unwrap();
-            node.client.generate_to_address(1, &address).unwrap();
+            node.client
+                .generate_to_address(1, &REGTEST_ADDRESS)
+                .unwrap();
             assert!(
                 !node
                     .client
@@ -310,6 +306,7 @@ async fn test_integration_p2pextractor_inv_annoucement() {
         false,
         true,
         |node| {
+            // Mine to a wallet-owned address so the node has spendable UTXOs
             let address = node
                 .client
                 .get_new_address(None, None)
@@ -321,7 +318,7 @@ async fn test_integration_p2pextractor_inv_annoucement() {
             node.client.generate_to_address(110, &address).unwrap();
             for _ in 0..NUM_TX {
                 node.client
-                    .send_to_address(&address, Amount::from_sat(10000))
+                    .send_to_address(&REGTEST_ADDRESS, Amount::from_sat(10000))
                     .unwrap();
             }
         },

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -26,7 +26,7 @@ use shared::{
             },
         },
     },
-    testing::nats_server::NatsServerForTesting,
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
     tokio::{
         self, select,
         sync::watch,
@@ -308,13 +308,9 @@ async fn test_integration_rpc_getchaintxstats() {
             // Note: window_tx_count, window_interval, and tx_rate
             // are only present when window_block_count > 0, which
             // requires mining a few blocks blocks.
-            let address = node1
-                .client
-                .new_address()
-                .expect("failed to get new address");
             node1
                 .client
-                .generate_to_address(201, &address)
+                .generate_to_address(201, &REGTEST_ADDRESS)
                 .expect("failed to generate to address");
         },
         |event| match event {
@@ -457,10 +453,6 @@ async fn test_integration_rpc_getorphantxs() {
         |node1, node2| {
             // Generate a couple of orphan transactions by spending from non-existing UTXOs.
             const NUM_ORPHANS: u8 = 3;
-            let address = node2
-                .client
-                .new_address()
-                .expect("failed to get new address");
             let orphans: Vec<Transaction> = (0..NUM_ORPHANS)
                 .map(|i| Transaction {
                     version: transaction::Version::ONE,
@@ -476,19 +468,15 @@ async fn test_integration_rpc_getorphantxs() {
                     }],
                     output: vec![TxOut {
                         value: Amount::from_sat(100_000),
-                        script_pubkey: address.script_pubkey(),
+                        script_pubkey: REGTEST_ADDRESS.script_pubkey(),
                     }],
                 })
                 .collect();
 
             // The receiving node needs to be out of IBD to start accepting transactions.
-            let address = node1
-                .client
-                .new_address()
-                .expect("failed to get new address");
             node1
                 .client
-                .generate_to_address(1, &address)
+                .generate_to_address(1, &REGTEST_ADDRESS)
                 .expect("failed to generate to address");
 
             // node1 is peer=0 of node2
@@ -603,7 +591,8 @@ async fn test_integration_rpc_estimatesmartfee() {
             estimatesmartfee: true,
             ..Default::default()
         },
-        |node1, node2| {
+        |node1, _node2| {
+            // Mine to a wallet-owned address so node1 has spendable UTXOs
             let miner_address = node1
                 .client
                 .new_address()
@@ -614,14 +603,11 @@ async fn test_integration_rpc_estimatesmartfee() {
                 .expect("failed to generate to address");
 
             // generate some transactions to create enough data for fee estimation
+            let recipient = REGTEST_ADDRESS.to_string();
             for _ in 0..20 {
-                let address = node2
-                    .client
-                    .new_address()
-                    .expect("failed to get new address");
                 node1
                     .client
-                    .call::<String>("sendtoaddress", &[address.to_string().into(), "1".into()])
+                    .call::<String>("sendtoaddress", &[recipient.clone().into(), "1".into()])
                     .expect("failed to send to address");
 
                 node1

--- a/shared/src/testing/mod.rs
+++ b/shared/src/testing/mod.rs
@@ -1,3 +1,16 @@
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use crate::bitcoin::{address::Address, Network};
+
+/// Static regtest address for integration tests initalized statically for global scope
+pub static REGTEST_ADDRESS: LazyLock<Address> = LazyLock::new(|| {
+    Address::from_str("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw")
+        .expect("valid bech32")
+        .require_network(Network::Regtest)
+        .expect("regtest address")
+});
+
 /// Utilities for fetching Prometheus metrics in integration tests.
 pub mod metrics_fetcher;
 /// A NATS publisher to be used in integration tests.


### PR DESCRIPTION
- Fixes #413 .
- Using `LazyLock` instead of `OnceLock` since i think we don't  require passing the initialization params during init and thus be suitable for global thread-safe initialization for regtest address used for spawned nodes in integration tests.