### PR TITLE
Fix remaining tests that can fail intermittently due to metrics server port reuse

### DIFF
--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -10,9 +10,10 @@ use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
 use shared::protobuf::rpc_extractor::{self, EstimateSmartFee};
-use shared::tokio::sync::watch;
+use shared::tokio::sync::{oneshot, watch};
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
+use std::net::SocketAddr;
 
 mod error;
 pub mod metrics;
@@ -172,12 +173,22 @@ impl Args {
     }
 }
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+) -> Result<(), RuntimeError> {
     // Create metrics instance with its own registry
     let metrics = Metrics::new();
 
     // Start the metric server with our custom registry.
-    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+    let metrics_addr =
+        shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(metrics_addr);
+    }
 
     let auth: Auth = match args.rpc_cookie_file {
         Some(path) => Auth::CookieFile(path.into()),

--- a/extractors/rpc/src/main.rs
+++ b/extractors/rpc/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx));
+    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -10,15 +10,6 @@ use std::sync::Once;
 
 use rpc_extractor::Args;
 
-/// Get an available port for the metrics server.
-pub fn get_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to bind to port 0")
-        .local_addr()
-        .expect("Failed to get local addr")
-        .port()
-}
-
 static INIT: Once = Once::new();
 
 // 1 second query interval for fast tests

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -5,7 +5,6 @@ use shared::{
     simple_logger::SimpleLogger,
 };
 
-use std::net::TcpListener;
 use std::sync::Once;
 
 use rpc_extractor::Args;

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -3,9 +3,7 @@
 
 mod common;
 
-use common::{
-    EnabledRPCsInTest, get_available_port, make_test_args, setup, setup_two_connected_nodes,
-};
+use common::{EnabledRPCsInTest, make_test_args, setup, setup_two_connected_nodes};
 
 use shared::{
     async_nats,
@@ -48,7 +46,6 @@ async fn check(
     let (node1, node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
 
     let url = node1.rpc_url().replace("http://", "");
     let cookie_file_path = node1.params.cookie_file.display().to_string();
@@ -62,7 +59,7 @@ async fn check(
             nats_server.port,
             url,
             cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             rpcs,
         );
         rpc_extractor::run(args, shutdown_rx.clone())

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -62,7 +62,7 @@ async fn check(
             "127.0.0.1:0".to_string(),
             rpcs,
         );
-        rpc_extractor::run(args, shutdown_rx.clone())
+        rpc_extractor::run(args, shutdown_rx.clone(), None)
             .await
             .expect("rpc extractor failed");
     });

--- a/extractors/rpc/tests/metrics_integration.rs
+++ b/extractors/rpc/tests/metrics_integration.rs
@@ -4,8 +4,7 @@
 mod common;
 
 use common::{
-    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, get_available_port, make_test_args, setup,
-    setup_two_connected_nodes,
+    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, make_test_args, setup, setup_two_connected_nodes,
 };
 
 use shared::{
@@ -13,7 +12,10 @@ use shared::{
         metrics_fetcher::{fetch_metrics, get_metric_value},
         nats_server::NatsServerForTesting,
     },
-    tokio::{self, sync::watch},
+    tokio::{
+        self,
+        sync::{oneshot, watch},
+    },
 };
 
 /// Verifies the Prometheus metrics server starts and responds to HTTP requests.
@@ -23,23 +25,23 @@ async fn test_integration_metrics_server_basic() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     let rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             EnabledRPCsInTest {
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        let _ = rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx)).await;
     });
 
-    // Wait for the metrics server to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     // Fetch metrics and verify the server responds
     let metrics = fetch_metrics(metrics_port, "/metrics");
@@ -64,21 +66,24 @@ async fn test_integration_metrics_rpc_fetch_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     let rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             EnabledRPCsInTest {
                 uptime: true, // lightweight RPC
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        let _ = rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx)).await;
     });
+
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -110,7 +115,7 @@ async fn test_integration_metrics_all_rpc_methods_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
     let rpcs = EnabledRPCsInTest::all();
 
     let rpc_extractor_handle = tokio::spawn(async move {
@@ -118,11 +123,14 @@ async fn test_integration_metrics_all_rpc_methods_duration() {
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             EnabledRPCsInTest::all(),
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        let _ = rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx)).await;
     });
