### PR TITLE
fix(p2p): force tx-inv trickle in integration test via setmocktime

### DIFF
--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -321,6 +321,16 @@ async fn test_integration_p2pextractor_inv_annoucement() {
                     .send_to_address(&REGTEST_ADDRESS, Amount::from_sat(10000))
                     .unwrap();
             }
+            // Bitcoin Core schedules tx invs to outbound peers via Poisson trickle
+            // (OUTBOUND_INVENTORY_BROADCAST_INTERVAL, mean 2s). Advance mocktime
+            // to force the next SendMessages cycle to fire the trickle immediately
+            // instead of relying on the timeout to outlast the Poisson tail.
+            node.client
+                .call::<()>(
+                    "setmocktime",
+                    &[(util::current_timestamp() + 60 * 10).into()],
+                )
+                .unwrap();
         },
         {
             let mut wtx_count = 0usize;


### PR DESCRIPTION
## Summary

`test_integration_p2pextractor_inv_annoucement` still flakes (latest hit on the `nix-test-detect-intermittent-failures` job for #423). Bitcoin Core schedules tx invs to outbound peers via Poisson trickle with `OUTBOUND_INVENTORY_BROADCAST_INTERVAL` mean 2s, so against the test's 10s `check()` window there's actually a 0.67% chance of not firing (`P(no trickle fires) ≈ e^{-5} ≈ 0.67%`).

Fix: after the 5 `send_to_address` calls, jump mocktime forward 10min via `setmocktime`. Mirrors `test_integration_p2pextractor_addr_annoucement`, which has used this for the addr-relay Poisson for ages. Next `SendMessages` tick sees the timer expired and flushes immediately.

Note that previous fix `0ff2e0a` (closing #357) handled a different symptom, Wtx items split across multiple invs failing a strict `len() == NUM_TX` assertion.


## Testing

Local run: all 5 Wtx items arrive in a single inv batch the moment mocktime advances:

```
INFO  [integration] InventoryAnnouncement: [WTx(...), WTx(...), WTx(...), WTx(...), WTx(...)]
INFO  [integration] accumulated 5/5 Wtx items
test test_integration_p2pextractor_inv_annoucement ... ok
```