### PR TITLE
Upgrade corepc crates (with custom patches)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "regex",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_repr",
@@ -218,6 +218,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoind"
+version = "0.38.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes",
+ "bitreq",
+ "corepc-client",
+ "flate2",
+ "log",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "which",
+ "zip",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,11 +249,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.3.5"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
+ "rustls",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -440,8 +458,8 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.13.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -452,27 +470,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "corepc-node"
-version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
-dependencies = [
- "anyhow",
- "bitcoin_hashes",
- "bitreq",
- "corepc-client",
- "flate2",
- "log",
- "serde_json",
- "tar",
- "tempfile",
- "which",
- "zip",
-]
-
-[[package]]
 name = "corepc-types"
 version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1078,8 +1078,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.19.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.20.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "base64 0.22.1",
  "bitreq",
@@ -1691,24 +1691,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -1736,31 +1726,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
-dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
@@ -1791,16 +1761,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secp256k1"
@@ -1934,9 +1894,9 @@ dependencies = [
  "async-nats",
  "base32",
  "bitcoin",
+ "bitcoind",
  "clap",
  "corepc-client",
- "corepc-node",
  "futures",
  "hex",
  "lazy_static",
@@ -2196,7 +2156,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.23",
+ "rustls",
  "tokio",
 ]
 