+
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -156,11 +164,11 @@ async fn test_integration_metrics_rpc_fetch_errors() {
     setup();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     // Create a temporary cookie file (required by Args validation)
     let temp_dir = std::env::temp_dir();
-    let cookie_file = temp_dir.join(format!("test_cookie_{}", metrics_port));
+    let cookie_file = temp_dir.join("test_cookie_rpc_fetch_errors");
     std::fs::write(&cookie_file, "__cookie__:test").expect("Failed to write cookie file");
 
     let cookie_file_path = cookie_file.display().to_string();
@@ -169,14 +177,17 @@ async fn test_integration_metrics_rpc_fetch_errors() {
             nats_server.port,
             "127.0.0.1:1".to_string(), // Unreachable RPC host
             cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             EnabledRPCsInTest {
                 uptime: true, // will fail
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        let _ = rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx)).await;
     });
+
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     // Wait for at least one RPC query cycle (which will fail)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -225,11 +236,11 @@ async fn test_integration_metrics_rpc_fetch_errors_invalid_auth() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     // Create a cookie file with invalid credentials
     let temp_dir = std::env::temp_dir();
-    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", metrics_port));
+    let invalid_cookie_file = temp_dir.join("invalid_cookie_rpc_fetch_errors_invalid_auth");
     std::fs::write(&invalid_cookie_file, "__cookie__:invalid_password")
         .expect("Failed to write invalid cookie file");
 
@@ -240,14 +251,17 @@ async fn test_integration_metrics_rpc_fetch_errors_invalid_auth() {
             nats_server.port,
             rpc_url,
             invalid_cookie_path,
-            format!("127.0.0.1:{}", metrics_port),
+            "127.0.0.1:0".to_string(),
             EnabledRPCsInTest {
                 uptime: true, // will fail due to auth
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        let _ = rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx)).await;
     });
+
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     // Wait for at least one RPC query cycle (which will fail due to invalid auth)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;

--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -5,6 +5,7 @@ use std::error;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
+use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::string::FromUtf8Error;
@@ -15,7 +16,10 @@ const LOG_TARGET: &str = "metricserver";
 // This is a minimal, per request thread spawning, and incorrect HTTP server
 // which answers on all request methods with prometheus formatted metrics.
 
-pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(), io::Error> {
+pub fn start(
+    prometheus_address: &str,
+    registry: Option<Registry>,
+) -> Result<SocketAddr, io::Error> {
     let listener = TcpListener::bind(prometheus_address)?;
     let local_addr = listener.local_addr()?;
     log::info!(
@@ -42,7 +46,7 @@ pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(),
             };
         }
     });
-    Ok(())
+    Ok(local_addr)
 }
 
 fn handle_request(

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -23,11 +23,12 @@ use shared::protobuf::{
     p2p_extractor::p2p,
     rpc_extractor::{rpc, Addrman, AddrmanBucket, FeeEstimateMode},
 };
-use shared::tokio::sync::watch;
+use shared::tokio::sync::{oneshot, watch};
 use shared::util::{self, is_on_linkinglion_banlist};
 use shared::{async_nats, clap};
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 pub mod error;
@@ -81,18 +82,26 @@ struct State {
 pub async fn run(
     args: Args,
     mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<(), error::RuntimeError> {
     info!(target: LOG_TARGET, "Starting metrics-server...",);
 
     let metrics = metrics::Metrics::new();
 
-    metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
+    let metrics_addr = metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
 
     let nc = nats_util::prepare_connection(&args.nats)?
         .connect(&args.nats.address)
         .await?;
     info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc.subscribe("*").await?;
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    // This is sent after the NATS subscription is established so that tests
+    // can safely publish events immediately after receiving the address.
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(metrics_addr);
+    }
 
     metrics
         .runtime_start_timestamp

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_handle = tokio::spawn(metrics::run(args, shutdown_rx));
+    let metrics_handle = tokio::spawn(metrics::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "nats_integration_tests")]
 
-use metrics::error::RuntimeError;
 use metrics::Args;
 
 use shared::{
-    log::{debug, warn, Level, LevelFilter},
+    log::{debug, Level, LevelFilter},
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
@@ -34,58 +33,29 @@ use shared::{
             PeerInfos, UploadTarget,
         },
     },
-    rand::{self, Rng},
     simple_logger::SimpleLogger,
     testing::{
         metrics_fetcher::fetch_metrics_root, nats_publisher::NatsPublisherForTesting,
         nats_server::NatsServerForTesting,
     },
-    tokio::{
-        self,
-        sync::{watch, Mutex},
-        time::sleep,
-    },
+    tokio::{self, sync::watch, time::sleep},
     util::current_timestamp,
 };
 
-use std::{
-    collections::HashMap,
-    io::ErrorKind,
-    sync::{
-        atomic::{AtomicU16, Ordering},
-        Arc, Once, OnceLock,
-    },
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Once, time::Duration};
 
 static INIT: Once = Once::new();
-static NEXT_METRICS_PORT: OnceLock<AtomicU16> = OnceLock::new();
 
-fn setup() -> u16 {
+fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
             .with_level(LevelFilter::Trace)
             .init()
             .unwrap();
-
-        let mut rng = rand::rng();
-
-        // choose start ports from the ephemeral port range
-        let metrics_start = rng.random_range(49152..65500);
-
-        NEXT_METRICS_PORT
-            .set(AtomicU16::new(metrics_start))
-            .unwrap();
     });
