### PR TITLE
clean: move tokio-util to shared and re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,6 @@ dependencies = [
  "capnp-rpc",
  "capnpc",
  "shared",
- "tokio-util",
 ]
 
 [[package]]
@@ -1467,7 +1466,6 @@ name = "p2p-extractor"
 version = "0.1.0"
 dependencies = [
  "shared",
- "tokio-util",
 ]
 
 [[package]]
@@ -2080,6 +2078,7 @@ dependencies = [
  "simple_logger",
  "time",
  "tokio",
+ "tokio-util",
  "zstd",
 ]
 

--- a/extractors/ipc/Cargo.toml
+++ b/extractors/ipc/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 capnp = "0.25.1"
 capnp-rpc = "0.25.0"
 shared = { path = "../../shared" }
-tokio-util = { version = "0.7.18", features = ["compat"] }
 
 [features]
 # Treat warnings as a build error.

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -17,6 +17,7 @@ use shared::{
     futures::AsyncReadExt,
     protobuf::ipc_extractor::BlockTip,
     tokio::{self, net::UnixStream, task::JoinHandle},
+    tokio_util,
 };
 
 use crate::error::RuntimeError;

--- a/extractors/p2p/Cargo.toml
+++ b/extractors/p2p/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 shared = { path = "../../shared" }
-tokio-util = { version = "0.7", features = ["compat"] }
 
 [features]
 # Treat warnings as a build error.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,6 +17,7 @@ async-nats = { version = "0.48.0", default-features = false }
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
 tokio = { version = "1.51.0", features = ["rt-multi-thread", "process", "signal"] }
+tokio-util = { version = "0.7.18", features = ["compat"] }
 futures = "0.3.31"
 rand = "0.9.2"
 time = { version = "0.3.47", features = ["parsing"] }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -14,6 +14,7 @@ pub extern crate rand;
 pub extern crate serde;
 pub extern crate simple_logger;
 pub extern crate tokio;
+pub extern crate tokio_util;
 pub extern crate zstd;
 
 /// Mappings and implementation for the protobuf types used in NATS


### PR DESCRIPTION
Both the p2p-extractor and the ipc-extractor have a dependency on tokio-util. We can combine these in `shared` and re-export from there.

This is a followup to #379 and tracked in #436.