### PR TITLE
Watching compact block reconstructions via log-extractor

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -15,11 +15,11 @@ use shared::{
         log_extractor::{LogDebugCategory, log},
     },
     simple_logger::SimpleLogger,
-    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting, node::mine_and_wait_for_tip},
     tokio::{
         self, select,
         sync::watch,
-        time::{Duration, Instant, sleep},
+        time::{Duration, sleep},
     },
 };
 use std::io::Write;
@@ -193,7 +193,7 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (bitcoind::BitcoinD, bitc
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
-    test_setup: impl AsyncFn(&bitcoind::Client, &bitcoind::Client),
+    test_setup: fn(&bitcoind::Client, &bitcoind::Client),
     check_event: fn(PeerObserverEvent) -> bool,
 ) {
     setup();
@@ -237,7 +237,7 @@ async fn check(
     write_marker(&log_path_main, &marker);
     let buffered = wait_for_marker(&mut sub, &marker, Duration::from_secs(10)).await;
 
-    test_setup(&node1.client, &node2.client).await;
+    test_setup(&node1.client, &node2.client);
 
     sleep(Duration::from_secs(1)).await;
 
@@ -285,7 +285,7 @@ async fn test_integration_logextractor_log_events() {
 
     check(
         vec![],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| match event {
             PeerObserverEvent::LogExtractor(r) => r.log_event.is_some(),
             _ => panic!("unexpected event {:?}", event),
@@ -300,7 +300,7 @@ async fn test_integration_logextractor_unknown_log_events() {
 
     check(
         vec![],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -326,7 +326,7 @@ async fn test_integration_logextractor_block_connected() {
 
     check(
         vec!["-debug=validation"],
-        async |node1, _node2| {
+        |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -354,7 +354,7 @@ async fn test_integration_logextractor_logtimemicros() {
 
     check(
         vec!["-logtimemicros=1"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -382,7 +382,7 @@ async fn test_integration_logextractor_extralogging() {
             "-logips=1",
             "-logtimemicros=1",
         ],
-        async |node1, _node2| {
+        |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -410,7 +410,7 @@ async fn test_integration_logextractor_block_checked() {
 
     check(
         vec!["-debug=validation"],
-        async |node1, _node2| {
+        |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -438,7 +438,7 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
 
     check(
         vec!["-debug=validation"],
-        async |node1, _node2| {
+        |node1, _node2| {
             let block = node1
                 .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
@@ -486,7 +486,7 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
 
     check(
         vec!["-debug=validation"],
-        async |node1, _node2| {
+        |node1, _node2| {
             let block = node1
                 .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
@@ -532,7 +532,7 @@ async fn test_integration_logextractor_unknown_with_threadname() {
 
     check(
         vec!["-logthreadnames=1"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -560,7 +560,7 @@ async fn test_integration_logextractor_unknown_with_category() {
 
     check(
         vec!["-debug=net"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -587,7 +587,7 @@ async fn test_integration_logextractor_unknown_with_threadname_and_category() {
 
     check(
         vec!["-logthreadnames=1", "-debug=net"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -618,7 +618,7 @@ async fn test_integration_logextractor_unknown_with_all_metadata() {
 
     check(
         vec!["-logthreadnames=1", "-logsourcelocations=1", "-debug=net"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -650,7 +650,7 @@ async fn test_integration_logextractor_testsshouldtimeout() {
 
     check(
         vec![],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(_) => {
@@ -670,7 +670,7 @@ async fn test_integration_logextractor_log_bytes() {
 
     check(
         vec!["-debug=net"],
-        async |_node1, _node2| {},
+        |_node1, _node2| {},
         |event| match event {
             PeerObserverEvent::LogExtractor(r) => {
                 if let Some(log::LogEvent::UnknownLogMessage(_)) = r.log_event
@@ -697,16 +697,8 @@ async fn test_integration_logextractor_saw_new_header() {
 
     check(
         vec![],
-        async |node1, node2| {
-            // first chain tip
-            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
-            // wait for node1 to finish IBD
-            let loop_start = Instant::now();
-            while loop_start.elapsed() < Duration::from_secs(30)
-                && node1.get_blockchain_info().unwrap().initial_block_download
-            {
-                sleep(Duration::from_millis(50)).await;
-            }
+        |node1, node2| {
+            mine_and_wait_for_tip(node1, node2);
             // this block should trigger the SawNewHeaderLog
             node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
@@ -738,16 +730,8 @@ async fn test_integration_logextractor_compact_block_reconstruction() {
 
     check(
         vec!["-debug=cmpctblock"],
-        async |node1, node2| {
-            // first chain tip
-            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
-            // wait for node1 to finish IBD
-            let loop_start = Instant::now();
-            while loop_start.elapsed() < Duration::from_secs(30)
-                && node1.get_blockchain_info().unwrap().initial_block_download
-            {
-                sleep(Duration::from_millis(50)).await;
-            }
+        |node1, node2| {
+            mine_and_wait_for_tip(node1, node2);
             // this block should trigger the CompactBlockReconstructedLog
             node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -19,7 +19,7 @@ use shared::{
     tokio::{
         self, select,
         sync::watch,
-        time::{Duration, sleep},
+        time::{Duration, Instant, sleep},
     },
 };
 use std::io::Write;
@@ -182,9 +182,9 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (bitcoind::BitcoinD, bitc
 ///    into `debug.log` and waits for it to arrive via NATS, buffering any
 ///    events consumed before the marker. This proves the full
 ///    `debug.log -> tail -> pipe -> extractor -> NATS` path is live.
-/// 5. Calls `test_setup` against node1's RPC client so the test can trigger
-///    the specific node behaviour it wants to observe (mine a block, submit a
-///    transaction, etc.).
+/// 5. Calls `test_setup` against node1's and node2's RPC client so the test can
+///    trigger the specific node behaviour it wants to observe (mine a block,
+///    submit a transaction, etc.).
 /// 6. Replays buffered pre-marker events through `check_event`, then polls
 ///    live NATS messages. The loop breaks as soon as `check_event` returns
 ///    `true`.
@@ -193,11 +193,11 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (bitcoind::BitcoinD, bitc
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
-    test_setup: fn(&bitcoind::Client),
+    test_setup: impl AsyncFn(&bitcoind::Client, &bitcoind::Client),
     check_event: fn(PeerObserverEvent) -> bool,
 ) {
     setup();
-    let (node1, _node2) = setup_two_connected_nodes(args);
+    let (node1, node2) = setup_two_connected_nodes(args);
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_port = nats_server.port;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -237,7 +237,7 @@ async fn check(
     write_marker(&log_path_main, &marker);
     let buffered = wait_for_marker(&mut sub, &marker, Duration::from_secs(10)).await;
 
-    test_setup(&node1.client);
+    test_setup(&node1.client, &node2.client).await;
 
     sleep(Duration::from_secs(1)).await;
 
@@ -285,7 +285,7 @@ async fn test_integration_logextractor_log_events() {
 
     check(
         vec![],
-        |_node1| (),
+        async |_node1, _node2| {},
         |event| match event {
             PeerObserverEvent::LogExtractor(r) => r.log_event.is_some(),
             _ => panic!("unexpected event {:?}", event),
@@ -300,7 +300,7 @@ async fn test_integration_logextractor_unknown_log_events() {
 
     check(
         vec![],
-        |_node1| (),
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -326,7 +326,7 @@ async fn test_integration_logextractor_block_connected() {
 
     check(
         vec!["-debug=validation"],
-        |node1| {
+        async |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -354,7 +354,7 @@ async fn test_integration_logextractor_logtimemicros() {
 
     check(
         vec!["-logtimemicros=1"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -382,7 +382,7 @@ async fn test_integration_logextractor_extralogging() {
             "-logips=1",
             "-logtimemicros=1",
         ],
-        |node1| {
+        async |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -410,7 +410,7 @@ async fn test_integration_logextractor_block_checked() {
 
     check(
         vec!["-debug=validation"],
-        |node1| {
+        async |node1, _node2| {
             node1.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
         },
         |event| {
@@ -438,7 +438,7 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
 
     check(
         vec!["-debug=validation"],
-        |node1| {
+        async |node1, _node2| {
             let block = node1
                 .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
@@ -486,7 +486,7 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
 
     check(
         vec!["-debug=validation"],
-        |node1| {
+        async |node1, _node2| {
             let block = node1
                 .generate_block(&REGTEST_ADDRESS.to_string(), &[], false)
                 .unwrap();
@@ -532,7 +532,7 @@ async fn test_integration_logextractor_unknown_with_threadname() {
 
     check(
         vec!["-logthreadnames=1"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -560,7 +560,7 @@ async fn test_integration_logextractor_unknown_with_category() {
 
     check(
         vec!["-debug=net"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -587,7 +587,7 @@ async fn test_integration_logextractor_unknown_with_threadname_and_category() {
 
     check(
         vec!["-logthreadnames=1", "-debug=net"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -618,7 +618,7 @@ async fn test_integration_logextractor_unknown_with_all_metadata() {
 
     check(
         vec!["-logthreadnames=1", "-logsourcelocations=1", "-debug=net"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
@@ -650,7 +650,7 @@ async fn test_integration_logextractor_testsshouldtimeout() {
 
     check(
         vec![],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(_) => {
@@ -670,7 +670,7 @@ async fn test_integration_logextractor_log_bytes() {
 
     check(
         vec!["-debug=net"],
-        |_node1| {},
+        async |_node1, _node2| {},
         |event| match event {
             PeerObserverEvent::LogExtractor(r) => {
                 if let Some(log::LogEvent::UnknownLogMessage(_)) = r.log_event
@@ -681,6 +681,91 @@ async fn test_integration_logextractor_log_bytes() {
                         "Received log event with log_line_bytes={}",
                         r.log_line_bytes
                     );
+                    return true;
+                }
+                false
+            }
+            _ => panic!("unexpected event {:?}", event),
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_logextractor_saw_new_header() {
+    println!("test that we can parse saw new header logs");
+
+    check(
+        vec![],
+        async |node1, node2| {
+            // first chain tip
+            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
+            // wait for node1 to finish IBD
+            let loop_start = Instant::now();
+            while loop_start.elapsed() < Duration::from_secs(30)
+                && node1.get_blockchain_info().unwrap().initial_block_download
+            {
+                sleep(Duration::from_millis(50)).await;
+            }
+            // this block should trigger the SawNewHeaderLog
+            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
+        },
+        |event| match event {
+            PeerObserverEvent::LogExtractor(r) => {
+                if let Some(log::LogEvent::SawNewHeaderLog(block)) = r.log_event
+                    && r.category == LogDebugCategory::Unknown as i32
+                {
+                    assert!(
+                        !block.block_hash.is_empty(),
+                        "block_hash should not be empty"
+                    );
+                    assert_eq!(block.block_height, 2);
+                    assert!(block.peer_id == 0 || block.peer_id == 1); // in rare cases, peer_id might be 1
+                    info!("SawNewHeaderLog event {}", block);
+                    return true;
+                }
+                false
+            }
+            _ => panic!("unexpected event {:?}", event),
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_logextractor_compact_block_reconstruction() {
+    println!("test that we can parse compact block reconstruction logs");
+
+    check(
+        vec!["-debug=cmpctblock"],
+        async |node1, node2| {
+            // first chain tip
+            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
+            // wait for node1 to finish IBD
+            let loop_start = Instant::now();
+            while loop_start.elapsed() < Duration::from_secs(30)
+                && node1.get_blockchain_info().unwrap().initial_block_download
+            {
+                sleep(Duration::from_millis(50)).await;
+            }
+            // this block should trigger the CompactBlockReconstructedLog
+            node2.generate_to_address(1, &REGTEST_ADDRESS).unwrap();
+        },
+        |event| match event {
+            PeerObserverEvent::LogExtractor(r) => {
+                if let Some(log::LogEvent::CompactBlockReconstructedLog(block)) = r.log_event
+                    && r.category == LogDebugCategory::Cmpctblock as i32
+                {
+                    assert!(
+                        !block.block_hash.is_empty(),
+                        "block_hash should not be empty"
+                    );
+                    assert_eq!(block.prefilled_txn_count, 1);
+                    assert_eq!(block.mempool_txn_count, 0);
+                    assert_eq!(block.extra_pool_txn_count, 0);
+                    assert_eq!(block.requested_txn_count, 0);
+                    assert_eq!(block.requested_txn_bytes, 0);
+                    info!("CompactBlockReconstructedLog event {}", block);
                     return true;
                 }
                 false

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -237,7 +237,7 @@ async fn test_integration_p2pextractor_addr_annoucement() {
         },
         |node| {
             // To self-announce our address, we need to be out of initial block download.
-            mine_and_wait_for_tip(&node.client);
+            mine_and_wait_for_tip(&node.client, &node.client);
 
             // Connects to the Bitcoin node, announces one address to it, and disconnect.
             // The node will then relay that address to the p2p-extractor eventually.

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -495,7 +495,7 @@ async fn test_integration_rpc_getorphantxs() {
                 .collect();
 
             // The receiving node needs to be out of IBD to start accepting transactions.
-            mine_and_wait_for_tip(&node1.client);
+            mine_and_wait_for_tip(&node1.client, &node1.client);
 
             // node1 is peer=0 of node2
             const PEER_ID: u64 = 0;

--- a/protobuf/log_extractor.proto
+++ b/protobuf/log_extractor.proto
@@ -20,6 +20,8 @@ message log {
     UnknownLogMessage unknown_log_message = 4;
     BlockConnectedLog block_connected_log = 5;
     BlockCheckedLog block_checked_log = 6;
+    SawNewHeaderLog saw_new_header_log = 9;
+    CompactBlockReconstructedLog compact_block_reconstructed_log = 10;
   }
 }
 
@@ -72,4 +74,23 @@ message BlockCheckedLog {
   required string block_hash = 1;
   required string state = 2;
   required string debug_message = 3;
+}
+
+// 2026-04-06T15:02:09.010720Z Saw new header hash=00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 height=943929 peer=498
+// 2026-04-30T14:42:51.622131Z Saw new cmpctblock header hash=00000000000000000001f143db1e9a20f4ab523c2e9e2367d4780eae09cba1fa height=947303 peer=6709
+message SawNewHeaderLog {
+  required string block_hash = 1;
+  required uint32 block_height = 2;
+  required uint32 peer_id = 3;
+  required bool is_cmpctblock = 4;
+}
+
+// 2026-04-06T15:02:09.404125Z [cmpctblock] Successfully reconstructed block 00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 with 1 txn prefilled, 2714 txn from mempool (incl at least 2 from extra pool) and 4 txn (886 bytes) requested
+message CompactBlockReconstructedLog {
+  required string block_hash = 1;
+  required uint32 prefilled_txn_count = 2;
+  required uint32 mempool_txn_count = 3;
+  required uint32 extra_pool_txn_count = 4;
+  required uint32 requested_txn_count = 5;
+  required uint32 requested_txn_bytes = 6;
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 async-nats = { version = "0.49.0", default-features = false }
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
-tokio = { version = "1.51.0", features = ["rt-multi-thread", "process", "signal"] }
+tokio = { version = "1.51.0", features = ["rt-multi-thread", "process", "signal", "test-util"] }
 tokio-util = { version = "0.7.18", features = ["compat"] }
 futures = "0.3.31"
 rand = "0.10.1"

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -1,6 +1,7 @@
 use crate::protobuf::log_extractor::log::LogEvent;
 use crate::protobuf::log_extractor::{
-    BlockCheckedLog, BlockConnectedLog, Log, LogDebugCategory, LogLevel, UnknownLogMessage,
+    BlockCheckedLog, BlockConnectedLog, CompactBlockReconstructedLog, Log, LogDebugCategory,
+    LogLevel, SawNewHeaderLog, UnknownLogMessage,
 };
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -78,6 +79,18 @@ lazy_static! {
         VALIDATION_STATE_PATTERN
     ))
     .unwrap();
+
+    static ref SAW_NEW_HEADER_REGEX: Regex = Regex::new(&format!(
+        r"Saw new (?:cmpctblock )?header hash=({}) height=(\d+) peer=(\d+)",
+        BLOCK_HASH_PATTERN
+    ))
+    .unwrap();
+
+    static ref COMPACT_BLOCK_RECONSTRUCTED_REGEX: Regex = Regex::new(&format!(
+        r"Successfully reconstructed block ({}) with (\d+) txn prefilled, (\d+) txn from mempool \(incl at least (\d+) from extra pool\) and (\d+) txn \((\d+) bytes\) requested",
+        BLOCK_HASH_PATTERN
+    ))
+    .unwrap();
 }
 
 trait LogMatcher {
@@ -122,6 +135,47 @@ impl LogMatcher for BlockCheckedLog {
     }
 }
 
+impl LogMatcher for SawNewHeaderLog {
+    fn parse_event(line: &str) -> Option<LogEvent> {
+        let caps = SAW_NEW_HEADER_REGEX.captures(line)?;
+
+        let block_hash = caps.get(1)?.as_str().to_string();
+        let block_height = caps.get(2)?.as_str().parse::<u32>().ok()?;
+        let peer_id = caps.get(3)?.as_str().parse::<u32>().ok()?;
+        let is_cmpctblock = line.contains("cmpctblock");
+
+        Some(LogEvent::SawNewHeaderLog(SawNewHeaderLog {
+            block_hash,
+            block_height,
+            peer_id,
+            is_cmpctblock,
+        }))
+    }
+}
+
+impl LogMatcher for CompactBlockReconstructedLog {
+    fn parse_event(line: &str) -> Option<LogEvent> {
+        let caps = COMPACT_BLOCK_RECONSTRUCTED_REGEX.captures(line)?;
+
+        let block_hash = caps.get(1)?.as_str().to_string();
+        let prefilled_txn_count = caps.get(2)?.as_str().parse::<u32>().ok()?;
+        let mempool_txn_count = caps.get(3)?.as_str().parse::<u32>().ok()?;
+        let extra_pool_txn_count = caps.get(4)?.as_str().parse::<u32>().ok()?;
+        let requested_txn_count = caps.get(5)?.as_str().parse::<u32>().ok()?;
+        let requested_txn_bytes = caps.get(6)?.as_str().parse::<u32>().ok()?;
+        Some(LogEvent::CompactBlockReconstructedLog(
+            CompactBlockReconstructedLog {
+                block_hash,
+                prefilled_txn_count,
+                mempool_txn_count,
+                extra_pool_txn_count,
+                requested_txn_count,
+                requested_txn_bytes,
+            },
+        ))
+    }
+}
+
 impl BlockCheckedLog {
     pub fn is_mutated_block(&self) -> bool {
         matches!(
@@ -144,8 +198,12 @@ pub fn parse_log_event(line: &str) -> Log {
         message,
     } = parse_common_log_data(line);
 
-    let matchers: Vec<fn(&str) -> Option<LogEvent>> =
-        vec![BlockConnectedLog::parse_event, BlockCheckedLog::parse_event];
+    let matchers: Vec<fn(&str) -> Option<LogEvent>> = vec![
+        BlockConnectedLog::parse_event,
+        BlockCheckedLog::parse_event,
+        SawNewHeaderLog::parse_event,
+        CompactBlockReconstructedLog::parse_event,
+    ];
     for matcher in &matchers {
         if let Some(event) = matcher(&message) {
             return Log {

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -716,4 +716,47 @@ mod tests {
         let log_event = parse_log_event(log);
         assert_eq!(log_event.log_level, LogLevel::Warning as i32);
     }
+
+    #[test]
+    fn test_log_matcher_saw_new_header() {
+        let log = "2026-04-06T15:02:09.010720Z Saw new header hash=00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 height=943929 peer=498";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.log_timestamp, 1775487729010720);
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::SawNewHeaderLog(event)) = log_event.log_event {
+            assert_eq!(
+                event.block_hash,
+                "00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5"
+            );
+            assert_eq!(event.block_height, 943929);
+            assert_eq!(event.peer_id, 498);
+            return;
+        }
+        panic!("Expected SawNewHeaderLog event");
+    }
+
+    #[test]
+    fn test_log_matcher_compact_block_reconstruction() {
+        let log = "2026-04-06T15:02:09.404125Z [cmpctblock] Successfully reconstructed block 00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 with 1 txn prefilled, 2714 txn from mempool (incl at least 2 from extra pool) and 4 txn (886 bytes) requested";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.log_timestamp, 1775487729404125);
+        assert_eq!(log_event.category, LogDebugCategory::Cmpctblock as i32);
+
+        if let Some(LogEvent::CompactBlockReconstructedLog(event)) = log_event.log_event {
+            assert_eq!(
+                event.block_hash,
+                "00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5"
+            );
+            assert_eq!(event.prefilled_txn_count, 1);
+            assert_eq!(event.mempool_txn_count, 2714);
+            assert_eq!(event.extra_pool_txn_count, 2);
+            assert_eq!(event.requested_txn_count, 4);
+            assert_eq!(event.requested_txn_bytes, 886);
+            return;
+        }
+        panic!("Expected CompactBlockReconstructedLog event");
+    }
 }

--- a/shared/src/protobuf/log_extractor.rs
+++ b/shared/src/protobuf/log_extractor.rs
@@ -29,6 +29,31 @@ impl fmt::Display for BlockCheckedLog {
     }
 }
 
+impl fmt::Display for SawNewHeaderLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SawNewHeader(hash={}, height={}, peer_id={}, is_compact_block={})",
+            self.block_hash, self.block_height, self.peer_id, self.is_cmpctblock
+        )
+    }
+}
+
+impl fmt::Display for CompactBlockReconstructedLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CompactBlockReconstructed(hash={}, prefilled={}, mempool={}, extra_pool={}, requested_count={}, requested_bytes={})",
+            self.block_hash,
+            self.prefilled_txn_count,
+            self.mempool_txn_count,
+            self.extra_pool_txn_count,
+            self.requested_txn_count,
+            self.requested_txn_bytes,
+        )
+    }
+}
+
 impl fmt::Display for log::LogEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -36,6 +61,10 @@ impl fmt::Display for log::LogEvent {
             log::LogEvent::BlockConnectedLog(block) => write!(f, "{}", block),
             log::LogEvent::BlockCheckedLog(block) => {
                 write!(f, "{}", block)
+            }
+            log::LogEvent::SawNewHeaderLog(header) => write!(f, "{}", header),
+            log::LogEvent::CompactBlockReconstructedLog(reconstructed) => {
+                write!(f, "{}", reconstructed)
             }
         }
     }

--- a/shared/src/testing/node.rs
+++ b/shared/src/testing/node.rs
@@ -34,9 +34,10 @@ fn wait_for_tip_post_ibd(node: &bitcoind::Client, expected_tip: BlockHash) {
     }
 }
 
-/// Mines one block on `node` and waits until that block is its active post-IBD tip.
-pub fn mine_and_wait_for_tip(node: &bitcoind::Client) {
-    let generated = node
+/// Mines one block on `miner` and waits until `observer` has that block as its
+/// active post-IBD tip.
+pub fn mine_and_wait_for_tip(miner: &bitcoind::Client, observer: &bitcoind::Client) {
+    let generated = miner
         .generate_to_address(1, &REGTEST_ADDRESS)
         .expect("failed to generate block while waiting for post-IBD tip");
     let block_hash = generated
@@ -47,5 +48,5 @@ pub fn mine_and_wait_for_tip(node: &bitcoind::Client) {
         .next()
         .expect("generatetoaddress returned no block hashes");
 
-    wait_for_tip_post_ibd(node, block_hash);
+    wait_for_tip_post_ibd(observer, block_hash);
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -25,12 +25,14 @@ use shared::protobuf::{
     rpc_extractor::{rpc, Addrman, AddrmanBucket, FeeEstimateMode},
 };
 use shared::tokio::sync::{oneshot, watch};
+use shared::tokio::time::Instant;
 use shared::util::{self, is_on_linkinglion_banlist};
 use shared::{async_nats, clap};
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 pub mod error;
 mod metrics;
@@ -60,6 +62,33 @@ pub struct Args {
     pub log_level: Level,
 }
 
+#[derive(Clone, Debug)]
+enum BandwidthMode {
+    Unknown,
+    High,
+    Low,
+}
+
+impl std::fmt::Display for BandwidthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BandwidthMode::Unknown => write!(f, "unknown"),
+            BandwidthMode::High => write!(f, "high"),
+            BandwidthMode::Low => write!(f, "low"),
+        }
+    }
+}
+
+/// Compact block reconstruction state tracking
+#[derive(Clone, Debug)]
+struct CompactBlockReconstruction {
+    started_at_microsec: Option<u64>,
+    ended_at_microsec: Option<u64>,
+    requested_txn_count: u32,
+    bandwidth_mode: BandwidthMode,
+    created_at: Instant,
+}
+
 /// State that's between processing events.
 /// This allows tracking differences between two statefull events.
 #[derive(Default, Debug)]
@@ -67,6 +96,9 @@ struct State {
     // Map of wtxid to bytes
     orphanage: HashMap<String, u64>,
     addrman: Addrman,
+
+    // block hash to compact block reconstruction state
+    compact_block_reconstruction: HashMap<String, CompactBlockReconstruction>,
 }
 
 /// runs the metrics tool
@@ -165,7 +197,7 @@ fn handle_event(
                 }
             }
             PeerObserverEvent::LogExtractor(l) => {
-                handle_log_event(&l, metrics);
+                handle_log_event(&l, state_arc, metrics);
             }
             PeerObserverEvent::IpcExtractor(ipc) => {
                 if let Some(e) = ipc.ipc_event {
@@ -1432,7 +1464,7 @@ fn handle_p2p_message(msg: &message::MessageEvent, timestamp_ms: u64, metrics: m
     }
 }
 
-fn handle_log_event(log: &Log, metrics: metrics::Metrics) {
+fn handle_log_event(log: &Log, state_arc: Arc<Mutex<State>>, metrics: metrics::Metrics) {
     let category = LogDebugCategory::try_from(log.category)
         .unwrap_or(LogDebugCategory::Unknown)
         .as_str_name()
@@ -1470,6 +1502,42 @@ fn handle_log_event(log: &Log, metrics: metrics::Metrics) {
                     .inc();
             }
         }
+        log::LogEvent::SawNewHeaderLog(block) => {
+            handle_compact_block_reconstruction_state(
+                block.block_hash.clone(),
+                |reconstruction| {
+                    reconstruction.started_at_microsec = Some(log.log_timestamp);
+                    reconstruction.bandwidth_mode = if block.is_cmpctblock {
+                        BandwidthMode::High
+                    } else {
+                        BandwidthMode::Low
+                    };
+                },
+                state_arc.clone(),
+                metrics.clone(),
+            );
+        }
+        log::LogEvent::CompactBlockReconstructedLog(block) => {
+            handle_compact_block_reconstruction_state(
+                block.block_hash.clone(),
+                |reconstruction| {
+                    reconstruction.ended_at_microsec = Some(log.log_timestamp);
+                    reconstruction.requested_txn_count = block.requested_txn_count;
+                },
+                state_arc.clone(),
+                metrics.clone(),
+            );
+
+            metrics
+                .log_compact_block_reconstruction_txs_requested
+                .inc_by(block.requested_txn_count.into());
+            metrics
+                .log_compact_block_reconstruction_requested_bytes
+                .inc_by(block.requested_txn_bytes.into());
+            metrics
+                .log_compact_block_reconstruction_txs_extra_pool
+                .inc_by(block.extra_pool_txn_count.into());
+        }
     }
 }
 
@@ -1479,4 +1547,56 @@ fn handle_ipc_event(e: &ipc_extractor::ipc::IpcEvent, metrics: metrics::Metrics)
             metrics.ipc_block_tip_height.set(tip.height as i64);
         }
     }
+}
+
+fn handle_compact_block_reconstruction_state(
+    block_hash: String,
+    update_reconstruction: impl FnOnce(&mut CompactBlockReconstruction),
+    state_arc: Arc<Mutex<State>>,
+    metrics: metrics::Metrics,
+) {
+    let mut state = state_arc.lock().expect("should be able to lock state_arc");
+    let reconstruction = state
+        .compact_block_reconstruction
+        .entry(block_hash.clone())
+        .or_insert_with(|| CompactBlockReconstruction {
+            started_at_microsec: None,
+            ended_at_microsec: None,
+            requested_txn_count: 0,
+            bandwidth_mode: BandwidthMode::Unknown,
+            created_at: Instant::now(),
+        });
+
+    update_reconstruction(reconstruction);
+
+    if let (Some(start), Some(end)) = (
+        reconstruction.started_at_microsec,
+        reconstruction.ended_at_microsec,
+    ) {
+        let tx_requested = reconstruction.requested_txn_count > 0;
+        let tx_requested_label = if tx_requested { "true" } else { "false" };
+        let duration_microsec = end.saturating_sub(start);
+
+        metrics
+            .log_compact_block_reconstruction_count
+            .with_label_values(&[
+                tx_requested_label,
+                &reconstruction.bandwidth_mode.to_string(),
+            ])
+            .inc();
+        metrics
+            .log_compact_block_reconstruction_time
+            .with_label_values(&[
+                tx_requested_label,
+                &reconstruction.bandwidth_mode.to_string(),
+            ])
+            .set(duration_microsec as i64);
+        state.compact_block_reconstruction.remove(&block_hash);
+    }
+
+    // if entries are older than 5 minutes, remove them to avoid unbounded
+    // growth of the hashmap in case of missing events
+    state
+        .compact_block_reconstruction
+        .retain(|_, reconstruction| reconstruction.created_at.elapsed() < Duration::from_mins(5));
 }

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -39,6 +39,8 @@ pub const LABEL_RPC_ASN: &str = "ASN";
 pub const LABEL_LOG_CATEGORY: &str = "category";
 pub const LABEL_LOG_LEVEL: &str = "level";
 pub const LABEL_LOG_MUTATED_BLOCK_STATUS: &str = "status";
+pub const LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_TX_REQUESTED: &str = "tx_requested";
+pub const LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_BANDWIDTH: &str = "bandwidth";
 
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
@@ -387,6 +389,11 @@ pub struct Metrics {
     pub log_block_connected_events: IntCounter,
     pub log_block_checked_events: IntCounter,
     pub log_mutated_blocks: IntCounterVec,
+    pub log_compact_block_reconstruction_count: IntCounterVec,
+    pub log_compact_block_reconstruction_time: IntGaugeVec,
+    pub log_compact_block_reconstruction_requested_bytes: IntCounter,
+    pub log_compact_block_reconstruction_txs_requested: IntCounter,
+    pub log_compact_block_reconstruction_txs_extra_pool: IntCounter,
 }
 
 impl Metrics {
@@ -605,6 +612,11 @@ impl Metrics {
         ic!(log_block_connected_events, "Number of block connected log events received.", registry);
         ic!(log_block_checked_events, "Number of block checked log events received.", registry);
         icv!(log_mutated_blocks, "Number of mutated blocks detected by status.", [LABEL_LOG_MUTATED_BLOCK_STATUS], registry);
+        icv!(log_compact_block_reconstruction_count, "Indicates how many times compact block reconstruction happened, with or without transaction requests and bandwidth mode.", [LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_TX_REQUESTED, LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_BANDWIDTH], registry);
+        igv!(log_compact_block_reconstruction_time, "Indicates how much time (microseconds) was spent reconstructing a compact block, with or without transaction requests and bandwidth mode.", [LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_TX_REQUESTED, LABEL_LOG_COMPACT_BLOCK_RECONSTRUCTION_BANDWIDTH], registry);
+        ic!(log_compact_block_reconstruction_requested_bytes, "The number of bytes requested for compact block reconstruction.", registry);
+        ic!(log_compact_block_reconstruction_txs_requested, "The number of transactions requested for compact block reconstruction.", registry);
+        ic!(log_compact_block_reconstruction_txs_extra_pool, "The number of transactions requested for compact block reconstruction that were found in the extra transaction pool.", registry);
 
         Self {
             registry,
@@ -813,12 +825,18 @@ impl Metrics {
             p2pextractor_invs_size,
             p2pextractor_feefilter_messages,
             p2pextractor_feefilter_last,
+
             // log-extractor
             log_events,
             log_bytes,
             log_block_connected_events,
             log_block_checked_events,
             log_mutated_blocks,
+            log_compact_block_reconstruction_count,
+            log_compact_block_reconstruction_time,
+            log_compact_block_reconstruction_requested_bytes,
+            log_compact_block_reconstruction_txs_requested,
+            log_compact_block_reconstruction_txs_extra_pool,
         }
     }
 }

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -172,7 +172,13 @@ async fn wait_for_metrics_ready(
     }
 }
 
-async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
+async fn start_metrics_service() -> (
+    u16,
+    NatsServerForTesting,
+    NatsPublisherForTesting,
+    watch::Sender<bool>,
+    tokio::task::JoinHandle<()>,
+) {
     setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
@@ -203,13 +209,26 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     // processed by the server before we publish the real test events.
     wait_for_metrics_ready(&nats_publisher, metrics_port, &mut metrics_handle).await;
 
-    for event in events {
-        debug!("publishing: {:?}", event);
-        nats_publisher
-            .publish(subject.to_string(), event.encode_to_vec())
-            .await;
-    }
+    (
+        metrics_port,
+        nats_server,
+        nats_publisher,
+        shutdown_tx,
+        metrics_handle,
+    )
+}
 
+async fn handle_metrics(callback: impl AsyncFnOnce(u16, NatsPublisherForTesting) -> ()) {
+    let (metrics_port, _nats_server, nats_publisher, shutdown_tx, metrics_handle) =
+        start_metrics_service().await;
+
+    callback(metrics_port, nats_publisher).await;
+
+    shutdown_tx.send(true).unwrap();
+    metrics_handle.await.unwrap();
+}
+
+async fn check_metrics(metrics_port: u16, expected: &str) {
     let expected_lines: Vec<&str> = expected.split('\n').collect();
 
     // Poll the metrics endpoint until all expected lines appear or we time out.
@@ -226,9 +245,22 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
         }
         sleep(Duration::from_millis(100)).await;
     }
+}
 
-    shutdown_tx.send(true).unwrap();
-    metrics_handle.await.unwrap();
+async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
+    handle_metrics(
+        |metrics_port: u16, nats_publisher: NatsPublisherForTesting| async move {
+            for event in events {
+                debug!("publishing: {:?}", event);
+                nats_publisher
+                    .publish(subject.to_string(), event.encode_to_vec())
+                    .await;
+            }
+
+            check_metrics(metrics_port, expected).await;
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3833,6 +3865,264 @@ async fn test_integration_metrics_ipc_block_tip() {
         r#"
         peerobserver_ipc_block_tip_height 867530
         "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_compact_block_reconstruction_requested_bytes() {
+    println!("test that log-extractor compact block reconstruction requested bytes metric work");
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: 1234,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::CompactBlockReconstructedLog(
+                    log_extractor::CompactBlockReconstructedLog {
+                        block_hash:
+                            "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1b"
+                                .to_string(),
+                        prefilled_txn_count: 1,
+                        mempool_txn_count: 396,
+                        extra_pool_txn_count: 0,
+                        requested_txn_count: 0,
+                        requested_txn_bytes: 777,
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::LogExtractor,
+        r#"
+        peerobserver_log_compact_block_reconstruction_requested_bytes 777
+        "#,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_metrics_compact_block_reconstruction_stats() {
+    println!("test that log-extractor compact block reconstruction stats metrics work");
+
+    let now_microsec = current_timestamp() * 1_000;
+
+    publish_and_check(
+        &[
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: now_microsec + 77777,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::CompactBlockReconstructedLog(
+                    log_extractor::CompactBlockReconstructedLog {
+                        block_hash:
+                            "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1b"
+                                .to_string(),
+                        prefilled_txn_count: 1,
+                        mempool_txn_count: 396,
+                        extra_pool_txn_count: 6,
+                        requested_txn_count: 3,
+                        requested_txn_bytes: 444,
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: now_microsec,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::SawNewHeaderLog(
+                    log_extractor::SawNewHeaderLog {
+                        block_hash:
+                            "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1b"
+                                .to_string(),
+                        block_height: 944942,
+                        peer_id: 30350,
+                        is_cmpctblock: true,
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: now_microsec + 37703,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::CompactBlockReconstructedLog(
+                    log_extractor::CompactBlockReconstructedLog {
+                        block_hash:
+                            "00000000000000000000f8a34d18b93b9385019b57ec13896f8c18a1d4d0d853"
+                                .to_string(),
+                        prefilled_txn_count: 1,
+                        mempool_txn_count: 396,
+                        extra_pool_txn_count: 7,
+                        requested_txn_count: 1,
+                        requested_txn_bytes: 777,
+                    },
+                )),
+            }))
+            .unwrap(),
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: now_microsec,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 4,
+                log_event: Some(log_extractor::log::LogEvent::SawNewHeaderLog(
+                    log_extractor::SawNewHeaderLog {
+                        block_hash:
+                            "00000000000000000000f8a34d18b93b9385019b57ec13896f8c18a1d4d0d853"
+                                .to_string(),
+                        block_height: 944942,
+                        peer_id: 30350,
+                        is_cmpctblock: false,
+                    },
+                )),
+            }))
+            .unwrap(),
+        ],
+        Subject::LogExtractor,
+        r#"
+        peerobserver_log_compact_block_reconstruction_time{bandwidth="low",tx_requested="true"} 37703
+        peerobserver_log_compact_block_reconstruction_time{bandwidth="high",tx_requested="true"} 77777
+        peerobserver_log_compact_block_reconstruction_count{bandwidth="low",tx_requested="true"} 1
+        peerobserver_log_compact_block_reconstruction_count{bandwidth="high",tx_requested="true"} 1
+        peerobserver_log_compact_block_reconstruction_txs_requested 4
+        peerobserver_log_compact_block_reconstruction_requested_bytes 1221
+        peerobserver_log_compact_block_reconstruction_txs_extra_pool 13
+        "#,
+    )
+    .await;
+}
+
+/// Test Case:
+/// orphan start log -> metrics stores it
+/// 10 mins pass -> log is expired and should be cleaned up
+/// another start log arrives -> store this new one and the old one is cleaned up
+/// both end log arrives -> it should submit only one metric
+#[tokio::test()]
+async fn test_integration_metrics_compact_block_reconstruction_state_cleanup() {
+    println!("test that log-extractor compact block reconstruction state cleanup works");
+
+    let now_microsec = current_timestamp() * 1_000;
+
+    let subject = Subject::LogExtractor.to_string();
+    let event_orphan_start = Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+        category: LogDebugCategory::Unknown.into(),
+        log_timestamp: now_microsec,
+        threadname: String::new(),
+        log_level: log_extractor::LogLevel::Info.into(),
+        log_line_bytes: 4,
+        log_event: Some(log_extractor::log::LogEvent::SawNewHeaderLog(
+            log_extractor::SawNewHeaderLog {
+                block_hash: "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1b"
+                    .to_string(),
+                block_height: 944942,
+                peer_id: 30350,
+                is_cmpctblock: true,
+            },
+        )),
+    }))
+    .unwrap();
+    let event_orphan_end = Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+        category: LogDebugCategory::Unknown.into(),
+        log_timestamp: now_microsec + 77777,
+        threadname: String::new(),
+        log_level: log_extractor::LogLevel::Info.into(),
+        log_line_bytes: 4,
+        log_event: Some(log_extractor::log::LogEvent::CompactBlockReconstructedLog(
+            log_extractor::CompactBlockReconstructedLog {
+                block_hash: "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1b"
+                    .to_string(),
+                prefilled_txn_count: 1,
+                mempool_txn_count: 396,
+                extra_pool_txn_count: 0,
+                requested_txn_count: 1,
+                requested_txn_bytes: 777,
+            },
+        )),
+    }))
+    .unwrap();
+
+    let event_start = Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+        category: LogDebugCategory::Unknown.into(),
+        log_timestamp: now_microsec,
+        threadname: String::new(),
+        log_level: log_extractor::LogLevel::Info.into(),
+        log_line_bytes: 4,
+        log_event: Some(log_extractor::log::LogEvent::SawNewHeaderLog(
+            log_extractor::SawNewHeaderLog {
+                block_hash: "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1a"
+                    .to_string(),
+                block_height: 944942,
+                peer_id: 30350,
+                is_cmpctblock: true,
+            },
+        )),
+    }))
+    .unwrap();
+    let event_end = Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+        category: LogDebugCategory::Unknown.into(),
+        log_timestamp: now_microsec + 77777,
+        threadname: String::new(),
+        log_level: log_extractor::LogLevel::Info.into(),
+        log_line_bytes: 4,
+        log_event: Some(log_extractor::log::LogEvent::CompactBlockReconstructedLog(
+            log_extractor::CompactBlockReconstructedLog {
+                block_hash: "000000000000000000015b62bd7219241b46793581d92e7df8ff11397b4e6f1a"
+                    .to_string(),
+                prefilled_txn_count: 1,
+                mempool_txn_count: 396,
+                extra_pool_txn_count: 0,
+                requested_txn_count: 1,
+                requested_txn_bytes: 777,
+            },
+        )),
+    }))
+    .unwrap();
+
+    handle_metrics(
+        |metrics_port: u16, nats_publisher: NatsPublisherForTesting| async move {
+            // orphan log
+            debug!("publishing: {:?}", event_orphan_start);
+            nats_publisher
+              .publish(subject.clone(), event_orphan_start.encode_to_vec())
+              .await;
+            sleep(Duration::from_millis(100)).await;
+
+            // simulate time passage
+            tokio::time::pause();
+            tokio::time::advance(Duration::from_mins(10)).await;
+            tokio::time::resume();
+
+            // cleanup trigger for orphan start log
+            debug!("publishing: {:?}", event_start);
+            nats_publisher
+                .publish(subject.clone(), event_start.encode_to_vec())
+                .await;
+            // submit trigger for second block hash
+            debug!("publishing: {:?}", event_end);
+            nats_publisher
+                .publish(subject.clone(), event_end.encode_to_vec())
+                .await;
+            // orphan end log arrives late, it should not submit nothing
+            debug!("publishing: {:?}", event_orphan_end);
+            nats_publisher
+                .publish(subject.clone(), event_orphan_end.encode_to_vec())
+                .await;
+            sleep(Duration::from_millis(100)).await;
+
+            let expected = "peerobserver_log_compact_block_reconstruction_count{bandwidth=\"high\",tx_requested=\"true\"} 1";
+            check_metrics(metrics_port, expected).await;
+        },
     )
     .await;
 }


### PR DESCRIPTION
No, this description wasn't AI generated, so don't simply skip it, it took quite some time :)

Inspired by @0xB10C post on delving [Stats on compact block reconstructions](https://delvingbitcoin.org/t/stats-on-compact-block-reconstructions/1052).

## What this PR does?

- Add log matchers for "Saw new header..." and "Successfully reconstructed block..." logs, which are the "start" and "end" points for measuring time;
- Add prometheus metrics for `log_compact_block_reconstruction_requested_bytes`, `log_compact_block_reconstruction_count` and `log_compact_block_reconstruction_time`.

## What kind of question could this PR answer?

- What is the proportion of compact block reconstructions that do not require transactions?
- What is the average size of requested transactions?
- What is the proportion of compact block reconstructions that happen in high-bandwidth connections?
- Is something affecting the reconstruction time of compact blocks? (anomaly/attacks)

## How reconstruction time is measured?

Bitcoin core outputs some logs when a block arrives, in this PR two of them are important for this, "Saw new header..." and "Successfully reconstructed block..." (with `-debug=cmpctblock` flag).

```
2026-04-06T15:02:09.010720Z Saw new header hash=00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 height=943929 peer=498
...
2026-04-06T15:02:09.404125Z [cmpctblock] Successfully reconstructed block 00000000000000000001405ace6e6e4abd39fd1e13d1b3434468ba99986b6ad5 with 1 txn prefilled, 2714 txn from mempool (incl at least 2 from extra pool) and 4 txn (886 bytes) requested
```

With them we know when the block was first seen and when our node have everything from that block. In that way we can take the diff between the dates and measure the elapsed time, a better measure is done with `-logtimemicros=1` as it will log the timestamp in microseconds.

## How do we know if the reconstruction was via low or high-bandwidth connection?

The heuristic here to know if it's a low or high bandwidth is if the "Saw new header..." has "cmpctblock" ([core ref code](https://github.com/bitcoin/bitcoin/blob/859215218667ca9f35d5adae0289e4a125798087/src/net_processing.cpp#L3543-L3549)). As [BIP-152](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki#specification-for-version-1) illustrates, the difference is if we receive first a `cmpctblock` message or `headers`/`inv`, if it's the first one, we are in a high-bandwidth connection.

## Using a gauge metric, how do we know if a new reconstruction happened?

As prometheus is a pull-based monitoring system, we can't just "emit" an event when a reconstruction happens, we'll update a value somewhere (gauge in this case). This generates a problem, what if `log_compact_block_reconstruction_time` measure the same time in a row, how do we know if it was the same reconstruction or a new one?

The solution for this is to use a counter metric, `log_compact_block_reconstruction_count`, that will be incremented every time we measure a reconstruction time, so if we see that the count increased, we know that the time measured is from a new reconstruction. This metric wasn't initially created to solve this problem, but it serves this purpose. It could be the block height but I saw some "zero" values on it (probably when I was messing with infra), so I sticked with a simple counter.

And of course, I consider this pretty rare, even more with the fact that we are measuring the time in microseconds, so the chances of two reconstructions taking the same microsecond time in a row are pretty low.

## How do we measure elapsed time if logs can arrive in different timings or even out of order?

We use a `HashMap` state in metrics tool to store "start" timestamp, "end" timestamp, how many transactions were requested, bandwidth mode and when this record was created. When we see a "Saw new header..." log, we store the "start" timestamp and bandwidth mode. When we see a "Successfully reconstructed block..." log, we store the "end" timestamp and how many transactions were requested.

The key is the block hash, when all data is there (start and end logs arrived), we can calculate the elapsed time and emit some metrics, then we remove this record from the `HashMap`. Also, if a record is there for more than 5 minutes, we remove it as well, this could be common to happen if node doesn't have `-debug=cmpctblock` flag as it will never receive the "end" log.