-
-    let metrics_port = NEXT_METRICS_PORT
-        .get()
-        .unwrap()
-        .fetch_add(1, Ordering::SeqCst);
-    metrics_port
 }
 
-fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
+fn make_test_args(nats_port: u16) -> Args {
     Args::new(
         NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -93,7 +63,7 @@ fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
             password: None,
             password_file: None,
         },
-        format!("127.0.0.1:{}", metrics_port),
+        "127.0.0.1:0".to_string(),
         Level::Trace,
     )
 }
@@ -128,47 +98,22 @@ fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
 }
 
 async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
-    let initial_metrics_port = setup();
-    let metrics_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_metrics_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port_clone = metrics_port.clone();
+    let (addr_tx, addr_rx) = shared::tokio::sync::oneshot::channel();
     let metrics_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *metrics_port_clone.lock().await;
-            }
-
-            let args = make_test_args(nats_server.port, port);
-            match metrics::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_METRICS_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = metrics_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start metrics tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start metrics tool: {}", e),
-                },
-            }
-        }
+        let args = make_test_args(nats_server.port);
+        metrics::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("Could not start metrics tool");
     });
-    // allow the metrics tool to start
-    sleep(Duration::from_secs(1)).await;
+
+    let metrics_addr = addr_rx.await.expect("Should receive bound address");
+    let metrics_port = metrics_addr.port();
 
     for event in events {
         debug!("publishing: {:?}", event);
@@ -177,11 +122,19 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
             .await;
     }
 
-    sleep(Duration::from_millis(100)).await;
-
     let expected_lines: Vec<&str> = expected.split('\n').collect();
-    let port = metrics_port.lock().await;
-    assert!(check_metrics(*port, &expected_lines).expect("Could not fetch metrics"));
+
+    // Poll the metrics endpoint until all expected lines appear or we time out.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if check_metrics(metrics_port, &expected_lines).expect("Could not fetch metrics") {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("Timed out waiting for expected metrics");
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
 
     shutdown_tx.send(true).unwrap();
     metrics_handle.await.unwrap();
@@ -190,11 +143,11 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
 #[tokio::test]
 async fn test_integration_metrics_no_nats_connection() {
     println!("test that we fail if we can't connect to NATS (due to port 0)");
-    let _ = setup();
+    setup();
 
-    let args = make_test_args(0, 0);
+    let args = make_test_args(0);
     let (_, shutdown_rx) = watch::channel(false);
-    let result = metrics::run(args, shutdown_rx).await;
+    let result = metrics::run(args, shutdown_rx, None).await;
 
     assert!(result.is_err());
     // allows for easier debugging if it's not a Io error..


### PR DESCRIPTION
Closes #382 (rpc-extractor) and fixes it for the metrics tool tests too. This is similar to https://github.com/peer-observer/peer-observer/pull/365 (websocket tool) and https://github.com/peer-observer/peer-observer/pull/358 (p2p extractor).