### PR TITLE
cleanup: In tests, pass structs for the checks we want to enable instead of bools

### DIFF
--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -177,22 +177,6 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn new(nats: nats_util::NatsArgs, bitcoind_path: String, bitcoind_pid: i32) -> Args {
-        Self {
-            nats,
-            bitcoind_path,
-            bitcoind_pid: Some(bitcoind_pid),
-            bitcoind_pid_file: None,
-            no_p2pmsg_tracepoints: false,
-            no_connection_tracepoints: false,
-            no_mempool_tracepoints: false,
-            no_validation_tracepoints: false,
-            log_level: log::Level::Debug,
-            libbpf_debug: false,
-            no_idle_exit: false,
-        }
-    }
-
     fn no_tracepoints_enabled(&self) -> bool {
         self.no_p2pmsg_tracepoints
             && self.no_connection_tracepoints

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -3,7 +3,7 @@ use shared::{
     clap::{self, Parser},
     log,
     nats_subjects::Subject,
-    nats_util::{self, NatsArgs},
+    nats_util,
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
@@ -46,23 +46,6 @@ pub struct Args {
     /// Interval (in seconds) in which to query from the Bitcoin Core IPC interface.
     #[arg(long, default_value_t = 10)]
     pub query_interval: u64,
-}
-
-impl Args {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        nats: NatsArgs,
-        log_level: log::Level,
-        ipc_socket_path: String,
-        query_interval: u64,
-    ) -> Args {
-        Self {
-            nats,
-            log_level,
-            ipc_socket_path,
-            query_interval,
-        }
-    }
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -27,17 +27,17 @@ pub const QUERY_INTERVAL_SECONDS: u64 = 1;
 const TEST_TIMEOUT_SECONDS: u64 = 5;
 
 pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
-    Args::new(
-        NatsArgs {
+    Args {
+        nats: NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
-        log::Level::Trace,
+        log_level: log::Level::Trace,
         ipc_socket_path,
-        QUERY_INTERVAL_SECONDS,
-    )
+        query_interval: QUERY_INTERVAL_SECONDS,
+    }
 }
 
 static INIT: Once = Once::new();

--- a/extractors/log/src/lib.rs
+++ b/extractors/log/src/lib.rs
@@ -5,7 +5,7 @@ use shared::clap::Parser;
 use shared::log;
 use shared::log_matchers::parse_log_event;
 use shared::nats_subjects::Subject;
-use shared::nats_util::{self, NatsArgs};
+use shared::nats_util;
 use shared::prost::Message;
 use shared::protobuf::event::Event;
 use shared::protobuf::event::event::PeerObserverEvent;
@@ -46,16 +46,6 @@ pub struct Args {
     /// "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html.
     #[arg(short, long, default_value_t = log::Level::Debug)]
     pub log_level: log::Level,
-}
-
-impl Args {
-    pub fn new(nats: NatsArgs, bitcoind_pipe: String, log_level: log::Level) -> Args {
-        Self {
-            nats,
-            bitcoind_pipe,
-            log_level,
-        }
-    }
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -113,16 +113,16 @@ fn spawn_pipe(log_path: String, pipe_path: String) {
 }
 
 fn make_test_args(nats_port: u16, bitcoind_pipe: String) -> Args {
-    Args::new(
-        NatsArgs {
+    Args {
+        nats: NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
         bitcoind_pipe,
-        Level::Trace,
-    )
+        log_level: Level::Trace,
+    }
 }
 
 /// Starts a regtest `bitcoind` node with the given configuration.

--- a/extractors/p2p/src/lib.rs
+++ b/extractors/p2p/src/lib.rs
@@ -14,7 +14,6 @@ use shared::{
     log,
     nats_subjects::Subject,
     nats_util,
-    nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         bitcoin_primitives,
@@ -127,34 +126,7 @@ pub struct Args {
     /// This allows disabling the feefilter annoucement events.
     #[arg(long, default_value_t = false)]
     pub disable_feefilter: bool,
-}
-
-impl Args {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        nats: NatsArgs,
-        log_level: log::Level,
-        p2p_address: String,
-        p2p_network: Network,
-        ping_interval: u64,
-        disable_ping: bool,
-        disable_addrv2: bool,
-        disable_invs: bool,
-        disable_feefilter: bool,
-    ) -> Args {
-        Self {
-            nats,
-            log_level,
-            p2p_address,
-            p2p_network,
-            ping_interval,
-            disable_ping,
-            disable_addrv2,
-            disable_invs,
-            disable_feefilter,
-            // when adding more disable_* args, make sure to update the disable_all below
-        }
-    }
+    // when adding more disable_* args, make sure to update the disable_all below
 }
 
 pub async fn run(

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -55,22 +55,22 @@ struct EnabledChecksInTest {
 }
 
 fn make_test_args(nats_port: u16, p2p_address: String, checks: EnabledChecksInTest) -> Args {
-    Args::new(
-        NatsArgs {
+    Args {
+        nats: NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
-        log::Level::Trace,
+        log_level: log::Level::Trace,
         p2p_address,
-        Network::Regtest,
-        PING_INTERVAL_SECONDS,
-        !checks.ping,
-        !checks.addrv2,
-        !checks.invs,
-        !checks.feefilter,
-    )
+        p2p_network: Network::Regtest,
+        ping_interval: PING_INTERVAL_SECONDS,
+        disable_ping: !checks.ping,
+        disable_addrv2: !checks.addrv2,
+        disable_invs: !checks.invs,
+        disable_feefilter: !checks.feefilter,
+    }
 }
 
 fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -46,14 +46,15 @@ fn setup() {
     });
 }
 
-fn make_test_args(
-    nats_port: u16,
-    p2p_address: String,
-    disable_ping: bool,
-    disable_addrv2: bool,
-    disable_invs: bool,
-    disable_feefilter: bool,
-) -> Args {
+#[derive(Default)]
+struct EnabledChecksInTest {
+    ping: bool,
+    addrv2: bool,
+    invs: bool,
+    feefilter: bool,
+}
+
+fn make_test_args(nats_port: u16, p2p_address: String, checks: EnabledChecksInTest) -> Args {
     Args::new(
         NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -65,10 +66,10 @@ fn make_test_args(
         p2p_address,
         Network::Regtest,
         PING_INTERVAL_SECONDS,
-        disable_ping,
-        disable_addrv2,
-        disable_invs,
-        disable_feefilter,
+        !checks.ping,
+        !checks.addrv2,
+        !checks.invs,
+        !checks.feefilter,
     )
 }
 
@@ -106,10 +107,7 @@ fn configure_node() -> bitcoind::BitcoinD {
 }
 
 async fn check(
-    disable_ping: bool,
-    disable_addrv2: bool,
-    disable_invs: bool,
-    disable_feefilter: bool,
+    checks: EnabledChecksInTest,
     test_setup: fn(&bitcoind::BitcoinD),
     mut check_expected: impl FnMut(PeerObserverEvent) -> bool,
 ) {
@@ -119,14 +117,7 @@ async fn check(
     let (addr_tx, addr_rx) = oneshot::channel();
 
     let mut p2p_extractor_handle = tokio::spawn(async move {
-        let args = make_test_args(
-            nats_server.port,
-            "127.0.0.1:0".to_string(),
-            disable_ping,
-            disable_addrv2,
-            disable_invs,
-            disable_feefilter,
-        );
+        let args = make_test_args(nats_server.port, "127.0.0.1:0".to_string(), checks);
         p2p_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
             .await
             .expect("p2p-extractor failed");
@@ -205,10 +196,10 @@ async fn test_integration_p2pextractor_ping_measurements() {
     println!("test that we receive Ping measurement P2P-extractor events");
 
     check(
-        false,
-        true,
-        true,
-        true,
+        EnabledChecksInTest {
+            ping: true,
+            ..Default::default()
+        },
         |_| (),
         |event| {
             match event {
@@ -240,10 +231,10 @@ async fn test_integration_p2pextractor_addr_annoucement() {
     println!("test that we receive AddressAnnouncement P2P-extractor events");
 
     check(
-        true,
-        false,
-        true,
-        true,
+        EnabledChecksInTest {
+            addrv2: true,
+            ..Default::default()
+        },
         |node| {
             // To self-announce our address, we need to be out ouf initial block download
             // Mine a block to get out of initial block download
@@ -301,10 +292,10 @@ async fn test_integration_p2pextractor_inv_annoucement() {
     const NUM_TX: usize = 5;
 
     check(
-        true,
-        true,
-        false,
-        true,
+        EnabledChecksInTest {
+            invs: true,
+            ..Default::default()
+        },
         |node| {
             // Mine to a wallet-owned address so the node has spendable UTXOs
             let address = node
@@ -378,10 +369,10 @@ async fn test_integration_p2pextractor_feefilter_annoucement() {
     println!("test that we receive FeefilterAnnouncement P2P-extractor events");
 
     check(
-        true,
-        true,
-        true,
-        false,
+        EnabledChecksInTest {
+            feefilter: true,
+            ..Default::default()
+        },
         |_node| {
             // No setup required as the node should automatically send a
             // feefilter message to us right after connecting.
@@ -531,10 +522,7 @@ async fn test_integration_p2p_testsshouldtimeout() {
     println!("test that we timeout long running tests");
 
     check(
-        true,
-        true,
-        true,
-        true,
+        EnabledChecksInTest::default(),
         |_node| {},
         |event| match event {
             PeerObserverEvent::P2pExtractor(_) => {

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -6,7 +6,7 @@ use shared::corepc_client::client_sync::Auth;
 use shared::corepc_client::client_sync::v30::{Client, FeeEstimateMode};
 use shared::log;
 use shared::nats_subjects::Subject;
-use shared::nats_util::{self, NatsArgs};
+use shared::nats_util;
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
 use shared::protobuf::rpc_extractor::{self, EstimateSmartFee};
@@ -121,56 +121,7 @@ pub struct Args {
     /// Disable querying and publishing of `estimatesmartfee` data.
     #[arg(long, default_value_t = false)]
     pub disable_estimatesmartfee: bool,
-}
-
-impl Args {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        nats: NatsArgs,
-        log_level: log::Level,
-        rpc_host: String,
-        rpc_cookie_file: String,
-        query_interval: u64,
-        query_interval_less_frequent: u64,
-        prometheus_address: String,
-        disable_getpeerinfo: bool,
-        disable_getmempoolinfo: bool,
-        disable_uptime: bool,
-        disable_getnettotals: bool,
-        disable_getmemoryinfo: bool,
-        disable_getaddrmaninfo: bool,
-        disable_getchaintxstats: bool,
-        disable_getnetworkinfo: bool,
-        disable_getblockchaininfo: bool,
-        disable_getorphantxs: bool,
-        disable_getrawaddrman: bool,
-        disable_estimatesmartfee: bool,
-    ) -> Args {
-        Self {
-            nats,
-            log_level,
-            rpc_host,
-            rpc_password: None,
-            rpc_user: None,
-            rpc_cookie_file: Some(rpc_cookie_file),
-            query_interval,
-            query_interval_less_frequent,
-            prometheus_address,
-            disable_getpeerinfo,
-            disable_getmempoolinfo,
-            disable_uptime,
-            disable_getnettotals,
-            disable_getmemoryinfo,
-            disable_getaddrmaninfo,
-            disable_getchaintxstats,
-            disable_getnetworkinfo,
-            disable_getblockchaininfo,
-            disable_getorphantxs,
-            disable_getrawaddrman,
-            disable_estimatesmartfee,
-            // when adding more disable_* args, make sure to update the disable_all below
-        }
-    }
+    // when adding more disable_* args, make sure to update the disable_all below
 }
 
 pub async fn run(

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -105,36 +105,38 @@ impl EnabledRPCsInTest {
 
 pub fn make_test_args(
     nats_port: u16,
-    rpc_url: String,
+    rpc_host: String,
     cookie_file: String,
     rpcs: EnabledRPCsInTest,
 ) -> Args {
-    Args::new(
-        NatsArgs {
+    Args {
+        nats: NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
-        log::Level::Trace,
-        rpc_url,
-        cookie_file,
-        QUERY_INTERVAL_SECONDS,
-        QUERY_INTERVAL_SECONDS, // query_interval_less_frequent, but don't fetch less frequently in tests
-        "127.0.0.1:0".to_string(),
-        !rpcs.getpeerinfo,
-        !rpcs.getmempoolinfo,
-        !rpcs.uptime,
-        !rpcs.getnettotals,
-        !rpcs.getmemoryinfo,
-        !rpcs.getaddrmaninfo,
-        !rpcs.getchaintxstats,
-        !rpcs.getnetworkinfo,
-        !rpcs.getblockchaininfo,
-        !rpcs.getorphantxs,
-        !rpcs.getrawaddrman,
-        !rpcs.estimatesmartfee,
-    )
+        log_level: log::Level::Trace,
+        rpc_host,
+        rpc_user: None,
+        rpc_password: None,
+        rpc_cookie_file: Some(cookie_file),
+        query_interval: QUERY_INTERVAL_SECONDS,
+        query_interval_less_frequent: QUERY_INTERVAL_SECONDS,
+        prometheus_address: "127.0.0.1:0".to_string(),
+        disable_getpeerinfo: !rpcs.getpeerinfo,
+        disable_getmempoolinfo: !rpcs.getmempoolinfo,
+        disable_uptime: !rpcs.uptime,
+        disable_getnettotals: !rpcs.getnettotals,
+        disable_getmemoryinfo: !rpcs.getmemoryinfo,
+        disable_getaddrmaninfo: !rpcs.getaddrmaninfo,
+        disable_getchaintxstats: !rpcs.getchaintxstats,
+        disable_getnetworkinfo: !rpcs.getnetworkinfo,
+        disable_getblockchaininfo: !rpcs.getblockchaininfo,
+        disable_getorphantxs: !rpcs.getorphantxs,
+        disable_getrawaddrman: !rpcs.getrawaddrman,
+        disable_estimatesmartfee: !rpcs.estimatesmartfee,
+    }
 }
 
 pub fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {

--- a/tools/alerts/tests/integration.rs
+++ b/tools/alerts/tests/integration.rs
@@ -26,15 +26,28 @@ use shared::{
 
 use std::time::Duration;
 
-/// Builds an `Args` instance pointing at the given NATS server
-fn make_test_args(
-    nats_port: u16,
+struct AlertSettingsInTest {
     ping_threshold: usize,
     ping_window_secs: u64,
     addr_threshold: usize,
     addr_window_secs: u64,
     peer_stale_secs: u64,
-) -> Args {
+}
+
+impl Default for AlertSettingsInTest {
+    fn default() -> Self {
+        Self {
+            ping_threshold: 10,
+            ping_window_secs: 60,
+            addr_threshold: 5,
+            addr_window_secs: 60,
+            peer_stale_secs: 3600,
+        }
+    }
+}
+
+/// Builds an `Args` instance pointing at the given NATS server
+fn make_test_args(nats_port: u16, settings: AlertSettingsInTest) -> Args {
     Args {
         nats: nats_util::NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -42,12 +55,12 @@ fn make_test_args(
             password: None,
             password_file: None,
         },
-        ping_threshold,
-        ping_window_secs,
-        addr_threshold,
-        addr_window_secs,
+        ping_threshold: settings.ping_threshold,
+        ping_window_secs: settings.ping_window_secs,
+        addr_threshold: settings.addr_threshold,
+        addr_window_secs: settings.addr_window_secs,
         log_level: log::Level::Trace,
-        peer_stale_secs,
+        peer_stale_secs: settings.peer_stale_secs,
     }
 }
 
@@ -205,8 +218,16 @@ impl TestHarness {
 #[tokio::test]
 async fn test_ping_spammer() {
     let ping_threshold = 3;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_ping_event(1, "1.2.3.4:8333", true);
     let subject = Subject::NetMsg.to_string();
@@ -233,8 +254,16 @@ async fn test_ping_spammer() {
 #[tokio::test]
 async fn test_addr_spammer() {
     let addr_threshold = 2;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_addr_event(2, "5.6.7.8:8333");
     let subject = Subject::NetMsg.to_string();
@@ -261,8 +290,16 @@ async fn test_addr_spammer() {
 #[tokio::test]
 async fn test_addrv2_spammer() {
     let addr_threshold = 2;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_addrv2_event(3, "9.10.11.12:8333");
     let subject = Subject::NetMsg.to_string();
@@ -287,7 +324,16 @@ async fn test_addrv2_spammer() {
 /// Verifies that outbound pings are silently dropped and never trigger an alert
 #[tokio::test]
 async fn test_ping_spammer_outbound_ignored() {
-    let mut harness = TestHarness::new(|port| make_test_args(port, 3, 60, 5, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold: 3,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     for _ in 0..4 {
         harness
@@ -313,7 +359,7 @@ async fn test_integration_alerts_fail_if_no_nats() {
     let (_, shutdown_rx) = watch::channel(false);
     let (alerter, _rx) = IntegrationTestAlerter::new();
     let alerts_handle = tokio::spawn(async move {
-        let args = make_test_args(65535, 10, 60, 5, 60, 3600);
+        let args = make_test_args(65535, AlertSettingsInTest::default());
         match alerts::run(args, alerter, shutdown_rx.clone()).await {
             Ok(_) => panic!("We should fail when no NATS server is reachable."),
             Err(e) => match e {
@@ -331,7 +377,8 @@ async fn test_integration_alerts_fail_if_no_nats() {
 #[tokio::test]
 async fn test_closed_connection_cleans_state() {
     // threshold=10 so peer 99 never becomes a spammer
-    let mut harness = TestHarness::new(|port| make_test_args(port, 10, 60, 5, 60, 3600)).await;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, AlertSettingsInTest::default())).await;
 
     harness
         .publisher
@@ -365,8 +412,16 @@ async fn test_closed_connection_cleans_state() {
 #[tokio::test]
 async fn test_ping_spammer_fires_only_once() {
     let ping_threshold = 3;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_ping_event(10, "20.21.22.23:8333", true);
     let subject = Subject::NetMsg.to_string();
@@ -398,8 +453,16 @@ async fn test_ping_spammer_fires_only_once() {
 #[tokio::test]
 async fn test_flagged_peer_disconnect_emits_disconnect_alert() {
     let ping_threshold = 3;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_ping_event(50, "50.51.52.53:8333", true);
     let subject = Subject::NetMsg.to_string();
@@ -440,8 +503,17 @@ async fn test_flagged_peer_disconnect_emits_disconnect_alert() {
 async fn test_stale_peer_cleanup_emits_disconnect_alert() {
     let ping_threshold = 3;
     // peer_stale_secs=1 so the cleanup tick evicts peer 60 quickly
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 1)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold,
+                peer_stale_secs: 1,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     let event = make_ping_event(60, "60.61.62.63:8333", true);
     let subject = Subject::NetMsg.to_string();
@@ -473,8 +545,16 @@ async fn test_stale_peer_cleanup_emits_disconnect_alert() {
 #[tokio::test]
 async fn test_undecodable_payload_does_not_kill_tool() {
     let ping_threshold = 3;
-    let mut harness =
-        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
 
     // Garbage payload first — must be logged and skipped, not propagated
     harness

--- a/tools/logger/src/lib.rs
+++ b/tools/logger/src/lib.rs
@@ -5,7 +5,6 @@ use shared::clap::Parser;
 use shared::futures::stream::StreamExt;
 use shared::log;
 use shared::nats_util;
-use shared::nats_util::NatsArgs;
 use shared::prost::Message;
 use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
@@ -79,33 +78,6 @@ impl Args {
             || self.ipc
             || self.p2p_extractor
             || self.log_extractor)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        nats_args: NatsArgs,
-        log_level: log::Level,
-        messages: bool,
-        connections: bool,
-        mempool: bool,
-        validation: bool,
-        rpc: bool,
-        ipc: bool,
-        p2p_extractor: bool,
-        log_extractor: bool,
-    ) -> Self {
-        Self {
-            nats: nats_args,
-            log_level,
-            messages,
-            connections,
-            mempool,
-            validation,
-            rpc,
-            ipc,
-            p2p_extractor,
-            log_extractor,
-        }
     }
 }
 

--- a/tools/logger/tests/integration.rs
+++ b/tools/logger/tests/integration.rs
@@ -66,18 +66,34 @@ pub fn get_logged_messages() -> Vec<String> {
     LOGS.lock().unwrap().clone()
 }
 
-#[allow(clippy::too_many_arguments)]
-fn make_test_args(
-    nats_port: u16,
+#[derive(Default)]
+struct EnabledLoggersInTest {
     messages: bool,
     connections: bool,
     mempool: bool,
     validation: bool,
     rpc: bool,
+    ipc: bool,
     p2p_extractor: bool,
     log_extractor: bool,
-    ipc_extractor: bool,
-) -> Args {
+}
+
+impl EnabledLoggersInTest {
+    fn all() -> Self {
+        Self {
+            messages: true,
+            connections: true,
+            mempool: true,
+            validation: true,
+            rpc: true,
+            ipc: true,
+            p2p_extractor: true,
+            log_extractor: true,
+        }
+    }
+}
+
+fn make_test_args(nats_port: u16, loggers: EnabledLoggersInTest) -> Args {
     Args::new(
         nats_util::NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -86,14 +102,14 @@ fn make_test_args(
             password_file: None,
         },
         log::Level::Trace,
-        messages,
-        connections,
-        mempool,
-        validation,
-        rpc,
-        p2p_extractor,
-        log_extractor,
-        ipc_extractor,
+        loggers.messages,
+        loggers.connections,
+        loggers.mempool,
+        loggers.validation,
+        loggers.rpc,
+        loggers.ipc,
+        loggers.p2p_extractor,
+        loggers.log_extractor,
     )
 }
 
@@ -123,17 +139,7 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let logger_handle = tokio::spawn(async move {
-        let args = make_test_args(
-            nats_server.port,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-        );
+        let args = make_test_args(nats_server.port, EnabledLoggersInTest::all());
         logger::run(args, shutdown_rx.clone()).await.unwrap();
     });
     // allow the logger tool to start
@@ -176,7 +182,7 @@ async fn test_integration_logger_fail_if_no_nats() {
     let logger_handle = tokio::spawn(async move {
         let args = make_test_args(
             65535, // There shouln't be a NATS server running on this port..
-            true, true, true, true, true, true, true, true,
+            EnabledLoggersInTest::all(),
         );
         match logger::run(args, shutdown_rx.clone()).await {
             Ok(_) => panic!("We should fail when no NATS server is reachable."),

--- a/tools/logger/tests/integration.rs
+++ b/tools/logger/tests/integration.rs
@@ -94,23 +94,23 @@ impl EnabledLoggersInTest {
 }
 
 fn make_test_args(nats_port: u16, loggers: EnabledLoggersInTest) -> Args {
-    Args::new(
-        nats_util::NatsArgs {
+    Args {
+        nats: nats_util::NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
-        log::Level::Trace,
-        loggers.messages,
-        loggers.connections,
-        loggers.mempool,
-        loggers.validation,
-        loggers.rpc,
-        loggers.ipc,
-        loggers.p2p_extractor,
-        loggers.log_extractor,
-    )
+        log_level: log::Level::Trace,
+        messages: loggers.messages,
+        connections: loggers.connections,
+        mempool: loggers.mempool,
+        validation: loggers.validation,
+        rpc: loggers.rpc,
+        ipc: loggers.ipc,
+        p2p_extractor: loggers.p2p_extractor,
+        log_extractor: loggers.log_extractor,
+    }
 }
 
 fn check_logs(expected: &[&str]) -> Result<bool, std::io::Error> {

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -6,7 +6,7 @@ use shared::clap::Parser;
 use shared::futures::StreamExt;
 use shared::log::{info, warn, Level};
 use shared::metricserver;
-use shared::nats_util::{self, NatsArgs};
+use shared::nats_util;
 use shared::prost::Message;
 use shared::protobuf::bitcoin_primitives;
 use shared::protobuf::{
@@ -51,21 +51,12 @@ pub struct Args {
 
     /// The metrics server address the tool should listen on.
     #[arg(short, long, default_value = "127.0.0.1:8282")]
-    metrics_address: String,
+    pub metrics_address: String,
+
     /// The log level the tool should run with. Valid log levels
     /// are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = Level::Debug)]
     pub log_level: Level,
-}
-
-impl Args {
-    pub fn new(nats: NatsArgs, metrics_address: String, log_level: Level) -> Self {
-        Self {
-            nats,
-            metrics_address,
-            log_level,
-        }
-    }
 }
 
 /// State that's between processing events.

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -87,16 +87,16 @@ fn setup() -> u16 {
 }
 
 fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
-    Args::new(
-        NatsArgs {
+    Args {
+        nats: NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
             password: None,
             password_file: None,
         },
-        format!("127.0.0.1:{}", metrics_port),
-        Level::Trace,
-    )
+        metrics_address: format!("127.0.0.1:{}", metrics_port),
+        log_level: Level::Trace,
+    }
 }
 
 fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {


### PR DESCRIPTION
While the bools where fine initially with very few args, it got unreadable and bug prone with more. Additionally, we need to touch unrelated tests when we add a new feature.

Pass structs instead. Similar to the RPC extractor tests in https://github.com/peer-observer/peer-observer/blob/dc0af9251d41b54facef1c9b1077b76ad0e40170/extractors/rpc/tests/common/mod.rs#L26-L60

This PR also drops our implementations of Args::new() and constructs an Args struct in the test. This has the benefit of being a lot clearer on which argument ends up at which position in the struct.