### PR TITLE
fix(rpc-extractor): use OS-assigned port in integration tests

### DIFF
--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -10,9 +10,10 @@ use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
 use shared::protobuf::rpc_extractor::{self, EstimateSmartFee};
-use shared::tokio::sync::watch;
+use shared::tokio::sync::{oneshot, watch};
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
+use std::net::SocketAddr;
 
 mod error;
 pub mod metrics;
@@ -172,12 +173,13 @@ impl Args {
     }
 }
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+) -> Result<(), RuntimeError> {
     // Create metrics instance with its own registry
     let metrics = Metrics::new();
-
-    // Start the metric server with our custom registry.
-    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
 
     let auth: Auth = match args.rpc_cookie_file {
         Some(path) => Auth::CookieFile(path.into()),
@@ -192,6 +194,19 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .connect(&args.nats.address)
         .await?;
     log::info!("Connected to NATS server at {}", &args.nats.address);
+
+    // Start the metric server with our custom registry. This happens after
+    // the RPC client and NATS connection are set up so that any startup
+    // failure surfaces through the readiness barrier in tests (which races
+    // bound_addr_tx against the extractor task handle) instead of leaving
+    // the test to time out. Matches the order used in p2p_extractor::run.
+    let local_addr =
+        shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);

--- a/extractors/rpc/src/main.rs
+++ b/extractors/rpc/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -5,19 +5,9 @@ use shared::{
     simple_logger::SimpleLogger,
 };
 
-use std::net::TcpListener;
 use std::sync::Once;
 
 use rpc_extractor::Args;
-
-/// Get an available port for the metrics server.
-pub fn get_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to bind to port 0")
-        .local_addr()
-        .expect("Failed to get local addr")
-        .port()
-}
 
 static INIT: Once = Once::new();
 
