### PR TITLE
Extend ipc-extractor to test bitcoin/bitcoin#29409

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,8 +199,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-capnp-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa52688d21da328acfaa3f23cd91b4dc1a7f01b02adc42d93438d714391dc52e"
+source = "git+https://github.com/xyzconstant/bitcoin-capnp-types?rev=e0756a5588cc5fee55b5c5e55ef5911e78a34f05#e0756a5588cc5fee55b5c5e55ef5911e78a34f05"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/extractors/ipc/Cargo.toml
+++ b/extractors/ipc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # Import the Cap'N Proto schemas for Bitcoin Core v31.0.
-bitcoin-capnp-types = "0.2.1"
+bitcoin-capnp-types = { git = "https://github.com/xyzconstant/bitcoin-capnp-types", rev = "e0756a5588cc5fee55b5c5e55ef5911e78a34f05" }
 shared = { path = "../../shared" }
 
 [features]

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -2,7 +2,7 @@ use bitcoin_capnp_types::{
     capnp,
     capnp::Error as CapnpError,
     capnp_rpc::{self, Disconnector, RpcSystem, rpc_twoparty_capnp, twoparty},
-    chain_capnp::{chain::Client as ChainClient, chain_notifications},
+    chain_capnp::{self, chain::Client as ChainClient, chain_notifications},
     handler_capnp::handler::Client as HandlerClient,
     init_capnp::init::Client as InitClient,
     mining_capnp::mining::Client as MiningClient,
@@ -11,81 +11,32 @@ use bitcoin_capnp_types::{
 
 use shared::{
     anyhow::Result,
+    bitcoin::{self, consensus::Decodable, hashes::Hash},
     futures::AsyncReadExt,
-    protobuf::ipc_extractor::BlockTip,
+    protobuf::{
+        bitcoin_primitives,
+        ipc_extractor::{
+            BlockConnected, BlockDisconnected, BlockInfo, BlockTip, ChainStateFlushed,
+            ChainstateRole, TransactionAddedToMempool, TransactionRemovedFromMempool,
+        },
+    },
     tokio::{self, net::UnixStream, task::JoinHandle},
     tokio_util,
 };
 
-struct ChainNotificationsImpl;
-
-impl chain_notifications::Server for ChainNotificationsImpl {
-    async fn destroy(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::DestroyParams,
-        _: chain_notifications::DestroyResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn transaction_added_to_mempool(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::TransactionAddedToMempoolParams,
-        _: chain_notifications::TransactionAddedToMempoolResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn transaction_removed_from_mempool(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::TransactionRemovedFromMempoolParams,
-        _: chain_notifications::TransactionRemovedFromMempoolResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn block_connected(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::BlockConnectedParams,
-        _: chain_notifications::BlockConnectedResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn block_disconnected(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::BlockDisconnectedParams,
-        _: chain_notifications::BlockDisconnectedResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn updated_block_tip(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::UpdatedBlockTipParams,
-        _: chain_notifications::UpdatedBlockTipResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-
-    async fn chain_state_flushed(
-        self: capnp::capability::Rc<Self>,
-        _: chain_notifications::ChainStateFlushedParams,
-        _: chain_notifications::ChainStateFlushedResults,
-    ) -> Result<(), CapnpError> {
-        Ok(())
-    }
-}
+use std::future::Future;
+use std::pin::Pin;
 
 pub struct IpcClient {
     pub reader: IpcReader,
-    pub listener: IpcListener,
     pub rpc_task: JoinHandle<Result<(), CapnpError>>,
     pub disconnector: Disconnector<rpc_twoparty_capnp::Side>,
+    init: InitClient,
+    thread: ThreadClient,
 }
 
 impl IpcClient {
-    pub async fn init(stream: UnixStream) -> Result<Self> {
+    pub async fn connect(stream: UnixStream) -> Result<Self> {
         let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
         let network = Box::new(twoparty::VatNetwork::new(
             reader,
@@ -118,24 +69,37 @@ impl IpcClient {
         set_context(req.get().get_context()?, &thread);
         let mining: MiningClient = req.send().promise.await?.get()?.get_result()?;
 
-        let mut req = init.make_chain_request();
-        set_context(req.get().get_context()?, &thread);
+        let reader = IpcReader {
+            mining,
+            thread: thread.clone(),
+        };
+
+        Ok(Self {
+            reader,
+            rpc_task,
+            disconnector,
+            init,
+            thread,
+        })
+    }
+
+    pub async fn subscribe_chain_notifications(
+        &self,
+        callbacks: ChainCallbacks,
+    ) -> Result<IpcListener> {
+        let mut req = self.init.make_chain_request();
+        set_context(req.get().get_context()?, &self.thread);
         let chain: ChainClient = req.send().promise.await?.get()?.get_result()?;
 
         let mut req = chain.handle_notifications_request();
-        set_context(req.get().get_context()?, &thread);
+        set_context(req.get().get_context()?, &self.thread);
         req.get()
-            .set_notifications(capnp_rpc::new_client(ChainNotificationsImpl));
+            .set_notifications(capnp_rpc::new_client(ChainNotificationsImpl { callbacks }));
         let handler: HandlerClient = req.send().promise.await?.get()?.get_result()?;
 
-        Ok(Self {
-            reader: IpcReader {
-                mining,
-                thread: thread.clone(),
-            },
-            listener: IpcListener { handler, thread },
-            rpc_task,
-            disconnector,
+        Ok(IpcListener {
+            handler,
+            thread: self.thread.clone(),
         })
     }
 }
@@ -165,11 +129,6 @@ impl IpcReader {
     }
 }
 
-fn set_context(mut ctx: proxy_capnp::context::Builder<'_>, thread: &ThreadClient) {
-    ctx.set_thread(thread.clone());
-    ctx.set_callback_thread(thread.clone());
-}
-
 pub struct IpcListener {
     pub handler: HandlerClient,
     pub thread: ThreadClient,
@@ -182,4 +141,127 @@ impl IpcListener {
         req.send().promise.await?;
         Ok(())
     }
+}
+
+pub type EventFut = Pin<Box<dyn Future<Output = ()>>>;
+
+pub struct ChainCallbacks {
+    pub on_block_connected: Box<dyn Fn(BlockConnected) -> EventFut>,
+    pub on_block_disconnected: Box<dyn Fn(BlockDisconnected) -> EventFut>,
+    pub on_tx_added: Box<dyn Fn(TransactionAddedToMempool) -> EventFut>,
+    pub on_tx_removed: Box<dyn Fn(TransactionRemovedFromMempool) -> EventFut>,
+    pub on_chain_state_flushed: Box<dyn Fn(ChainStateFlushed) -> EventFut>,
+    pub on_updated_block_tip: Box<dyn Fn() -> EventFut>,
+}
+
+struct ChainNotificationsImpl {
+    callbacks: ChainCallbacks,
+}
+
+impl chain_notifications::Server for ChainNotificationsImpl {
+    async fn destroy(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::DestroyParams,
+        _: chain_notifications::DestroyResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn transaction_added_to_mempool(
+        self: capnp::capability::Rc<Self>,
+        params: chain_notifications::TransactionAddedToMempoolParams,
+        _: chain_notifications::TransactionAddedToMempoolResults,
+    ) -> Result<(), CapnpError> {
+        let tx = parse_transaction(params.get()?.get_tx()?)?;
+        (self.callbacks.on_tx_added)(TransactionAddedToMempool { tx }).await;
+        Ok(())
+    }
+
+    async fn transaction_removed_from_mempool(
+        self: capnp::capability::Rc<Self>,
+        params: chain_notifications::TransactionRemovedFromMempoolParams,
+        _: chain_notifications::TransactionRemovedFromMempoolResults,
+    ) -> Result<(), CapnpError> {
+        let r = params.get()?;
+        let tx = parse_transaction(r.get_tx()?)?;
+        let reason = r.get_reason();
+        (self.callbacks.on_tx_removed)(TransactionRemovedFromMempool { tx, reason }).await;
+        Ok(())
+    }
+
+    async fn block_connected(
+        self: capnp::capability::Rc<Self>,
+        params: chain_notifications::BlockConnectedParams,
+        _: chain_notifications::BlockConnectedResults,
+    ) -> Result<(), CapnpError> {
+        let r = params.get()?;
+        let role = parse_chainstate_role(r.get_role()?);
+        let block = parse_block_info(r.get_block()?)?;
+        (self.callbacks.on_block_connected)(BlockConnected { role, block }).await;
+        Ok(())
+    }
+
+    async fn block_disconnected(
+        self: capnp::capability::Rc<Self>,
+        params: chain_notifications::BlockDisconnectedParams,
+        _: chain_notifications::BlockDisconnectedResults,
+    ) -> Result<(), CapnpError> {
+        let block = parse_block_info(params.get()?.get_block()?)?;
+        (self.callbacks.on_block_disconnected)(BlockDisconnected { block }).await;
+        Ok(())
+    }
+
+    async fn updated_block_tip(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::UpdatedBlockTipParams,
+        _: chain_notifications::UpdatedBlockTipResults,
+    ) -> Result<(), CapnpError> {
+        (self.callbacks.on_updated_block_tip)().await;
+        Ok(())
+    }
+
+    async fn chain_state_flushed(
+        self: capnp::capability::Rc<Self>,
+        params: chain_notifications::ChainStateFlushedParams,
+        _: chain_notifications::ChainStateFlushedResults,
+    ) -> Result<(), CapnpError> {
+        let r = params.get()?;
+        let role = parse_chainstate_role(r.get_role()?);
+        let locator = r.get_locator()?.to_vec();
+        (self.callbacks.on_chain_state_flushed)(ChainStateFlushed { role, locator }).await;
+        Ok(())
+    }
+}
+
+fn set_context(mut ctx: proxy_capnp::context::Builder<'_>, thread: &ThreadClient) {
+    ctx.set_thread(thread.clone());
+    ctx.set_callback_thread(thread.clone());
+}
+
+fn parse_chainstate_role(r: chain_capnp::chainstate_role::Reader<'_>) -> ChainstateRole {
+    ChainstateRole {
+        validated: r.get_validated(),
+        historical: r.get_historical(),
+    }
+}
+
+fn parse_block_info(r: chain_capnp::block_info::Reader<'_>) -> Result<BlockInfo, CapnpError> {
+    Ok(BlockInfo {
+        height: r.get_height(),
+        hash: r.get_hash()?.to_vec(),
+        prev_hash: r.get_prev_hash()?.to_vec(),
+        chain_time_max: Some(r.get_chain_time_max()),
+    })
+}
+
+fn parse_transaction(raw: &[u8]) -> Result<bitcoin_primitives::Transaction, CapnpError> {
+    let parsed = bitcoin::Transaction::consensus_decode(&mut &raw[..])
+        .map_err(|e| CapnpError::failed(format!("tx decode failed: {e}")))?;
+    let txid = parsed.compute_txid().to_byte_array().to_vec();
+    let wtxid = parsed.compute_wtxid().to_byte_array().to_vec();
+    Ok(bitcoin_primitives::Transaction {
+        txid,
+        wtxid,
+        raw: Some(raw.to_vec()),
+    })
 }

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -6,7 +6,7 @@ use bitcoin_capnp_types::{
     handler_capnp::handler::Client as HandlerClient,
     init_capnp::init::Client as InitClient,
     mining_capnp::mining::Client as MiningClient,
-    proxy_capnp::{self, thread::Client as ThreadClient},
+    proxy_capnp::{self, thread::Client as ThreadClient, thread_map::Client as ThreadMapClient},
 };
 
 use shared::{
@@ -99,38 +99,41 @@ impl IpcClient {
         let disconnector = rpc_system.get_disconnector();
         let rpc_task = tokio::task::spawn_local(rpc_system);
 
-        let response = init.construct_request().send().promise.await?;
-        let thread_map = response.get()?.get_thread_map()?;
-        let response = thread_map.make_thread_request().send().promise.await?;
-        let thread = response.get()?.get_result()?;
+        let thread_map: ThreadMapClient = init
+            .construct_request()
+            .send()
+            .promise
+            .await?
+            .get()?
+            .get_thread_map()?;
+        let thread: ThreadClient = thread_map
+            .make_thread_request()
+            .send()
+            .promise
+            .await?
+            .get()?
+            .get_result()?;
 
         let mut req = init.make_mining_request();
         set_context(req.get().get_context()?, &thread);
-        let response = req.send().promise.await?;
-        let mining = response.get()?.get_result()?;
+        let mining: MiningClient = req.send().promise.await?.get()?.get_result()?;
 
         let mut req = init.make_chain_request();
         set_context(req.get().get_context()?, &thread);
-        let response = req.send().promise.await?;
-        let chain: ChainClient = response.get()?.get_result()?;
+        let chain: ChainClient = req.send().promise.await?.get()?.get_result()?;
 
-        let notif_client: chain_notifications::Client =
-            capnp_rpc::new_client(ChainNotificationsImpl);
         let mut req = chain.handle_notifications_request();
         set_context(req.get().get_context()?, &thread);
-        req.get().set_notifications(notif_client);
-        let handler = req.send().promise.await?.get()?.get_result()?;
-
-        let listener = IpcListener {
-            handler,
-            thread: thread.clone(),
-        };
-
-        let reader = IpcReader { mining, thread };
+        req.get()
+            .set_notifications(capnp_rpc::new_client(ChainNotificationsImpl));
+        let handler: HandlerClient = req.send().promise.await?.get()?.get_result()?;
 
         Ok(Self {
-            reader,
-            listener,
+            reader: IpcReader {
+                mining,
+                thread: thread.clone(),
+            },
+            listener: IpcListener { handler, thread },
             rpc_task,
             disconnector,
         })

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -1,6 +1,9 @@
 use bitcoin_capnp_types::{
+    capnp,
     capnp::Error as CapnpError,
-    capnp_rpc::{Disconnector, RpcSystem, rpc_twoparty_capnp, twoparty},
+    capnp_rpc::{self, Disconnector, RpcSystem, rpc_twoparty_capnp, twoparty},
+    chain_capnp::{chain::Client as ChainClient, chain_notifications},
+    handler_capnp::handler::Client as HandlerClient,
     init_capnp::init::Client as InitClient,
     mining_capnp::mining::Client as MiningClient,
     proxy_capnp::{self, thread::Client as ThreadClient},
@@ -14,8 +17,69 @@ use shared::{
     tokio_util,
 };
 
+struct ChainNotificationsImpl;
+
+impl chain_notifications::Server for ChainNotificationsImpl {
+    async fn destroy(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::DestroyParams,
+        _: chain_notifications::DestroyResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn transaction_added_to_mempool(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::TransactionAddedToMempoolParams,
+        _: chain_notifications::TransactionAddedToMempoolResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn transaction_removed_from_mempool(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::TransactionRemovedFromMempoolParams,
+        _: chain_notifications::TransactionRemovedFromMempoolResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn block_connected(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::BlockConnectedParams,
+        _: chain_notifications::BlockConnectedResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn block_disconnected(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::BlockDisconnectedParams,
+        _: chain_notifications::BlockDisconnectedResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn updated_block_tip(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::UpdatedBlockTipParams,
+        _: chain_notifications::UpdatedBlockTipResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+
+    async fn chain_state_flushed(
+        self: capnp::capability::Rc<Self>,
+        _: chain_notifications::ChainStateFlushedParams,
+        _: chain_notifications::ChainStateFlushedResults,
+    ) -> Result<(), CapnpError> {
+        Ok(())
+    }
+}
+
 pub struct IpcClient {
     pub reader: IpcReader,
+    pub listener: IpcListener,
     pub rpc_task: JoinHandle<Result<(), CapnpError>>,
     pub disconnector: Disconnector<rpc_twoparty_capnp::Side>,
 }
@@ -45,10 +109,28 @@ impl IpcClient {
         let response = req.send().promise.await?;
         let mining = response.get()?.get_result()?;
 
+        let mut req = init.make_chain_request();
+        set_context(req.get().get_context()?, &thread);
+        let response = req.send().promise.await?;
+        let chain: ChainClient = response.get()?.get_result()?;
+
+        let notif_client: chain_notifications::Client =
+            capnp_rpc::new_client(ChainNotificationsImpl);
+        let mut req = chain.handle_notifications_request();
+        set_context(req.get().get_context()?, &thread);
+        req.get().set_notifications(notif_client);
+        let handler = req.send().promise.await?.get()?.get_result()?;
+
+        let listener = IpcListener {
+            handler,
+            thread: thread.clone(),
+        };
+
         let reader = IpcReader { mining, thread };
 
         Ok(Self {
             reader,
+            listener,
             rpc_task,
             disconnector,
         })
@@ -83,4 +165,18 @@ impl IpcReader {
 fn set_context(mut ctx: proxy_capnp::context::Builder<'_>, thread: &ThreadClient) {
     ctx.set_thread(thread.clone());
     ctx.set_callback_thread(thread.clone());
+}
+
+pub struct IpcListener {
+    pub handler: HandlerClient,
+    pub thread: ThreadClient,
+}
+
+impl IpcListener {
+    pub async fn shutdown(&self) -> Result<()> {
+        let mut req = self.handler.disconnect_request();
+        set_context(req.get().get_context()?, &self.thread);
+        req.send().promise.await?;
+        Ok(())
+    }
 }

--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -15,8 +15,7 @@ use shared::{
 };
 
 pub struct IpcClient {
-    pub mining: MiningClient,
-    pub thread: ThreadClient,
+    pub reader: IpcReader,
     pub rpc_task: JoinHandle<Result<(), CapnpError>>,
     pub disconnector: Disconnector<rpc_twoparty_capnp::Side>,
 }
@@ -38,28 +37,34 @@ impl IpcClient {
 
         let response = init.construct_request().send().promise.await?;
         let thread_map = response.get()?.get_thread_map()?;
-
         let response = thread_map.make_thread_request().send().promise.await?;
         let thread = response.get()?.get_result()?;
 
         let mut req = init.make_mining_request();
         set_context(req.get().get_context()?, &thread);
-
         let response = req.send().promise.await?;
         let mining = response.get()?.get_result()?;
 
+        let reader = IpcReader { mining, thread };
+
         Ok(Self {
+            reader,
             rpc_task,
-            thread,
-            mining,
             disconnector,
         })
     }
+}
 
+#[derive(Clone)]
+pub struct IpcReader {
+    pub mining: MiningClient,
+    pub thread: ThreadClient,
+}
+
+impl IpcReader {
     pub async fn get_tip(&self) -> Result<Option<BlockTip>> {
         let mut req = self.mining.get_tip_request();
         set_context(req.get().get_context()?, &self.thread);
-
         let response = req.send().promise.await?;
 
         let has_result = response.get()?.get_has_result();

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -8,7 +8,7 @@ use shared::{
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
-        ipc_extractor,
+        ipc_extractor::{self, ipc::IpcEvent},
     },
     tokio::{
         self,
@@ -22,8 +22,8 @@ use std::net::SocketAddr;
 mod ipc;
 mod metrics;
 
-use ipc::IpcClient;
 use metrics::Metrics;
+use ipc::{ChainCallbacks, EventFut, IpcClient, IpcReader};
 
 /// The peer-observer ipc-extractor periodically queries data from the
 /// Bitcoin Core IPC interface and publishes the results as events into
@@ -75,9 +75,13 @@ pub async fn run(
         })?;
     log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
 
-    let mut ipc = IpcClient::init(stream)
+    let mut ipc = IpcClient::connect(stream)
         .await
         .context("initializing the IPC session")?;
+    let chain_listener = ipc
+        .subscribe_chain_notifications(make_chain_callbacks(nats_client.clone()))
+        .await
+        .context("subscribing to Chain notifications")?;
 
     let metrics = Metrics::new().context("creating metrics registry")?;
     let local_addr =
@@ -97,7 +101,7 @@ pub async fn run(
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = fetch_and_publish_tip(&ipc, &nats_client, &metrics).await {
+                if let Err(e) = fetch_and_publish_tip(&ipc.reader, &nats_client, &metrics).await {
                     log::error!("Could not fetch and publish 'BlockTip': {:#}", e);
                 }
             }
@@ -128,7 +132,7 @@ pub async fn run(
         return Ok(());
     }
 
-    if let Err(e) = ipc.listener.shutdown().await {
+    if let Err(e) = chain_listener.shutdown().await {
         log::error!("could not shut down listener: {}", e);
     }
     if let Err(e) = ipc.disconnector.await {
@@ -163,11 +167,11 @@ where
 }
 
 async fn fetch_and_publish_tip(
-    ipc_client: &IpcClient,
+    reader: &IpcReader,
     nats_client: &async_nats::Client,
     metrics: &Metrics,
 ) -> Result<()> {
-    let tip = match measure_ipc_call("get_tip", metrics, ipc_client.reader.get_tip())
+    let tip = match measure_ipc_call("get_tip", metrics, reader.get_tip())
         .await
         .context("measuring get_tip IPC")?
     {
@@ -190,4 +194,46 @@ async fn fetch_and_publish_tip(
         })
         .context("publishing the block tip to NATS")?;
     Ok(())
+}
+
+fn make_chain_callbacks(nats: async_nats::Client) -> ChainCallbacks {
+    ChainCallbacks {
+        on_block_connected: wrap_publisher(nats.clone(), IpcEvent::BlockConnected),
+        on_block_disconnected: wrap_publisher(nats.clone(), IpcEvent::BlockDisconnected),
+        on_tx_added: wrap_publisher(nats.clone(), IpcEvent::TransactionAddedToMempool),
+        on_tx_removed: wrap_publisher(nats.clone(), IpcEvent::TransactionRemovedFromMempool),
+        on_chain_state_flushed: wrap_publisher(nats, IpcEvent::ChainStateFlushed),
+        on_updated_block_tip: Box::new(|| {
+            Box::pin(async move {
+                log::debug!("updated_block_tip notification received");
+            })
+        }),
+    }
+}
+
+fn wrap_publisher<T: 'static>(
+    nats: async_nats::Client,
+    variant: fn(T) -> IpcEvent,
+) -> Box<dyn Fn(T) -> EventFut> {
+    Box::new(move |value: T| {
+        let nats = nats.clone();
+        let event_inner = variant(value);
+        Box::pin(async move {
+            let event = match Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+                ipc_event: Some(event_inner),
+            })) {
+                Ok(e) => e,
+                Err(e) => {
+                    log::error!("Event build failed: {e}");
+                    return;
+                }
+            };
+            if let Err(e) = nats
+                .publish(Subject::Ipc.to_string(), event.encode_to_vec().into())
+                .await
+            {
+                log::error!("NATS publish failed: {e}");
+            }
+        })
+    })
 }

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -75,14 +75,6 @@ pub async fn run(
         })?;
     log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
 
-    let mut ipc = IpcClient::connect(stream)
-        .await
-        .context("initializing the IPC session")?;
-    let chain_listener = ipc
-        .subscribe_chain_notifications(make_chain_callbacks(nats_client.clone()))
-        .await
-        .context("subscribing to Chain notifications")?;
-
     let metrics = Metrics::new().context("creating metrics registry")?;
     let local_addr =
         shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))
@@ -91,39 +83,40 @@ pub async fn run(
         let _ = tx.send(local_addr);
     }
 
-    let duration_sec = Duration::from_secs(args.query_interval);
-    let mut interval = time::interval(duration_sec);
-    log::info!(
-        "Querying the Bitcoin Core IPC interface every {:?}.",
-        duration_sec
-    );
+    let mut ipc = IpcClient::connect(stream).await?;
+    let chain_listener = ipc
+        .subscribe_chain_notifications(make_chain_callbacks(
+            nats_client.clone(),
+            ipc.reader.clone(),
+            metrics.clone(),
+        ))
+        .await?;
 
-    loop {
-        tokio::select! {
-            _ = interval.tick() => {
-                if let Err(e) = fetch_and_publish_tip(&ipc.reader, &nats_client, &metrics).await {
-                    log::error!("Could not fetch and publish 'BlockTip': {:#}", e);
-                }
+    let mut poll_handle = tokio::task::spawn_local(poll_task(args.query_interval));
+
+    tokio::select! {
+        res = &mut poll_handle => {
+            match res {
+                Ok(()) => log::info!("Poll task exited."),
+                Err(e) => log::error!("Poll task panicked: {e}"),
             }
-            res = &mut ipc.rpc_task => {
-                match res {
-                    Ok(Ok(())) => log::warn!("Lost IPC connection to bitcoin-node."),
-                    Ok(Err(e)) => log::error!("Lost IPC connection to bitcoin-node: {e}"),
-                    Err(e) => log::error!("IPC task panicked or was cancelled: {e}"),
-                }
-                break;
+        }
+        res = &mut ipc.rpc_task => {
+            match res {
+                Ok(Ok(())) => log::warn!("Lost IPC connection to bitcoin-node."),
+                Ok(Err(e)) => log::error!("Lost IPC connection to bitcoin-node: {e}"),
+                Err(e) => log::error!("IPC task panicked or was cancelled: {e}"),
             }
-            res = shutdown_rx.changed() => {
-                match res {
-                    Ok(_) if *shutdown_rx.borrow() => {
-                        log::info!("ipc_extractor received shutdown signal.");
-                    }
-                    _ => {
-                        // all senders dropped -> treat as shutdown
-                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
-                    }
+        }
+        res = shutdown_rx.changed() => {
+            match res {
+                Ok(_) if *shutdown_rx.borrow() => {
+                    log::info!("ipc_extractor received shutdown signal.");
                 }
-                break;
+                _ => {
+                    // all senders dropped -> treat as shutdown
+                    log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                }
             }
         }
     }
@@ -166,46 +159,44 @@ where
     res
 }
 
-async fn fetch_and_publish_tip(
-    reader: &IpcReader,
-    nats_client: &async_nats::Client,
-    metrics: &Metrics,
-) -> Result<()> {
-    let tip = match measure_ipc_call("get_tip", metrics, reader.get_tip())
-        .await
-        .context("measuring get_tip IPC")?
-    {
-        Some(t) => t,
-        None => return Ok(()), // the node has no tip loaded yet, skip NATS publish
-    };
+async fn poll_task(interval_secs: u64) {
+    let duration_sec = Duration::from_secs(interval_secs);
+    log::info!(
+        "Querying the Bitcoin Core IPC interface every {:?}.",
+        duration_sec
+    );
+    let mut interval = time::interval(duration_sec);
 
-    let proto = Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
-        ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(tip)),
-    }))
-    .context("creating the protobuf block tip event")?;
-    nats_client
-        .publish(Subject::Ipc.to_string(), proto.encode_to_vec().into())
-        .await
-        .inspect_err(|_| {
-            metrics
-                .nats_publish_errors
-                .with_label_values(&["get_tip"])
-                .inc();
-        })
-        .context("publishing the block tip to NATS")?;
-    Ok(())
+    loop {
+        interval.tick().await;
+    }
 }
 
-fn make_chain_callbacks(nats: async_nats::Client) -> ChainCallbacks {
+fn make_chain_callbacks(
+    nats: async_nats::Client,
+    reader: IpcReader,
+    metrics: Metrics,
+) -> ChainCallbacks {
     ChainCallbacks {
         on_block_connected: wrap_publisher(nats.clone(), IpcEvent::BlockConnected),
         on_block_disconnected: wrap_publisher(nats.clone(), IpcEvent::BlockDisconnected),
         on_tx_added: wrap_publisher(nats.clone(), IpcEvent::TransactionAddedToMempool),
         on_tx_removed: wrap_publisher(nats.clone(), IpcEvent::TransactionRemovedFromMempool),
-        on_chain_state_flushed: wrap_publisher(nats, IpcEvent::ChainStateFlushed),
-        on_updated_block_tip: Box::new(|| {
+        on_chain_state_flushed: wrap_publisher(nats.clone(), IpcEvent::ChainStateFlushed),
+
+        // `updatedBlockTip` pushes no value to the subscriber
+        // so we fetch through the reader the new tip and publish
+        // a BlockTip event to NATS.
+        on_updated_block_tip: Box::new(move || {
+            let nats = nats.clone();
+            let reader = reader.clone();
+            let metrics = metrics.clone();
             Box::pin(async move {
-                log::debug!("updated_block_tip notification received");
+                match measure_ipc_call("get_tip", &metrics, reader.get_tip()).await {
+                    Ok(Some(tip)) => publish_ipc_event(&nats, IpcEvent::BlockTip(tip)).await,
+                    Ok(None) => unreachable!("updatedBlockTip fired without a tip"),
+                    Err(e) => log::error!("could not get tip on updated_block_tip: {}", e),
+                }
             })
         }),
     }
@@ -218,22 +209,26 @@ fn wrap_publisher<T: 'static>(
     Box::new(move |value: T| {
         let nats = nats.clone();
         let event_inner = variant(value);
-        Box::pin(async move {
-            let event = match Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
-                ipc_event: Some(event_inner),
-            })) {
-                Ok(e) => e,
-                Err(e) => {
-                    log::error!("Event build failed: {e}");
-                    return;
-                }
-            };
+        Box::pin(async move { publish_ipc_event(&nats, event_inner).await })
+    })
+}
+
+async fn publish_ipc_event(nats: &async_nats::Client, ipc_event: IpcEvent) {
+    match Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
+        ipc_event: Some(ipc_event),
+    })) {
+        Ok(proto) => {
             if let Err(e) = nats
-                .publish(Subject::Ipc.to_string(), event.encode_to_vec().into())
+                .publish(Subject::Ipc.to_string(), proto.encode_to_vec().into())
                 .await
             {
-                log::error!("NATS publish failed: {e}");
+                log::error!("could not publish IPC event into NATS: {}", e);
+            } else {
+                log::trace!("published IPC event into NATS: {:?}", proto);
             }
-        })
-    })
+        }
+        Err(e) => {
+            log::error!("could not create IPC event protobuf: {}", e);
+        }
+    }
 }

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -162,7 +162,7 @@ async fn fetch_and_publish_tip(
     nats_client: &async_nats::Client,
     metrics: &Metrics,
 ) -> Result<()> {
-    let tip = match measure_ipc_call("get_tip", metrics, ipc_client.get_tip())
+    let tip = match measure_ipc_call("get_tip", metrics, ipc_client.reader.get_tip())
         .await
         .context("measuring get_tip IPC")?
     {

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn run(
         })?;
     log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
 
-    let mut ipc_session = IpcClient::init(stream)
+    let mut ipc = IpcClient::init(stream)
         .await
         .context("initializing the IPC session")?;
 
@@ -97,11 +97,11 @@ pub async fn run(
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = fetch_and_publish_tip(&ipc_session, &nats_client, &metrics).await {
+                if let Err(e) = fetch_and_publish_tip(&ipc, &nats_client, &metrics).await {
                     log::error!("Could not fetch and publish 'BlockTip': {:#}", e);
                 }
             }
-            res = &mut ipc_session.rpc_task => {
+            res = &mut ipc.rpc_task => {
                 match res {
                     Ok(Ok(())) => log::warn!("Lost IPC connection to bitcoin-node."),
                     Ok(Err(e)) => log::error!("Lost IPC connection to bitcoin-node: {e}"),
@@ -124,12 +124,17 @@ pub async fn run(
         }
     }
 
-    if let Err(e) = ipc_session.disconnector.await {
+    if ipc.rpc_task.is_finished() {
+        return Ok(());
+    }
+
+    if let Err(e) = ipc.listener.shutdown().await {
+        log::error!("could not shut down listener: {}", e);
+    }
+    if let Err(e) = ipc.disconnector.await {
         log::error!("could not run disconnector during shutdown: {}", e);
     }
-    if !ipc_session.rpc_task.is_finished() {
-        let _ = ipc_session.rpc_task.await;
-    }
+    let _ = ipc.rpc_task.await;
     Ok(())
 }
 

--- a/extractors/ipc/tests/common/mod.rs
+++ b/extractors/ipc/tests/common/mod.rs
@@ -59,11 +59,10 @@ pub fn configure_node() -> bitcoind::BitcoinD {
     info!("Using bitcoin-node at '{}'", exe_path);
 
     let mut conf = bitcoind::Conf::default();
-    conf.args = vec!["-regtest", "-ipcbind=unix"];
+    conf.args = vec!["-regtest", "-ipcbind=unix", "-fallbackfee=0.00001"];
     conf.view_stdout = false;
-    // bitcoin-node has no wallet capabilities. Disable to avoid the
-    // default wallet creation attempt.
-    // conf.wallet = None;
+    // Disable default wallet auto-creation. Create it manually in tests requiring wallet.
+    conf.wallet = None;
 
     bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap()
 }

--- a/extractors/ipc/tests/common/mod.rs
+++ b/extractors/ipc/tests/common/mod.rs
@@ -54,23 +54,18 @@ fn bitcoin_node_exe_path() -> String {
         .into_owned()
 }
 
-fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
+pub fn configure_node() -> bitcoind::BitcoinD {
     let exe_path = bitcoin_node_exe_path();
     info!("Using bitcoin-node at '{}'", exe_path);
+
+    let mut conf = bitcoind::Conf::default();
+    conf.args = vec!["-regtest", "-ipcbind=unix"];
+    conf.view_stdout = false;
+    // bitcoin-node has no wallet capabilities. Disable to avoid the
+    // default wallet creation attempt.
+    // conf.wallet = None;
+
     bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap()
-}
-
-pub fn configure_node() -> bitcoind::BitcoinD {
-    let mut node_conf = bitcoind::Conf::default();
-    node_conf.args = vec!["-regtest", "-ipcbind=unix"];
-    // enabling this is useful for debugging, but enabling this by default will
-    // be quite spammy.
-    node_conf.view_stdout = false;
-    // node_conf.wallet is `true` by default, but since `bitcoin-node` binary doesn't
-    // have wallet capabilities we disable it
-    node_conf.wallet = None;
-
-    setup_node(node_conf)
 }
 
 pub fn ipc_socket_path(node: &bitcoind::BitcoinD) -> String {

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -84,6 +84,7 @@ async fn test_integration_ipc() {
                             "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
                         );
                     }
+                    _ => panic!("unexpected IPC event: {:?}", e),
                 }
             }
         }

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -7,7 +7,7 @@ use common::{configure_node, ipc_socket_path, make_test_args, setup};
 
 use shared::{
     async_nats,
-    bitcoin::{Address, Network, PubkeyHash, hashes::Hash},
+    bitcoin::{Address, BlockHash, Network, PubkeyHash, hashes::Hash},
     bitcoind,
     futures::StreamExt,
     prost::Message,
@@ -111,6 +111,33 @@ async fn test_integration_ipc() {
     };
     assert_eq!(tip.height, 1);
     assert_eq!(tip.hash.len(), 32);
+}
+
+#[tokio::test]
+async fn test_integration_block_connected() {
+    println!("test that we receive a BlockConnected event when a block is connected");
+
+    let event = check(
+        |e| matches!(e, IpcEvent::BlockConnected(_)),
+        |node| {
+            node.client
+                .generate_to_address(1, &regtest_burn_address())
+                .expect("generate 1 block");
+        },
+    )
+    .await;
+
+    let IpcEvent::BlockConnected(bc) = event else {
+        unreachable!()
+    };
+    let block = bc.block;
+    assert_eq!(block.height, 1);
+    assert_eq!(block.hash.len(), 32);
+    assert_eq!(block.prev_hash.len(), 32);
+    assert_eq!(
+        BlockHash::from_slice(&block.prev_hash).unwrap().to_string(),
+        "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", // regtest genesis blockhash
+    );
 }
 
 #[tokio::test]

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -98,7 +98,7 @@ async fn test_integration_ipc_node_shutdown() {
     println!("test that the ipc-extractor shuts down when the node is stopped");
 
     setup();
-    let mut node = configure_node();
+    let node = configure_node();
     let nats_server = NatsServerForTesting::new(&[]).await;
 
     let ipc_socket_path = node
@@ -135,7 +135,7 @@ async fn test_integration_ipc_node_shutdown() {
                         if unwrapped.peer_observer_event.is_some() {
                             // After we received the first message from the ipc-extractor,
                             // we shut down the node.
-                            node.stop().unwrap();
+                            node.client.stop().unwrap();
                         }
                     } else {
                         panic!("subscription ended");

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -7,7 +7,7 @@ use common::{configure_node, ipc_socket_path, make_test_args, setup};
 
 use shared::{
     async_nats,
-    bitcoin::{Address, BlockHash, Network, PubkeyHash, hashes::Hash},
+    bitcoin::{Address, Amount, BlockHash, Network, PubkeyHash, hashes::Hash},
     bitcoind,
     futures::StreamExt,
     prost::Message,
@@ -167,6 +167,74 @@ async fn test_integration_block_disconnected() {
     let block = bd.block;
     assert_eq!(block.height, 2);
     assert_eq!(block.hash.len(), 32);
+}
+
+#[tokio::test]
+async fn test_integration_tx_added_to_mempool() {
+    println!("test that we receive a TransactionAddedToMempool event after submitting a tx");
+
+    let event = check(
+        |e| matches!(e, IpcEvent::TransactionAddedToMempool(_)),
+        |node| {
+            node.client.create_wallet("default").expect("create wallet");
+
+            let mining_address = node.client.new_address().expect("new address");
+            node.client
+                .generate_to_address(101, &mining_address)
+                .expect("generate 101 blocks to mature a coinbase");
+
+            let dest = regtest_burn_address();
+            let amount = Amount::from_btc(1.0).unwrap();
+            node.client
+                .send_to_address(&dest, amount)
+                .expect("send_to_address");
+        },
+    )
+    .await;
+
+    let IpcEvent::TransactionAddedToMempool(t) = event else {
+        unreachable!()
+    };
+    assert_eq!(t.tx.txid.len(), 32);
+    assert_eq!(t.tx.wtxid.len(), 32);
+    assert!(t.tx.raw.is_some());
+}
+
+#[tokio::test]
+async fn test_integration_tx_removed_from_mempool() {
+    println!(
+        "test that we receive a TransactionRemovedFromMempool event when a tx is replaced via RBF"
+    );
+
+    let event = check(
+        |e| matches!(e, IpcEvent::TransactionRemovedFromMempool(_)),
+        |node| {
+            node.client.create_wallet("default").expect("create wallet");
+
+            let mining_address = node.client.new_address().expect("new address");
+            node.client
+                .generate_to_address(101, &mining_address)
+                .expect("generate 101 blocks to mature a coinbase");
+
+            let dest = regtest_burn_address();
+            let amount = Amount::from_btc(1.0).unwrap();
+            let original_txid = node
+                .client
+                .send_to_address(&dest, amount)
+                .expect("send_to_address");
+
+            node.client
+                .bump_fee(original_txid.txid().expect("send_to_address txid"))
+                .expect("bumpfee");
+        },
+    )
+    .await;
+
+    let IpcEvent::TransactionRemovedFromMempool(t) = event else {
+        unreachable!()
+    };
+    assert_eq!(t.tx.txid.len(), 32);
+    assert_eq!(t.tx.wtxid.len(), 32);
 }
 
 #[tokio::test]

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -7,146 +7,122 @@ use common::{configure_node, ipc_socket_path, make_test_args, setup};
 
 use shared::{
     async_nats,
-    bitcoin::{self, hashes::Hash},
+    bitcoin::{Address, Network, PubkeyHash, hashes::Hash},
+    bitcoind,
     futures::StreamExt,
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
-        ipc_extractor::ipc::IpcEvent::BlockTip,
+        ipc_extractor::ipc::IpcEvent,
     },
     testing::nats_server::NatsServerForTesting,
     tokio::{self, sync::watch, task::LocalSet, time::sleep},
 };
+use std::sync::Arc;
 use std::time::Duration;
 
 // 5 second check() timeout.
 const TEST_TIMEOUT_SECONDS: u64 = 5;
 
-async fn check(check_expected: fn(PeerObserverEvent) -> ()) {
+async fn check<P, D>(pred: P, drive: D) -> IpcEvent
+where
+    P: Fn(&IpcEvent) -> bool + Send + 'static,
+    D: FnOnce(Arc<bitcoind::BitcoinD>) + Send + 'static,
+{
     setup();
-    let node = configure_node();
+    let node = Arc::new(configure_node());
     let nats_server = NatsServerForTesting::new(&[]).await;
 
     let args = make_test_args(nats_server.port, ipc_socket_path(&node));
 
-    let local = LocalSet::new();
-    local
+    LocalSet::new()
         .run_until(async move {
             let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
-            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone(), None);
-            tokio::pin!(ipc_extractor_future);
+            let mut extractor =
+                tokio::task::spawn_local(ipc_extractor::run(args, shutdown_rx, None));
 
             let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
                 .await
                 .unwrap();
             let mut sub = nc.subscribe("*").await.unwrap();
 
-            tokio::select! {
-                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
-                    panic!("timed out waiting for check() to complete");
-                }
-                msg = sub.next() => {
-                    if let Some(msg) = msg {
-                        let unwrapped = Event::decode(msg.payload).unwrap();
-                        if let Some(event) = unwrapped.peer_observer_event {
-                            check_expected(event);
-                        }
-                    } else {
-                        panic!("subscription ended");
-                    }
-                }
-                result = &mut ipc_extractor_future => {
-                    panic!("ipc_extractor stopped unexpectedly: {:?}", result);
-                }
-            }
+            // Allow the extractor to register its ChainNotifications subscription
+            // before driving node state.
+            sleep(Duration::from_millis(250)).await;
+            std::thread::spawn({
+                let node = node.clone();
+                move || drive(node)
+            });
 
-            shutdown_tx.send(true).unwrap();
-            ipc_extractor_future.await.unwrap();
+            let event = tokio::select! {
+                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
+                    panic!("timed out waiting for matching IPC event");
+                }
+                ev = await_ipc_event(&mut sub, pred) => ev,
+                res = &mut extractor => {
+                    panic!("ipc_extractor stopped unexpectedly: {:?}", res);
+                }
+            };
+
+            let _ = shutdown_tx.send(true);
+            let _ = extractor.await;
+            event
         })
-        .await;
+        .await
+}
+
+fn regtest_burn_address() -> Address {
+    Address::p2pkh(PubkeyHash::from_byte_array([0u8; 20]), Network::Regtest)
+}
+
+async fn await_ipc_event<F>(sub: &mut async_nats::Subscriber, pred: F) -> IpcEvent
+where
+    F: Fn(&IpcEvent) -> bool,
+{
+    while let Some(msg) = sub.next().await {
+        let Ok(envelope) = Event::decode(msg.payload) else {
+            continue;
+        };
+        let Some(PeerObserverEvent::IpcExtractor(ipc)) = envelope.peer_observer_event else {
+            continue;
+        };
+        let Some(e) = ipc.ipc_event else { continue };
+        if pred(&e) {
+            return e;
+        }
+    }
+    panic!("subscription ended without matching event");
 }
 
 #[tokio::test]
 async fn test_integration_ipc() {
-    println!("test that we receive BlockTip IPC events");
-
-    check(|event| match event {
-        PeerObserverEvent::IpcExtractor(i) => {
-            if let Some(ref e) = i.ipc_event {
-                match e {
-                    BlockTip(t) => {
-                        assert_eq!(t.height, 0);
-                        assert_eq!(t.hash.len(), 32);
-                        assert_eq!(
-                            bitcoin::BlockHash::from_slice(&t.hash).unwrap().to_string(),
-                            // genesis blockhash in Regtest
-                            "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
-                        );
-                    }
-                    _ => panic!("unexpected IPC event: {:?}", e),
-                }
-            }
-        }
-        _ => panic!("unexpected event {:?}", event),
-    })
+    let event = check(
+        |e| matches!(e, IpcEvent::BlockTip(_)),
+        |node| {
+            node.client
+                .generate_to_address(1, &regtest_burn_address())
+                .expect("generate 1 block");
+        },
+    )
     .await;
+
+    let IpcEvent::BlockTip(tip) = event else {
+        unreachable!()
+    };
+    assert_eq!(tip.height, 1);
+    assert_eq!(tip.hash.len(), 32);
 }
 
 #[tokio::test]
 async fn test_integration_ipc_node_shutdown() {
     println!("test that the ipc-extractor shuts down when the node is stopped");
 
-    setup();
-    let node = configure_node();
-    let nats_server = NatsServerForTesting::new(&[]).await;
-
-    let ipc_socket_path = node
-        .workdir()
-        .as_path()
-        .join("regtest")
-        .join("node.sock")
-        .to_str()
-        .unwrap()
-        .into();
-
-    let args = make_test_args(nats_server.port, ipc_socket_path);
-
-    let local = LocalSet::new();
-    local
-        .run_until(async move {
-            let (_shutdown_tx, shutdown_rx) = watch::channel(false);
-
-            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone(), None);
-            tokio::pin!(ipc_extractor_future);
-
-            let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
-                .await
-                .unwrap();
-            let mut sub = nc.subscribe("*").await.unwrap();
-
-            tokio::select! {
-                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
-                    panic!("timed out waiting for check() to complete");
-                }
-                msg = sub.next() => {
-                    if let Some(msg) = msg {
-                        let unwrapped = Event::decode(msg.payload).unwrap();
-                        if unwrapped.peer_observer_event.is_some() {
-                            // After we received the first message from the ipc-extractor,
-                            // we shut down the node.
-                            node.client.stop().unwrap();
-                        }
-                    } else {
-                        panic!("subscription ended");
-                    }
-                }
-                result = &mut ipc_extractor_future => {
-                    panic!("ipc_extractor stopped unexpectedly: {:?}", result);
-                }
-            }
-
-            assert_eq!(ipc_extractor_future.await.unwrap(), ());
-        })
-        .await;
+    let _ = check(
+        |_| true,
+        |node| {
+            // Should trigger a clean shutdown and not throw unexpectedly
+            node.client.stop().unwrap();
+        },
+    )
+    .await;
 }

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -141,6 +141,35 @@ async fn test_integration_block_connected() {
 }
 
 #[tokio::test]
+async fn test_integration_block_disconnected() {
+    println!("test that we receive a BlockDisconnected event when a block is invalidated");
+
+    let event = check(
+        |e| matches!(e, IpcEvent::BlockDisconnected(_)),
+        |node| {
+            let block_hashes = node
+                .client
+                .generate_to_address(2, &regtest_burn_address())
+                .expect("generate 2 blocks")
+                .into_model()
+                .expect("parse block hashes");
+            let to_invalidate = block_hashes.0[1];
+            node.client
+                .invalidate_block(to_invalidate)
+                .expect("invalidate block 2");
+        },
+    )
+    .await;
+
+    let IpcEvent::BlockDisconnected(bd) = event else {
+        unreachable!()
+    };
+    let block = bd.block;
+    assert_eq!(block.height, 2);
+    assert_eq!(block.hash.len(), 32);
+}
+
+#[tokio::test]
 async fn test_integration_ipc_node_shutdown() {
     println!("test that the ipc-extractor shuts down when the node is stopped");
 

--- a/extractors/ipc/tests/metrics_integration.rs
+++ b/extractors/ipc/tests/metrics_integration.rs
@@ -61,6 +61,7 @@ async fn test_integration_metrics_server_basic() {
 
 /// Verifies that a successful IPC call records its duration in the histogram.
 #[tokio::test]
+#[ignore = "moved get_tip from polling to listener"]
 async fn test_integration_metrics_ipc_fetch_duration() {
     setup();
     let node = configure_node();

--- a/protobuf/ipc_extractor.proto
+++ b/protobuf/ipc_extractor.proto
@@ -2,13 +2,65 @@ syntax = "proto2";
 
 package ipc_extractor;
 
+import "bitcoin_primitives.proto";
+
 message ipc {
   oneof ipc_event {
     BlockTip block_tip = 1;
+    BlockConnected block_connected = 2;
+    BlockDisconnected block_disconnected = 3;
+    TransactionAddedToMempool transaction_added_to_mempool = 4;
+    TransactionRemovedFromMempool transaction_removed_from_mempool = 5;
+    ChainStateFlushed chain_state_flushed = 6;
   }
 }
 
+// The current chain tip as reported by Bitcoin Core.
 message BlockTip {
   required int32 height = 1;
   required bytes hash   = 2;
+}
+
+// A block summary delivered by Chain notifications.
+message BlockInfo {
+  required int32  height       = 1;
+  required bytes  hash         = 2;
+  required bytes  prev_hash    = 3;
+  optional uint32 chain_time_max = 4;
+}
+
+// Role of the chainstate from which a notification originated.
+message ChainstateRole {
+  required bool validated  = 1;
+  required bool historical = 2;
+}
+
+// Fired when a block is connected to the active chain.
+message BlockConnected {
+  required ChainstateRole role  = 1;
+  required BlockInfo      block = 2;
+}
+
+// Fired when a block is disconnected from the active chain (e.g. during a reorg).
+message BlockDisconnected {
+  required BlockInfo block = 1;
+}
+
+// Fired when a transaction enters the mempool.
+message TransactionAddedToMempool {
+  required bitcoin_primitives.Transaction tx = 1;
+}
+
+// Fired when a transaction leaves the mempool. The `reason` field is a
+// pass-through of Bitcoin Core's MemPoolRemovalReason enum value.
+message TransactionRemovedFromMempool {
+  required bitcoin_primitives.Transaction tx     = 1;
+  required int32                          reason = 2;
+}
+
+// Fired when the chainstate is flushed to disk. `locator` is a serialized
+// CBlockLocator pointing at the flushed tip.
+message ChainStateFlushed {
+  required ChainstateRole role    = 1;
+  required bytes          locator = 2;
 }

--- a/shared/src/protobuf/ipc_extractor.rs
+++ b/shared/src/protobuf/ipc_extractor.rs
@@ -4,14 +4,6 @@ use std::fmt;
 // structs are generated via the ipc_extractor.proto file
 include!(concat!(env!("OUT_DIR"), "/ipc_extractor.rs"));
 
-impl fmt::Display for ipc::IpcEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ipc::IpcEvent::BlockTip(tip) => write!(f, "{}", tip),
-        }
-    }
-}
-
 impl fmt::Display for BlockTip {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -20,5 +12,88 @@ impl fmt::Display for BlockTip {
             self.height,
             bitcoin::BlockHash::from_slice(&self.hash).unwrap()
         )
+    }
+}
+
+impl fmt::Display for BlockInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BlockInfo(height={}, hash={}, prev_hash={})",
+            self.height,
+            bitcoin::BlockHash::from_slice(&self.hash).unwrap(),
+            bitcoin::BlockHash::from_slice(&self.prev_hash).unwrap()
+        )
+    }
+}
+
+impl fmt::Display for ChainstateRole {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ChainstateRole(validated={}, historical={})",
+            self.validated, self.historical
+        )
+    }
+}
+
+impl fmt::Display for BlockConnected {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BlockConnected(role={}, block={})",
+            self.role, self.block
+        )
+    }
+}
+
+impl fmt::Display for BlockDisconnected {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BlockDisconnected(block={})", self.block)
+    }
+}
+
+impl fmt::Display for TransactionAddedToMempool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TransactionAddedToMempool(txid={})",
+            bitcoin::Txid::from_slice(&self.tx.txid).unwrap()
+        )
+    }
+}
+
+impl fmt::Display for TransactionRemovedFromMempool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TransactionRemovedFromMempool(txid={}, reason={})",
+            bitcoin::Txid::from_slice(&self.tx.txid).unwrap(),
+            self.reason
+        )
+    }
+}
+
+impl fmt::Display for ChainStateFlushed {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ChainStateFlushed(role={}, locator_len={})",
+            self.role,
+            self.locator.len()
+        )
+    }
+}
+
+impl fmt::Display for ipc::IpcEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ipc::IpcEvent::BlockTip(t) => write!(f, "{}", t),
+            ipc::IpcEvent::BlockConnected(b) => write!(f, "{}", b),
+            ipc::IpcEvent::BlockDisconnected(b) => write!(f, "{}", b),
+            ipc::IpcEvent::TransactionAddedToMempool(t) => write!(f, "{}", t),
+            ipc::IpcEvent::TransactionRemovedFromMempool(t) => write!(f, "{}", t),
+            ipc::IpcEvent::ChainStateFlushed(c) => write!(f, "{}", c),
+        }
     }
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -1552,6 +1552,11 @@ fn handle_ipc_event(e: &ipc_extractor::ipc::IpcEvent, metrics: metrics::Metrics)
         ipc_extractor::ipc::IpcEvent::BlockTip(tip) => {
             metrics.ipc_block_tip_height.set(tip.height as i64);
         }
+        ipc_extractor::ipc::IpcEvent::BlockConnected(_) => {}
+        ipc_extractor::ipc::IpcEvent::BlockDisconnected(_) => {}
+        ipc_extractor::ipc::IpcEvent::TransactionAddedToMempool(_) => {}
+        ipc_extractor::ipc::IpcEvent::TransactionRemovedFromMempool(_) => {}
+        ipc_extractor::ipc::IpcEvent::ChainStateFlushed(_) => {}
     }
 }
 


### PR DESCRIPTION
This is an extension of the `ipc-extractor` work to address #370.

As stated in https://github.com/peer-observer/peer-observer/issues/370#issuecomment-4500724967, this PR introduces the `ChainNotifications` interface to subscribe to the following chain events:

- `TransactionAddedToMempool`
- `TransactionRemovedFromMempool`
- `BlockConnected`
- `BlockDisconnected`
- `UpdatedBlockTip`
- `ChainStateFlushed`

`capnp` schemas are vendored from bitcoin/bitcoin#29409, so this `ipc-extractor` version works with a compiled binary built from that PR. They'll need to be re-synced if the upstream schemas change.

Note: the polling scaffolding is in place ready to be extended. The tip is now being fetched reactively, triggered by `UpdatedBlockTip` events.