### PR TITLE
test(rpc-extractor): replace brittle getchaintxstats constants with relational check

### DIFF
--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -330,8 +330,23 @@ async fn test_integration_rpc_getchaintxstats() {
                             assert_eq!(stats.window_final_block_height, 201);
                             assert_eq!(stats.window_block_count, 200);
                             assert_eq!(stats.window_tx_count, Some(200));
-                            assert_eq!(stats.window_interval, Some(34));
-                            assert_eq!(stats.tx_rate, Some(5.882352941176471));
+                            // window_interval drifts with host load (block timestamp
+                            // deltas), so don't pin it to an exact value. tx_rate
+                            // must remain consistent with window_tx_count /
+                            // window_interval.
+                            let window_interval = stats
+                                .window_interval
+                                .expect("window_interval should be present");
+                            let tx_rate = stats.tx_rate.expect("tx_rate should be present");
+                            assert!(window_interval > 0);
+                            let expected_rate = 200.0 / window_interval as f64;
+                            assert!(
+                                (tx_rate - expected_rate).abs() < 1e-9,
+                                "tx_rate {} should match window_tx_count / window_interval = 200/{} = {}",
+                                tx_rate,
+                                window_interval,
+                                expected_rate
+                            );
                         }
                         _ => panic!("unexpected RPC data {:?}", r.rpc_event),
                     }


### PR DESCRIPTION
## Summary

`test_integration_rpc_getchaintxstats` previously pinned `stats.window_interval == Some(34)` and `stats.tx_rate == Some(5.882352941176471)`. Both fields derive from block timestamp deltas in the rolling window, and regtest generates blocks with real wall-clock timestamps, so the values drift with host load. A stress run on a slower host saw `window_interval=38, tx_rate~=5.263`, tripping the pinned values.

Replace them with the semantic invariant: `tx_rate` must equal `window_tx_count / window_interval` within f64 precision, plus `window_interval > 0`. The numerator `window_tx_count` is already asserted at `Some(200)` and is a transaction count rather than a timing derivative, so it is stable across host load.

## Testing

- `cargo fmt -- --check`
- `NATS_SERVER_BINARY=$(which nats-server) cargo test -p rpc-extractor --features nats_integration_tests,node_integration_tests test_integration_rpc_getchaintxstats -- --nocapture`