@@ -2435,9 +2395,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "websocket"

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -5,7 +5,7 @@ use log_extractor::Args;
 use shared::{
     async_nats,
     bitcoin::{Block, consensus::Decodable, hashes::Hash, hex::FromHex},
-    corepc_node,
+    bitcoind,
     futures::StreamExt,
     log::{Level, LevelFilter, info},
     nats_util::NatsArgs,
@@ -128,19 +128,19 @@ fn make_test_args(nats_port: u16, bitcoind_pipe: String) -> Args {
 /// Starts a regtest `bitcoind` node with the given configuration.
 ///
 /// The binary is resolved from the `BITCOIND_EXE` environment variable
-/// (via `corepc_node::exe_path`); if unset, a pre-built binary is
+/// (via `bitcoind::exe_path`); if unset, a pre-built binary is
 /// downloaded automatically.
-fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
 /// Creates a two-node regtest topology:
@@ -149,10 +149,10 @@ fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
 ///
 /// `node1_args` are appended as extra `bitcoind` CLI flags (e.g. `-debug=validation`) so tests
 /// can enable the specific logging needed to trigger the events they want to observe.
-fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corepc_node::Node) {
+fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (bitcoind::BitcoinD, bitcoind::BitcoinD) {
     // node1 listens for p2p connections
-    let mut node1_conf = corepc_node::Conf::default();
-    node1_conf.p2p = corepc_node::P2P::Yes;
+    let mut node1_conf = bitcoind::Conf::default();
+    node1_conf.p2p = bitcoind::P2P::Yes;
     for arg in node1_args {
         info!("Running node1 with arg: {}", arg);
         node1_conf.args.push(arg);
@@ -160,7 +160,7 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
     let node1 = setup_node(node1_conf);
 
     // node2 connects to node1
-    let mut node2_conf = corepc_node::Conf::default();
+    let mut node2_conf = bitcoind::Conf::default();
     node2_conf.p2p = node1.p2p_connect(true).unwrap();
     let node2 = setup_node(node2_conf);
 
@@ -193,7 +193,7 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
-    test_setup: fn(&corepc_node::Client),
+    test_setup: fn(&bitcoind::Client),
     check_event: fn(PeerObserverEvent) -> bool,
 ) {
     setup();

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -4,7 +4,7 @@
 use shared::{
     async_nats,
     bitcoin::{self, Amount},
-    corepc_node::{self},
+    bitcoind::{self},
     futures::StreamExt,
     log::{self, info},
     nats_util::NatsArgs,
@@ -72,21 +72,21 @@ fn make_test_args(
     )
 }
 
-fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
-fn configure_node() -> corepc_node::Node {
-    let mut node_conf = corepc_node::Conf::default();
+fn configure_node() -> bitcoind::BitcoinD {
+    let mut node_conf = bitcoind::Conf::default();
     node_conf.args = vec![
         "-regtest",
         "-debug=net",
@@ -100,7 +100,7 @@ fn configure_node() -> corepc_node::Node {
     // enabling this is useful for debugging, but enabling this by default will
     // be quite spammy.
     node_conf.view_stdout = false;
-    node_conf.p2p = corepc_node::P2P::Yes;
+    node_conf.p2p = bitcoind::P2P::Yes;
 
     setup_node(node_conf)
 }
@@ -110,7 +110,7 @@ async fn check(
     disable_addrv2: bool,
     disable_invs: bool,
     disable_feefilter: bool,
-    test_setup: fn(&corepc_node::Node),
+    test_setup: fn(&bitcoind::BitcoinD),
     mut check_expected: impl FnMut(PeerObserverEvent) -> bool,
 ) {
     setup();

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,9 +1,9 @@
+use shared::bitcoind::mtype::{
+    GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
+};
 use shared::clap::{ArgGroup, Parser};
 use shared::corepc_client::client_sync::Auth;
 use shared::corepc_client::client_sync::v30::{Client, FeeEstimateMode};
-use shared::corepc_node::mtype::{
-    GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
-};
 use shared::log;
 use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use shared::{
-    corepc_node,
+    bitcoind,
     log::{self, info},
     nats_util::NatsArgs,
     simple_logger::SimpleLogger,
@@ -148,27 +148,27 @@ pub fn make_test_args(
     )
 }
 
-pub fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+pub fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
-pub fn setup_two_connected_nodes() -> (corepc_node::Node, corepc_node::Node) {
+pub fn setup_two_connected_nodes() -> (bitcoind::BitcoinD, bitcoind::BitcoinD) {
     // node1 listens for p2p connections
-    let mut node1_conf = corepc_node::Conf::default();
-    node1_conf.p2p = corepc_node::P2P::Yes;
+    let mut node1_conf = bitcoind::Conf::default();
+    node1_conf.p2p = bitcoind::P2P::Yes;
     let node1 = setup_node(node1_conf);
 
     // node2 connects to node1
-    let mut node2_conf = corepc_node::Conf::default();
+    let mut node2_conf = bitcoind::Conf::default();
     node2_conf.p2p = node1.p2p_connect(true).unwrap();
     let node2 = setup_node(node2_conf);
 

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -13,7 +13,7 @@ use shared::{
         Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness, absolute,
         consensus, hashes::Hash, hex::DisplayHex, transaction,
     },
-    corepc_node,
+    bitcoind,
     futures::StreamExt,
     prost::Message,
     protobuf::{
@@ -41,7 +41,7 @@ const TEST_TIMEOUT_SECONDS: u64 = 5;
 
 async fn check(
     rpcs: EnabledRPCsInTest,
-    test_setup: fn(&corepc_node::Node, &corepc_node::Node),
+    test_setup: fn(&bitcoind::BitcoinD, &bitcoind::BitcoinD),
     check_expected: fn(PeerObserverEvent) -> (),
 ) {
     setup();

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -24,11 +24,11 @@ regex = "1.12"
 
 # Use custom commit to support:
 # - cpu_load and inv_to_send in getpeerinfo
-# (branch 2026-04-corepc-0.12+custom-peer-observer-patches)
+# (branch 2026-05-corepc-0.12+custom-peer-observer-patches)
 # When updating the Bitcoin Core version used, grep for CORE_VERSION_GREP
 # and update the corepc_client::types::v* to the new version.
-corepc-node = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["download", "30_2"] }
-corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["client-sync"]}
+bitcoind = { git = "https://github.com/0xb10c/corepc", rev = "8798e7f9c240c626dc3aa61adadeaf42f8221e40", features = ["download", "30_2"] }
+corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "8798e7f9c240c626dc3aa61adadeaf42f8221e40", features = ["client-sync"]}
 
 [build-dependencies]
 prost-build = "0.14"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,9 +2,9 @@
 
 pub extern crate async_nats;
 pub extern crate bitcoin;
+pub extern crate bitcoind;
 pub extern crate clap;
 pub extern crate corepc_client;
-pub extern crate corepc_node;
 pub extern crate futures;
 pub extern crate lazy_static;
 pub extern crate log;

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -12,7 +12,7 @@ use corepc_client::types::v30::{
 };
 
 // Ideally, all type imports should use the generic mtype types.
-use corepc_node::mtype::{
+use bitcoind::mtype::{
     EstimateSmartFee as RPCEstimateSmartFee, GetBlockchainInfo, GetChainTxStats, GetMempoolInfo,
     GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetOrphanTxsVerboseTwo,
     GetOrphanTxsVerboseTwoEntry,
@@ -390,7 +390,7 @@ impl From<GetBlockchainInfo> for BlockchainInfo {
             size_on_disk: info.size_on_disk,
             pruned: info.pruned,
             prune_height: info.prune_height.unwrap_or_default(),
-            prune_target_size: info.prune_target_size.map(|s| s as u64).unwrap_or_default(),
+            prune_target_size: info.prune_target_size.unwrap_or_default(),
             warnings: info.warnings,
         }
     }


### PR DESCRIPTION
This PR bumps `corepc`'s rev to `8798e7f` on [b10c's fork](https://github.com/0xB10C/corepc/tree/2026-05-corepc-0.12%2Bcustom-peer-observer-patches). 

Additionally this adjusts references  to `corepc_node`/`Node` in the codebase and regenerates Cargo.lock to satisfy `bitreq 0.3.5`. 