@@ -117,7 +107,6 @@ pub fn make_test_args(
     nats_port: u16,
     rpc_url: String,
     cookie_file: String,
-    prometheus_address: String,
     rpcs: EnabledRPCsInTest,
 ) -> Args {
     Args::new(
@@ -132,7 +121,7 @@ pub fn make_test_args(
         cookie_file,
         QUERY_INTERVAL_SECONDS,
         QUERY_INTERVAL_SECONDS, // query_interval_less_frequent, but don't fetch less frequently in tests
-        prometheus_address,
+        "127.0.0.1:0".to_string(),
         !rpcs.getpeerinfo,
         !rpcs.getmempoolinfo,
         !rpcs.uptime,

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -3,9 +3,7 @@
 
 mod common;
 
-use common::{
-    EnabledRPCsInTest, get_available_port, make_test_args, setup, setup_two_connected_nodes,
-};
+use common::{EnabledRPCsInTest, make_test_args, setup, setup_two_connected_nodes};
 
 use shared::{
     async_nats,
@@ -29,7 +27,7 @@ use shared::{
     testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
     tokio::{
         self, select,
-        sync::watch,
+        sync::{oneshot, watch},
         time::{Duration, sleep},
     },
 };
@@ -48,7 +46,7 @@ async fn check(
     let (node1, node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     let url = node1.rpc_url().replace("http://", "");
     let cookie_file_path = node1.params.cookie_file.display().to_string();
@@ -57,18 +55,26 @@ async fn check(
     test_setup(&node1, &node2);
     sleep(Duration::from_secs(1)).await;
 
-    let rpc_extractor_handle = tokio::spawn(async move {
-        let args = make_test_args(
-            nats_server.port,
-            url,
-            cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
-            rpcs,
-        );
-        rpc_extractor::run(args, shutdown_rx.clone())
+    let mut rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(nats_server.port, url, cookie_file_path, rpcs);
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
             .await
             .expect("rpc extractor failed");
     });
+
+    // Wait for the rpc-extractor to bind its Prometheus port and report
+    // the OS-assigned address back. Race against the task handle so that
+    // if the extractor fails before binding (e.g. NATS connection error),
+    // we surface the real error instead of a generic "channel closed" panic.
+    select! {
+        addr = addr_rx => {
+            addr.expect("rpc-extractor should send bound address");
+        }
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    }
 
     let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
         .await

--- a/extractors/rpc/tests/metrics_integration.rs
+++ b/extractors/rpc/tests/metrics_integration.rs
@@ -4,8 +4,7 @@
 mod common;
 
 use common::{
-    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, get_available_port, make_test_args, setup,
-    setup_two_connected_nodes,
+    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, make_test_args, setup, setup_two_connected_nodes,
 };
 
 use shared::{
@@ -13,7 +12,10 @@ use shared::{
         metrics_fetcher::{fetch_metrics, get_metric_value},
         nats_server::NatsServerForTesting,
     },
-    tokio::{self, sync::watch},
+    tokio::{
+        self, select,
+        sync::{oneshot, watch},
+    },
 };
 
 /// Verifies the Prometheus metrics server starts and responds to HTTP requests.
@@ -23,23 +25,29 @@ async fn test_integration_metrics_server_basic() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
 
-    // Wait for the metrics server to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Fetch metrics and verify the server responds
     let metrics = fetch_metrics(metrics_port, "/metrics");
@@ -64,21 +72,30 @@ async fn test_integration_metrics_rpc_fetch_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // lightweight RPC
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -110,19 +127,28 @@ async fn test_integration_metrics_all_rpc_methods_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
     let rpcs = EnabledRPCsInTest::all();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest::all(),
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -156,27 +182,37 @@ async fn test_integration_metrics_rpc_fetch_errors() {
     setup();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    // Create a temporary cookie file (required by Args validation)
+    // Create a temporary cookie file (required by Args validation). Use the
+    // NATS server port as a per-test-unique suffix.
     let temp_dir = std::env::temp_dir();
-    let cookie_file = temp_dir.join(format!("test_cookie_{}", metrics_port));
+    let cookie_file = temp_dir.join(format!("test_cookie_{}", nats_server.port));
     std::fs::write(&cookie_file, "__cookie__:test").expect("Failed to write cookie file");
 
     let cookie_file_path = cookie_file.display().to_string();
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             "127.0.0.1:1".to_string(), // Unreachable RPC host
             cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // will fail
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle (which will fail)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -225,29 +261,39 @@ async fn test_integration_metrics_rpc_fetch_errors_invalid_auth() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    // Create a cookie file with invalid credentials
+    // Create a cookie file with invalid credentials. Use the NATS server
+    // port as a per-test-unique suffix.
     let temp_dir = std::env::temp_dir();
-    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", metrics_port));
+    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", nats_server.port));
     std::fs::write(&invalid_cookie_file, "__cookie__:invalid_password")
         .expect("Failed to write invalid cookie file");
 
     let invalid_cookie_path = invalid_cookie_file.display().to_string();
     let rpc_url = node1.rpc_url().replace("http://", "");
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             rpc_url,
             invalid_cookie_path,
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // will fail due to auth
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle (which will fail due to invalid auth)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;

--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -5,6 +5,7 @@ use std::error;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
+use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::string::FromUtf8Error;
@@ -15,7 +16,10 @@ const LOG_TARGET: &str = "metricserver";
 // This is a minimal, per request thread spawning, and incorrect HTTP server
 // which answers on all request methods with prometheus formatted metrics.
 
-pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(), io::Error> {
+pub fn start(
+    prometheus_address: &str,
+    registry: Option<Registry>,
+) -> Result<SocketAddr, io::Error> {
     let listener = TcpListener::bind(prometheus_address)?;
     let local_addr = listener.local_addr()?;
     log::info!(
@@ -42,7 +46,7 @@ pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(),
             };
         }
     });
-    Ok(())
+    Ok(local_addr)
 }
 
 fn handle_request(


### PR DESCRIPTION
## Summary

Apply the OS-assigned-port + readiness-oneshot pattern from #358 (p2p) and #365 (websocket) to the rpc-extractor integration tests, closing the rpc-extractor portion of #382.

`shared::metricserver::start` now returns `Result<SocketAddr, io::Error>` so callers can discover the bound port, and `rpc_extractor::run` accepts an optional `oneshot::Sender<SocketAddr>` that fires once the metrics server is listening. The body of `run()` is reordered so RPC client construction and NATS connect happen *before* `metricserver::start`, matching the p2p shape. The readiness barrier now catches RPC and NATS startup failures, not just the metricserver bind. (Deliberate ordering choice, different from #417.)

Tests pick up the p2p-style `tokio::select!` race against the extractor task handle (so startup failures surface as real errors, not `channel closed` panics) in both `check()` and the five `metrics_integration.rs` tests. The old `get_available_port()` helper and the now-unused `prometheus_address` parameter on `make_test_args` are removed.

The check() predicate refactor, state-readiness guards, and `TEST_TIMEOUT_SECONDS` bump that were part of into the original second commit are split out into a follow-up PR (per review feedback).

Fixes #382 (rpc-extractor).

## Testing

rpc-extractor crate stress on NixOS x86_64, 4-core: 20/20 green at `--test-threads=2`, 20/20 green at `--test-threads=4`. Zero `AddrInUse`, zero readiness-barrier panics.
