### PR TITLE
add(replayer): sequence diagrams, CSV export, and P2P message filtering

### DIFF
--- a/tools/replayer/README.md
+++ b/tools/replayer/README.md
@@ -3,6 +3,15 @@
 Reads peer-observer archive files (`.bin` or `.bin.zst`) and prints decoded
 events to stdout.
 
+## Example output
+
+```text
+header: version=1 git=abcd1234
+[1] ts=1234567890 ebpf: ...
+[2] ts=1234567891 ebpf: ...
+total: 2 events
+```
+
 ## Usage
 
 ```bash
@@ -26,6 +35,9 @@ cargo run -p replayer -- archive.0.bin.zst --sequence-diagram --html diagram.htm
 
 # write P2P events as CSV
 cargo run -p replayer -- archive.0.bin.zst --csv events.csv
+
+# filter by message type
+cargo run -p replayer -- archive.0.bin.zst --msg-type ping,pong,inv
 
 # filter events by timestamp (milliseconds)
 cargo run -p replayer -- archive.0.bin.zst --from 1703001600000 --to 1703001700000

--- a/tools/replayer/README.md
+++ b/tools/replayer/README.md
@@ -1,32 +1,34 @@
 # `replayer`
 
-Reads peer-observer archive files and prints decoded events to stdout.
-
-Supports:
-- `.bin`
-- `.bin.zst`
+Reads peer-observer archive files (`.bin` or `.bin.zst`) and prints decoded
+events to stdout.
 
 ## Usage
 
 ```bash
-cargo run -p replayer -- archive/test.0.bin
-cargo run -p replayer -- archive/test.0.bin.zst
-cargo run -p replayer -- archive/test.0.bin archive/test.1.bin.zst
+# print decoded events
+cargo run -p replayer -- archive.0.bin.zst
+
+# multiple files
+cargo run -p replayer -- archive.0.bin.zst archive.1.bin.zst
+
+# list peers sorted by message count
+cargo run -p replayer -- archive.0.bin.zst --list-peers
+
+# generate a mermaid sequence diagram
+cargo run -p replayer -- archive.0.bin.zst --sequence-diagram
+
+# filter diagram to specific peers
+cargo run -p replayer -- archive.0.bin.zst --sequence-diagram --peer 1 --peer 3
+
+# write diagram as self-contained HTML
+cargo run -p replayer -- archive.0.bin.zst --sequence-diagram --html diagram.html
+
+# write P2P events as CSV
+cargo run -p replayer -- archive.0.bin.zst --csv events.csv
+
+# filter events by timestamp (milliseconds)
+cargo run -p replayer -- archive.0.bin.zst --from 1703001600000 --to 1703001700000
 ```
 
-## Example output
-
-```text
-header: version=1 git=abcd1234
-[1] ts=1234567890 ebpf: ...
-[2] ts=1234567891 ebpf: ...
-total: 2 events
-```
-
-## Help
-
-```
-Read and display peer-observer archive files
-
-Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]
-```
+Note: `--sequence-diagram`, `--html`, and `--csv` only work with a single archive file.

--- a/tools/replayer/src/lib.rs
+++ b/tools/replayer/src/lib.rs
@@ -19,6 +19,22 @@ pub struct Archive {
     pub events: Vec<Event>,
 }
 
+/// Build a raw archive buffer from header fields and encoded events.
+/// Used by tests to create valid archive data without the archiver.
+#[cfg(test)]
+fn build_archive_bytes(version: u8, git_hash: [u8; 4], events: &[Event]) -> Vec<u8> {
+    use shared::prost::Message as _;
+    let mut buf = vec![0u8; HEADER_SIZE];
+    buf[0..2].copy_from_slice(b"PA");
+    buf[2] = version;
+    buf[3..7].copy_from_slice(&git_hash);
+    for event in events {
+        let encoded = event.encode_length_delimited_to_vec();
+        buf.extend_from_slice(&encoded);
+    }
+    buf
+}
+
 pub fn read_archive(path: &Path) -> std::io::Result<Archive> {
     let mut file = File::open(path)?;
     let mut buf = Vec::new();
@@ -63,4 +79,153 @@ pub fn read_archive(path: &Path) -> std::io::Result<Archive> {
     }
 
     Ok(Archive { header, events })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::protobuf::ebpf_extractor::ebpf;
+    use shared::protobuf::ebpf_extractor::message::{
+        message_event::Msg, MessageEvent, Metadata, Ping, Version,
+    };
+    use shared::protobuf::ebpf_extractor::Ebpf;
+    use shared::protobuf::event::event::PeerObserverEvent;
+    use std::io::Write;
+
+    fn make_test_event(ts: u64) -> Event {
+        Event {
+            timestamp: ts,
+            peer_observer_event: Some(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                    meta: Metadata {
+                        peer_id: 1,
+                        addr: "127.0.0.1:8333".to_string(),
+                        conn_type: 1,
+                        command: "ping".to_string(),
+                        inbound: true,
+                        size: 8,
+                    },
+                    msg: Some(Msg::Ping(Ping { value: 42 })),
+                })),
+            })),
+        }
+    }
+
+    fn write_tmp_file(name: &str, data: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("replayer-test-{}", name));
+        std::fs::write(&path, data).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_read_archive_valid_no_events() {
+        let buf = build_archive_bytes(1, [0xaa, 0xbb, 0xcc, 0xdd], &[]);
+        let path = write_tmp_file("valid-empty.bin", &buf);
+        let archive = read_archive(&path).unwrap();
+        assert_eq!(archive.header.version, 1);
+        assert_eq!(archive.header.git_hash, [0xaa, 0xbb, 0xcc, 0xdd]);
+        assert!(archive.events.is_empty());
+    }
+
+    #[test]
+    fn test_read_archive_valid_with_events() {
+        let events = vec![make_test_event(1000), make_test_event(2000)];
+        let buf = build_archive_bytes(1, [0x01, 0x02, 0x03, 0x04], &events);
+        let path = write_tmp_file("valid-events.bin", &buf);
+        let archive = read_archive(&path).unwrap();
+        assert_eq!(archive.events.len(), 2);
+        assert_eq!(archive.events[0].timestamp, 1000);
+        assert_eq!(archive.events[1].timestamp, 2000);
+    }
+
+    #[test]
+    fn test_read_archive_too_small() {
+        let path = write_tmp_file("too-small.bin", &[0u8; 10]);
+        let err = read_archive(&path).err().unwrap();
+        assert!(err.to_string().contains("file too small"));
+    }
+
+    #[test]
+    fn test_read_archive_bad_magic() {
+        let mut buf = vec![0u8; 16];
+        buf[0..2].copy_from_slice(b"XX");
+        let path = write_tmp_file("bad-magic.bin", &buf);
+        let err = read_archive(&path).err().unwrap();
+        assert!(err.to_string().contains("invalid magic"));
+    }
+
+    #[test]
+    fn test_read_archive_truncated_event() {
+        let mut buf = build_archive_bytes(1, [0; 4], &[]);
+        // Append a varint length that promises more bytes than available
+        buf.push(0x80); // varint: incomplete
+        let path = write_tmp_file("truncated.bin", &buf);
+        let err = read_archive(&path).err().unwrap();
+        assert!(err.to_string().contains("bad length"));
+    }
+
+    #[test]
+    fn test_read_archive_corrupt_event() {
+        let mut buf = build_archive_bytes(1, [0; 4], &[]);
+        // Length delimiter says 5 bytes, then garbage
+        buf.push(5);
+        buf.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff]);
+        let path = write_tmp_file("corrupt.bin", &buf);
+        let err = read_archive(&path).err().unwrap();
+        assert!(err.to_string().contains("decode error"));
+    }
+
+    #[test]
+    fn test_read_archive_zst_extension() {
+        let events = vec![make_test_event(5000)];
+        let raw = build_archive_bytes(1, [0; 4], &events);
+        let mut encoder = zstd::Encoder::new(Vec::new(), 3).unwrap();
+        encoder.write_all(&raw).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let path = write_tmp_file("compressed.bin.zst", &compressed);
+        let archive = read_archive(&path).unwrap();
+        assert_eq!(archive.events.len(), 1);
+        assert_eq!(archive.events[0].timestamp, 5000);
+    }
+
+    #[test]
+    fn test_read_archive_large_event() {
+        let event = Event {
+            timestamp: 1000,
+            peer_observer_event: Some(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                    meta: Metadata {
+                        peer_id: 1,
+                        addr: "127.0.0.1:8333".to_string(),
+                        conn_type: 1,
+                        command: "version".to_string(),
+                        inbound: true,
+                        size: 200,
+                    },
+                    msg: Some(Msg::Version(Version {
+                        version: 70016,
+                        services: 1033,
+                        timestamp: 0,
+                        receiver: Default::default(),
+                        sender: Default::default(),
+                        nonce: 0,
+                        user_agent: "a]".repeat(100),
+                        start_height: 800000,
+                        relay: true,
+                    })),
+                })),
+            })),
+        };
+        let buf = build_archive_bytes(1, [0; 4], &[event]);
+        let path = write_tmp_file("large-event.bin", &buf);
+        let archive = read_archive(&path).unwrap();
+        assert_eq!(archive.events.len(), 1);
+        assert_eq!(archive.events[0].timestamp, 1000);
+    }
+
+    #[test]
+    fn test_read_archive_file_not_found() {
+        let path = std::path::PathBuf::from("/tmp/replayer-test-nonexistent.bin");
+        assert!(read_archive(&path).is_err());
+    }
 }

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -1,58 +1,129 @@
-use std::env;
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
+use shared::clap;
+use shared::clap::Parser;
+use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 
+#[derive(Parser)]
+#[command(version, about = "Read and display peer-observer archive files")]
+struct Args {
+    /// Archive files to read.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+
+    /// List peers found in the archive.
+    #[arg(long)]
+    list_peers: bool,
+
+    /// Only include events with timestamp >= this value (milliseconds).
+    #[arg(long)]
+    from: Option<u64>,
+
+    /// Only include events with timestamp <= this value (milliseconds).
+    #[arg(long)]
+    to: Option<u64>,
+}
+
+struct Peer {
+    addr: String,
+    messages: u64,
+}
+
 fn main() {
-    let files: Vec<String> = env::args().skip(1).collect();
-    if files.is_empty() || files.iter().any(|f| f == "--help" || f == "-h") {
-        println!("Read and display peer-observer archive files");
-        println!();
-        println!("Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]");
+    let args = Args::parse();
+
+    let multiple_files = args.files.len() > 1;
+    for path in &args.files {
+        if multiple_files {
+            println!("=== {} ===", path.display());
+        }
+        match replayer::read_archive(path) {
+            Ok(mut archive) => {
+                if args.from.is_some() || args.to.is_some() {
+                    let from = args.from.unwrap_or(0);
+                    let to = args.to.unwrap_or(u64::MAX);
+                    archive
+                        .events
+                        .retain(|event| (from..=to).contains(&event.timestamp));
+                }
+                if args.list_peers {
+                    print_peers(&archive);
+                } else {
+                    print_events(&archive);
+                }
+            }
+            Err(e) => eprintln!("error reading {}: {}", path.display(), e),
+        }
+    }
+}
+
+fn print_events(archive: &replayer::Archive) {
+    println!(
+        "header: version={} git={}",
+        archive.header.version,
+        archive
+            .header
+            .git_hash
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
+    );
+    for (index, event) in archive.events.iter().enumerate() {
+        let num = index + 1;
+        let ts = event.timestamp;
+        match &event.peer_observer_event {
+            Some(PeerObserverEvent::EbpfExtractor(ebpf)) => {
+                println!(
+                    "[{num}] ts={ts} ebpf: {}",
+                    ebpf.ebpf_event.as_ref().unwrap()
+                )
+            }
+            Some(PeerObserverEvent::RpcExtractor(rpc)) => {
+                println!("[{num}] ts={ts} rpc: {}", rpc.rpc_event.as_ref().unwrap())
+            }
+            Some(PeerObserverEvent::P2pExtractor(p2p)) => {
+                println!("[{num}] ts={ts} p2p: {}", p2p.p2p_event.as_ref().unwrap())
+            }
+            Some(PeerObserverEvent::LogExtractor(log)) => {
+                println!("[{num}] ts={ts} log: {}", log.log_event.as_ref().unwrap())
+            }
+            Some(PeerObserverEvent::IpcExtractor(ipc)) => {
+                println!("[{num}] ts={ts} ipc: {}", ipc.ipc_event.as_ref().unwrap())
+            }
+            None => println!("[{num}] ts={ts} <unknown>"),
+        }
+    }
+    println!("total: {} events", archive.events.len());
+}
+
+fn collect_peers(archive: &replayer::Archive) -> HashMap<u64, Peer> {
+    let mut peers: HashMap<u64, Peer> = HashMap::new();
+    for event in &archive.events {
+        if let Some(PeerObserverEvent::EbpfExtractor(ebpf)) = &event.peer_observer_event {
+            if let Some(ebpf::EbpfEvent::Message(msg)) = &ebpf.ebpf_event {
+                let peer = peers.entry(msg.meta.peer_id).or_insert_with(|| Peer {
+                    addr: msg.meta.addr.clone(),
+                    messages: 0,
+                });
+                peer.messages += 1;
+            }
+        }
+    }
+    peers
+}
+
+fn print_peers(archive: &replayer::Archive) {
+    let peers = collect_peers(archive);
+    if peers.is_empty() {
+        eprintln!("no peers found in archive");
         return;
     }
-
-    for path in &files {
-        if files.len() > 1 {
-            println!("=== {} ===", path);
-        }
-        match replayer::read_archive(Path::new(path)) {
-            Ok(archive) => {
-                println!(
-                    "header: version={} git={}",
-                    archive.header.version,
-                    archive
-                        .header
-                        .git_hash
-                        .iter()
-                        .map(|b| format!("{:02x}", b))
-                        .collect::<String>()
-                );
-                for (i, event) in archive.events.iter().enumerate() {
-                    let n = i + 1;
-                    let ts = event.timestamp;
-                    match &event.peer_observer_event {
-                        Some(PeerObserverEvent::EbpfExtractor(e)) => {
-                            println!("[{n}] ts={ts} ebpf: {}", e.ebpf_event.as_ref().unwrap())
-                        }
-                        Some(PeerObserverEvent::RpcExtractor(r)) => {
-                            println!("[{n}] ts={ts} rpc: {}", r.rpc_event.as_ref().unwrap())
-                        }
-                        Some(PeerObserverEvent::P2pExtractor(p)) => {
-                            println!("[{n}] ts={ts} p2p: {}", p.p2p_event.as_ref().unwrap())
-                        }
-                        Some(PeerObserverEvent::LogExtractor(l)) => {
-                            println!("[{n}] ts={ts} log: {}", l.log_event.as_ref().unwrap())
-                        }
-                        Some(PeerObserverEvent::IpcExtractor(i)) => {
-                            println!("[{n}] ts={ts} ipc: {}", i.ipc_event.as_ref().unwrap())
-                        }
-                        None => println!("[{n}] ts={ts} <unknown>"),
-                    }
-                }
-                println!("total: {} events", archive.events.len());
-            }
-            Err(e) => eprintln!("error reading {}: {}", path, e),
-        }
+    let mut sorted_peers: Vec<_> = peers.into_iter().collect();
+    sorted_peers.sort_by(|a, b| b.1.messages.cmp(&a.1.messages));
+    println!("{:<10} {:<25} Messages", "Peer ID", "Address");
+    for (peer_id, peer) in &sorted_peers {
+        println!("{:<10} {:<25} {}", peer_id, peer.addr, peer.messages);
     }
 }

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use shared::clap;
 use shared::clap::Parser;
 use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::ebpf_extractor::message::message_event::Msg;
+use shared::protobuf::ebpf_extractor::message::MessageEvent;
 use shared::protobuf::event::event::PeerObserverEvent;
 
 #[derive(Parser)]
@@ -13,8 +15,20 @@ struct Args {
     #[arg(required = true)]
     files: Vec<PathBuf>,
 
+    /// Output a sequence diagram (mermaid format).
+    #[arg(long, conflicts_with = "list_peers")]
+    sequence_diagram: bool,
+
+    /// Write sequence diagram as a self-contained HTML file.
+    #[arg(long, requires = "sequence_diagram")]
+    html: Option<PathBuf>,
+
+    /// Filter sequence diagram to specific peer IDs.
+    #[arg(long, requires = "sequence_diagram")]
+    peer: Vec<u64>,
+
     /// List peers found in the archive.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "sequence_diagram")]
     list_peers: bool,
 
     /// Only include events with timestamp >= this value (milliseconds).
@@ -34,6 +48,11 @@ struct Peer {
 fn main() {
     let args = Args::parse();
 
+    if args.sequence_diagram && args.files.len() > 1 {
+        eprintln!("error: --sequence-diagram only supports a single archive file");
+        std::process::exit(1);
+    }
+
     let multiple_files = args.files.len() > 1;
     for path in &args.files {
         if multiple_files {
@@ -50,6 +69,15 @@ fn main() {
                 }
                 if args.list_peers {
                     print_peers(&archive);
+                } else if args.sequence_diagram {
+                    let mermaid = build_sequence_diagram(&archive, &args.peer);
+                    if let Some(mermaid) = mermaid {
+                        if let Some(html_path) = &args.html {
+                            write_html(html_path, &mermaid);
+                        } else {
+                            print!("{mermaid}");
+                        }
+                    }
                 } else {
                     print_events(&archive);
                 }
@@ -98,12 +126,16 @@ fn print_events(archive: &replayer::Archive) {
     println!("total: {} events", archive.events.len());
 }
 
-fn collect_peers(archive: &replayer::Archive) -> HashMap<u64, Peer> {
+fn collect_peers(archive: &replayer::Archive, peer_filter: &[u64]) -> HashMap<u64, Peer> {
     let mut peers: HashMap<u64, Peer> = HashMap::new();
     for event in &archive.events {
         if let Some(PeerObserverEvent::EbpfExtractor(ebpf)) = &event.peer_observer_event {
             if let Some(ebpf::EbpfEvent::Message(msg)) = &ebpf.ebpf_event {
-                let peer = peers.entry(msg.meta.peer_id).or_insert_with(|| Peer {
+                let peer_id = msg.meta.peer_id;
+                if !peer_filter.is_empty() && !peer_filter.contains(&peer_id) {
+                    continue;
+                }
+                let peer = peers.entry(peer_id).or_insert_with(|| Peer {
                     addr: msg.meta.addr.clone(),
                     messages: 0,
                 });
@@ -115,7 +147,7 @@ fn collect_peers(archive: &replayer::Archive) -> HashMap<u64, Peer> {
 }
 
 fn print_peers(archive: &replayer::Archive) {
-    let peers = collect_peers(archive);
+    let peers = collect_peers(archive, &[]);
     if peers.is_empty() {
         eprintln!("no peers found in archive");
         return;
@@ -125,5 +157,380 @@ fn print_peers(archive: &replayer::Archive) {
     println!("{:<10} {:<25} Messages", "Peer ID", "Address");
     for (peer_id, peer) in &sorted_peers {
         println!("{:<10} {:<25} {}", peer_id, peer.addr, peer.messages);
+    }
+}
+
+fn build_sequence_diagram(archive: &replayer::Archive, peer_filter: &[u64]) -> Option<String> {
+    let peers = collect_peers(archive, peer_filter);
+
+    if peers.is_empty() {
+        eprintln!("no P2P messages found in archive");
+        return None;
+    }
+
+    let mut out = String::new();
+    out.push_str("sequenceDiagram\n");
+    out.push_str("    participant Node as Our Node\n");
+    let mut sorted_peers: Vec<_> = peers.iter().collect();
+    sorted_peers.sort_by_key(|(id, _)| *id);
+    for (peer_id, peer) in &sorted_peers {
+        let addr = sanitize_for_mermaid(&peer.addr);
+        out.push_str(&format!(
+            "    participant P{} as Peer {} ({})\n",
+            peer_id, peer_id, addr
+        ));
+    }
+    out.push('\n');
+
+    for event in &archive.events {
+        if let Some(PeerObserverEvent::EbpfExtractor(ebpf)) = &event.peer_observer_event {
+            if let Some(ebpf::EbpfEvent::Message(msg)) = &ebpf.ebpf_event {
+                let peer_id = msg.meta.peer_id;
+                if !peer_filter.is_empty() && !peer_filter.contains(&peer_id) {
+                    continue;
+                }
+                let label = message_label(msg);
+
+                if msg.meta.inbound {
+                    out.push_str(&format!("    P{}->>Node: {}\n", peer_id, label));
+                } else {
+                    out.push_str(&format!("    Node->>P{}: {}\n", peer_id, label));
+                }
+            }
+        }
+    }
+
+    Some(out)
+}
+
+fn write_html(path: &Path, mermaid: &str) {
+    let html = format!(
+        "<!DOCTYPE html>\n\
+         <html><head>\n\
+         <script src=\"https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js\"></script>\n\
+         <script>mermaid.initialize({{ maxTextSize: 500000 }});</script>\n\
+         </head><body>\n\
+         <pre class=\"mermaid\">\n\
+         {mermaid}\
+         </pre>\n\
+         </body></html>\n"
+    );
+    if let Err(e) = std::fs::write(path, &html) {
+        eprintln!("error writing {}: {}", path.display(), e);
+        std::process::exit(1);
+    }
+    eprintln!("wrote {}", path.display());
+}
+
+/// Escape characters that break mermaid/HTML rendering (e.g. user_agent in version messages)
+fn sanitize_for_mermaid(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\n', " ")
+        .replace('\r', "")
+}
+
+fn message_label(msg: &MessageEvent) -> String {
+    let detail = message_detail(msg);
+    let label = if detail.is_empty() {
+        if msg.meta.size > 0 {
+            format!("{} ({}B)", msg.meta.command, msg.meta.size)
+        } else {
+            msg.meta.command.clone()
+        }
+    } else {
+        format!("{} ({})", msg.meta.command, detail)
+    };
+    sanitize_for_mermaid(&label)
+}
+
+fn message_detail(msg: &MessageEvent) -> String {
+    match &msg.msg {
+        Some(Msg::Ping(ping)) => format!("nonce: {:#x}", ping.value),
+        Some(Msg::Pong(pong)) => format!("nonce: {:#x}", pong.value),
+        Some(Msg::Inv(inv)) => format!("{} items", inv.items.len()),
+        Some(Msg::Getdata(getdata)) => format!("{} items", getdata.items.len()),
+        Some(Msg::Headers(headers)) => format!("{} headers", headers.headers.len()),
+        Some(Msg::Addr(addr)) => format!("{} addrs", addr.addresses.len()),
+        Some(Msg::Addrv2(addrv2)) => format!("{} addrs", addrv2.addresses.len()),
+        Some(Msg::Version(version)) => {
+            format!("ua={} height={}", version.user_agent, version.start_height)
+        }
+        Some(Msg::Feefilter(feefilter)) => format!("fee={}", feefilter.fee),
+        Some(Msg::Sendcompact(sendcompact)) => format!("v={}", sendcompact.version),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::protobuf::ebpf_extractor::message::{
+        Addr, AddrV2, FeeFilter, GetData, Headers, Inv, Metadata, Ping, Pong, SendCompact, Version,
+    };
+    use shared::protobuf::ebpf_extractor::Ebpf;
+    use shared::protobuf::event::Event;
+
+    // --- helpers ---
+
+    fn make_meta(command: &str, peer_id: u64, inbound: bool, size: u64) -> Metadata {
+        Metadata {
+            peer_id,
+            addr: "127.0.0.1:8333".to_string(),
+            conn_type: 1,
+            command: command.to_string(),
+            inbound,
+            size,
+        }
+    }
+
+    fn make_msg_event(meta: Metadata, msg: Option<Msg>) -> MessageEvent {
+        MessageEvent { meta, msg }
+    }
+
+    fn make_archive(events: Vec<Event>) -> replayer::Archive {
+        replayer::Archive {
+            header: replayer::ArchiveHeader {
+                version: 1,
+                git_hash: [0; 4],
+            },
+            events,
+        }
+    }
+
+    fn make_event(peer_id: u64, addr: &str, command: &str, inbound: bool) -> Event {
+        Event {
+            timestamp: 1000,
+            peer_observer_event: Some(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                    meta: Metadata {
+                        peer_id,
+                        addr: addr.to_string(),
+                        conn_type: 1,
+                        command: command.to_string(),
+                        inbound,
+                        size: 0,
+                    },
+                    msg: None,
+                })),
+            })),
+        }
+    }
+
+    // --- collect_peers ---
+
+    #[test]
+    fn test_collect_peers_empty() {
+        let archive = make_archive(vec![]);
+        let peers = collect_peers(&archive, &[]);
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn test_collect_peers_counts() {
+        let archive = make_archive(vec![
+            make_event(5, "1.2.3.4:8333", "ping", true),
+            make_event(5, "1.2.3.4:8333", "pong", false),
+            make_event(5, "1.2.3.4:8333", "inv", true),
+            make_event(10, "5.6.7.8:8333", "ping", true),
+        ]);
+        let peers = collect_peers(&archive, &[]);
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[&5].addr, "1.2.3.4:8333");
+        assert_eq!(peers[&5].messages, 3);
+        assert_eq!(peers[&10].messages, 1);
+    }
+
+    #[test]
+    fn test_collect_peers_with_filter() {
+        let archive = make_archive(vec![
+            make_event(5, "1.2.3.4:8333", "ping", true),
+            make_event(10, "5.6.7.8:8333", "ping", true),
+        ]);
+        let peers = collect_peers(&archive, &[5]);
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains_key(&5));
+        assert!(!peers.contains_key(&10));
+    }
+
+    #[test]
+    fn test_collect_peers_filter_no_match() {
+        let archive = make_archive(vec![make_event(5, "1.2.3.4:8333", "ping", true)]);
+        let peers = collect_peers(&archive, &[999]);
+        assert!(peers.is_empty());
+    }
+
+    // --- message_detail ---
+
+    #[test]
+    fn test_message_detail_ping() {
+        let msg = make_msg_event(
+            make_meta("ping", 1, true, 8),
+            Some(Msg::Ping(Ping { value: 0xdeadbeef })),
+        );
+        assert_eq!(message_detail(&msg), "nonce: 0xdeadbeef");
+    }
+
+    #[test]
+    fn test_message_detail_pong() {
+        let msg = make_msg_event(
+            make_meta("pong", 1, false, 8),
+            Some(Msg::Pong(Pong { value: 0xcafe })),
+        );
+        assert_eq!(message_detail(&msg), "nonce: 0xcafe");
+    }
+
+    #[test]
+    fn test_message_detail_inv() {
+        let msg = make_msg_event(
+            make_meta("inv", 1, true, 100),
+            Some(Msg::Inv(Inv {
+                items: vec![Default::default(); 3],
+            })),
+        );
+        assert_eq!(message_detail(&msg), "3 items");
+    }
+
+    #[test]
+    fn test_message_detail_getdata() {
+        let msg = make_msg_event(
+            make_meta("getdata", 1, false, 100),
+            Some(Msg::Getdata(GetData {
+                items: vec![Default::default(); 5],
+            })),
+        );
+        assert_eq!(message_detail(&msg), "5 items");
+    }
+
+    #[test]
+    fn test_message_detail_headers() {
+        let msg = make_msg_event(
+            make_meta("headers", 1, true, 100),
+            Some(Msg::Headers(Headers {
+                headers: vec![Default::default(); 2],
+            })),
+        );
+        assert_eq!(message_detail(&msg), "2 headers");
+    }
+
+    #[test]
+    fn test_message_detail_addr() {
+        let msg = make_msg_event(
+            make_meta("addr", 1, true, 100),
+            Some(Msg::Addr(Addr {
+                addresses: vec![Default::default(); 10],
+            })),
+        );
+        assert_eq!(message_detail(&msg), "10 addrs");
+    }
+
+    #[test]
+    fn test_message_detail_addrv2() {
+        let msg = make_msg_event(
+            make_meta("addrv2", 1, true, 100),
+            Some(Msg::Addrv2(AddrV2 {
+                addresses: vec![Default::default(); 4],
+            })),
+        );
+        assert_eq!(message_detail(&msg), "4 addrs");
+    }
+
+    #[test]
+    fn test_message_detail_version() {
+        let msg = make_msg_event(
+            make_meta("version", 1, true, 100),
+            Some(Msg::Version(Version {
+                version: 70016,
+                services: 1033,
+                timestamp: 0,
+                receiver: Default::default(),
+                sender: Default::default(),
+                nonce: 0,
+                user_agent: "/Satoshi:25.0.0/".to_string(),
+                start_height: 800000,
+                relay: true,
+            })),
+        );
+        assert_eq!(message_detail(&msg), "ua=/Satoshi:25.0.0/ height=800000");
+    }
+
+    #[test]
+    fn test_message_detail_feefilter() {
+        let msg = make_msg_event(
+            make_meta("feefilter", 1, true, 8),
+            Some(Msg::Feefilter(FeeFilter { fee: 1000 })),
+        );
+        assert_eq!(message_detail(&msg), "fee=1000");
+    }
+
+    #[test]
+    fn test_message_detail_sendcompact() {
+        let msg = make_msg_event(
+            make_meta("sendcmpct", 1, false, 9),
+            Some(Msg::Sendcompact(SendCompact {
+                send_compact: true,
+                version: 2,
+            })),
+        );
+        assert_eq!(message_detail(&msg), "v=2");
+    }
+
+    #[test]
+    fn test_message_detail_unknown() {
+        let msg = make_msg_event(make_meta("verack", 1, true, 0), Some(Msg::Verack(true)));
+        assert_eq!(message_detail(&msg), "");
+    }
+
+    #[test]
+    fn test_message_detail_none() {
+        let msg = make_msg_event(make_meta("wtxidrelay", 1, true, 0), None);
+        assert_eq!(message_detail(&msg), "");
+    }
+
+    // --- message_label ---
+
+    #[test]
+    fn test_message_label_with_detail() {
+        let msg = make_msg_event(
+            make_meta("ping", 1, true, 8),
+            Some(Msg::Ping(Ping { value: 42 })),
+        );
+        assert_eq!(message_label(&msg), "ping (nonce: 0x2a)");
+    }
+
+    #[test]
+    fn test_message_label_no_detail_with_size() {
+        let msg = make_msg_event(make_meta("verack", 1, true, 100), Some(Msg::Verack(true)));
+        assert_eq!(message_label(&msg), "verack (100B)");
+    }
+
+    #[test]
+    fn test_message_label_no_detail_no_size() {
+        let msg = make_msg_event(make_meta("verack", 1, true, 0), Some(Msg::Verack(true)));
+        assert_eq!(message_label(&msg), "verack");
+    }
+
+    #[test]
+    fn test_message_label_escapes_special_chars() {
+        let msg = make_msg_event(
+            make_meta("version", 1, true, 100),
+            Some(Msg::Version(Version {
+                version: 70016,
+                services: 1033,
+                timestamp: 0,
+                receiver: Default::default(),
+                sender: Default::default(),
+                nonce: 0,
+                user_agent: "<script>alert(1)</script>".to_string(),
+                start_height: 800000,
+                relay: true,
+            })),
+        );
+        let label = message_label(&msg);
+        assert!(!label.contains('<'));
+        assert!(!label.contains('>'));
+        assert!(label.contains("&lt;script&gt;"));
     }
 }

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -37,6 +37,10 @@ struct Args {
     #[arg(long, conflicts_with_all = ["sequence_diagram", "list_peers"])]
     csv: Option<PathBuf>,
 
+    /// Filter to specific message types, comma-separated (e.g. ping,inv,tx).
+    #[arg(long, value_delimiter = ',')]
+    msg_type: Vec<String>,
+
     /// Only include events with timestamp >= this value (milliseconds).
     #[arg(long)]
     from: Option<u64>,
@@ -77,6 +81,18 @@ fn main() {
                     archive
                         .events
                         .retain(|event| (from..=to).contains(&event.timestamp));
+                }
+                if !args.msg_type.is_empty() {
+                    archive.events.retain(|event| {
+                        if let Some(PeerObserverEvent::EbpfExtractor(ebpf)) =
+                            &event.peer_observer_event
+                        {
+                            if let Some(ebpf::EbpfEvent::Message(msg)) = &ebpf.ebpf_event {
+                                return args.msg_type.iter().any(|t| t == &msg.meta.command);
+                            }
+                        }
+                        false
+                    });
                 }
                 if let Some(csv_path) = &args.csv {
                     write_csv(csv_path, &archive);

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use shared::clap;
@@ -31,6 +33,10 @@ struct Args {
     #[arg(long, conflicts_with = "sequence_diagram")]
     list_peers: bool,
 
+    /// Write P2P events as CSV to a file.
+    #[arg(long, conflicts_with_all = ["sequence_diagram", "list_peers"])]
+    csv: Option<PathBuf>,
+
     /// Only include events with timestamp >= this value (milliseconds).
     #[arg(long)]
     from: Option<u64>,
@@ -53,6 +59,11 @@ fn main() {
         std::process::exit(1);
     }
 
+    if args.csv.is_some() && args.files.len() > 1 {
+        eprintln!("error: --csv only supports a single archive file");
+        std::process::exit(1);
+    }
+
     let multiple_files = args.files.len() > 1;
     for path in &args.files {
         if multiple_files {
@@ -67,7 +78,9 @@ fn main() {
                         .events
                         .retain(|event| (from..=to).contains(&event.timestamp));
                 }
-                if args.list_peers {
+                if let Some(csv_path) = &args.csv {
+                    write_csv(csv_path, &archive);
+                } else if args.list_peers {
                     print_peers(&archive);
                 } else if args.sequence_diagram {
                     let mermaid = build_sequence_diagram(&archive, &args.peer);
@@ -124,6 +137,43 @@ fn print_events(archive: &replayer::Archive) {
         }
     }
     println!("total: {} events", archive.events.len());
+}
+
+fn csv_escape(field: &str) -> String {
+    if field.contains(',') || field.contains('"') || field.contains('\n') || field.contains('\r') {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+
+fn write_csv(path: &Path, archive: &replayer::Archive) {
+    let write = || -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        writeln!(file, "timestamp,peer_id,addr,command,direction,size")?;
+        for event in &archive.events {
+            if let Some(PeerObserverEvent::EbpfExtractor(ebpf)) = &event.peer_observer_event {
+                if let Some(ebpf::EbpfEvent::Message(msg)) = &ebpf.ebpf_event {
+                    writeln!(
+                        file,
+                        "{},{},{},{},{},{}",
+                        event.timestamp,
+                        msg.meta.peer_id,
+                        csv_escape(&msg.meta.addr),
+                        csv_escape(&msg.meta.command),
+                        if msg.meta.inbound { "in" } else { "out" },
+                        msg.meta.size,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    };
+    if let Err(e) = write() {
+        eprintln!("error writing {}: {}", path.display(), e);
+        std::process::exit(1);
+    }
+    eprintln!("wrote {}", path.display());
 }
 
 fn collect_peers(archive: &replayer::Archive, peer_filter: &[u64]) -> HashMap<u64, Peer> {
@@ -532,5 +582,27 @@ mod tests {
         assert!(!label.contains('<'));
         assert!(!label.contains('>'));
         assert!(label.contains("&lt;script&gt;"));
+    }
+
+    // --- csv_escape ---
+
+    #[test]
+    fn test_csv_escape_plain() {
+        assert_eq!(csv_escape("127.0.0.1:8333"), "127.0.0.1:8333");
+    }
+
+    #[test]
+    fn test_csv_escape_comma() {
+        assert_eq!(csv_escape("a,b"), "\"a,b\"");
+    }
+
+    #[test]
+    fn test_csv_escape_quotes() {
+        assert_eq!(csv_escape("say \"hello\""), "\"say \"\"hello\"\"\"");
+    }
+
+    #[test]
+    fn test_csv_escape_newline() {
+        assert_eq!(csv_escape("line1\nline2"), "\"line1\nline2\"");
     }
 }

--- a/tools/replayer/tests/integration.rs
+++ b/tools/replayer/tests/integration.rs
@@ -416,6 +416,124 @@ fn test_from_to_filter_with_sequence_diagram() {
     assert!(!stdout.contains("P10"));
 }
 
+// --- msg-type filter ---
+
+#[test]
+fn test_msg_type_filter() {
+    let events = vec![
+        make_msg_event(1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(2, "pong", false, 8, Some(Msg::Pong(Pong { value: 1 }))),
+        make_msg_event(1, "inv", true, 100, None),
+    ];
+    let path = write_archive("msg-type-filter.bin", &events);
+    let output = replayer()
+        .arg("--msg-type")
+        .arg("ping")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 1 events"));
+}
+
+#[test]
+fn test_msg_type_filter_comma_separated() {
+    let events = vec![
+        make_msg_event(1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(2, "pong", false, 8, Some(Msg::Pong(Pong { value: 1 }))),
+        make_msg_event(1, "inv", true, 100, None),
+    ];
+    let path = write_archive("msg-type-comma.bin", &events);
+    let output = replayer()
+        .arg("--msg-type")
+        .arg("ping,pong")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 2 events"));
+}
+
+#[test]
+fn test_msg_type_filter_with_sequence_diagram() {
+    let events = vec![
+        make_msg_event_ts(1000, 5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            2000,
+            5,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+        make_msg_event_ts(3000, 5, "inv", true, 100, None),
+    ];
+    let path = write_archive("msg-type-seq.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--msg-type")
+        .arg("ping")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("ping"));
+    assert!(!stdout.contains("pong"));
+    assert!(!stdout.contains("inv"));
+}
+
+#[test]
+fn test_msg_type_filter_with_csv() {
+    let events = vec![
+        make_msg_event_ts(1000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            2000,
+            1,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+        make_msg_event_ts(3000, 1, "inv", true, 100, None),
+    ];
+    let archive_path = write_archive("msg-type-csv.bin", &events);
+    let csv_path = std::env::temp_dir().join("replayer-integ-msg-type.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg("--msg-type")
+        .arg("ping,inv")
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let csv = std::fs::read_to_string(&csv_path).unwrap();
+    let lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(lines.len(), 3); // header + 2 rows
+    assert!(lines[1].contains("ping"));
+    assert!(lines[2].contains("inv"));
+}
+
+#[test]
+fn test_msg_type_filter_no_match() {
+    let events = vec![make_msg_event(
+        1,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let path = write_archive("msg-type-nomatch.bin", &events);
+    let output = replayer()
+        .arg("--msg-type")
+        .arg("tx")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 0 events"));
+}
+
 // --- list-peers ---
 
 #[test]

--- a/tools/replayer/tests/integration.rs
+++ b/tools/replayer/tests/integration.rs
@@ -1,0 +1,754 @@
+use std::io::Write;
+use std::process::Command;
+
+use shared::prost::Message as _;
+use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::ebpf_extractor::message::{
+    message_event::Msg, MessageEvent, Metadata, Ping, Pong,
+};
+use shared::protobuf::ebpf_extractor::Ebpf;
+use shared::protobuf::event::event::PeerObserverEvent;
+use shared::protobuf::event::Event;
+use shared::zstd;
+
+const HEADER_SIZE: usize = 16;
+
+fn build_archive_bytes(version: u8, git_hash: [u8; 4], events: &[Event]) -> Vec<u8> {
+    let mut buf = vec![0u8; HEADER_SIZE];
+    buf[0..2].copy_from_slice(b"PA");
+    buf[2] = version;
+    buf[3..7].copy_from_slice(&git_hash);
+    for event in events {
+        let encoded = event.encode_length_delimited_to_vec();
+        buf.extend_from_slice(&encoded);
+    }
+    buf
+}
+
+fn make_meta(command: &str, peer_id: u64, inbound: bool, size: u64) -> Metadata {
+    Metadata {
+        peer_id,
+        addr: format!("127.0.0.{}:8333", peer_id),
+        conn_type: 1,
+        command: command.to_string(),
+        inbound,
+        size,
+    }
+}
+
+fn make_msg_event(
+    peer_id: u64,
+    command: &str,
+    inbound: bool,
+    size: u64,
+    msg: Option<Msg>,
+) -> Event {
+    Event {
+        timestamp: 1000 + peer_id * 100,
+        peer_observer_event: Some(PeerObserverEvent::EbpfExtractor(Ebpf {
+            ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                meta: make_meta(command, peer_id, inbound, size),
+                msg,
+            })),
+        })),
+    }
+}
+
+fn make_msg_event_ts(
+    ts: u64,
+    peer_id: u64,
+    command: &str,
+    inbound: bool,
+    size: u64,
+    msg: Option<Msg>,
+) -> Event {
+    Event {
+        timestamp: ts,
+        peer_observer_event: Some(PeerObserverEvent::EbpfExtractor(Ebpf {
+            ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                meta: make_meta(command, peer_id, inbound, size),
+                msg,
+            })),
+        })),
+    }
+}
+
+fn write_archive(name: &str, events: &[Event]) -> std::path::PathBuf {
+    let buf = build_archive_bytes(1, [0xde, 0xad, 0xbe, 0xef], events);
+    let path = std::env::temp_dir().join(format!("replayer-integ-{}", name));
+    std::fs::write(&path, &buf).unwrap();
+    path
+}
+
+fn write_archive_zst(name: &str, events: &[Event]) -> std::path::PathBuf {
+    let buf = build_archive_bytes(1, [0xde, 0xad, 0xbe, 0xef], events);
+    let mut encoder = zstd::Encoder::new(Vec::new(), 3).unwrap();
+    encoder.write_all(&buf).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let path = std::env::temp_dir().join(format!("replayer-integ-{}.zst", name));
+    std::fs::write(&path, &compressed).unwrap();
+    path
+}
+
+fn replayer() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_replayer"))
+}
+
+// --- print_events ---
+
+#[test]
+fn test_print_events_header() {
+    let path = write_archive("events-header.bin", &[]);
+    let output = replayer().arg(path).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("header: version=1 git=deadbeef"));
+    assert!(stdout.contains("total: 0 events"));
+}
+
+#[test]
+fn test_print_events_with_messages() {
+    let events = vec![
+        make_msg_event(1, "ping", true, 8, Some(Msg::Ping(Ping { value: 42 }))),
+        make_msg_event(2, "pong", false, 8, Some(Msg::Pong(Pong { value: 42 }))),
+    ];
+    let path = write_archive("events-msgs.bin", &events);
+    let output = replayer().arg(path).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("[1] ts=1100 ebpf:"));
+    assert!(stdout.contains("[2] ts=1200 ebpf:"));
+    assert!(stdout.contains("total: 2 events"));
+}
+
+#[test]
+fn test_print_events_multiple_files() {
+    let events = vec![make_msg_event(
+        1,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let p1 = write_archive("multi-1.bin", &events);
+    let p2 = write_archive("multi-2.bin", &events);
+    let output = replayer().arg(&p1).arg(&p2).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("=== "));
+}
+
+// --- sequence diagram (mermaid) ---
+
+#[test]
+fn test_sequence_diagram_basic() {
+    let events = vec![
+        make_msg_event_ts(1000, 5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            1050,
+            5,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+    ];
+    let path = write_archive("seq-basic.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("sequenceDiagram"));
+    assert!(stdout.contains("participant Node as Our Node"));
+    assert!(stdout.contains("participant P5 as Peer 5"));
+    assert!(stdout.contains("P5->>Node:"));
+    assert!(stdout.contains("Node->>P5:"));
+}
+
+#[test]
+fn test_sequence_diagram_peer_filter() {
+    let events = vec![
+        make_msg_event(5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(10, "ping", true, 8, Some(Msg::Ping(Ping { value: 2 }))),
+    ];
+    let path = write_archive("seq-filter.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--peer")
+        .arg("5")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("P5"));
+    assert!(!stdout.contains("P10"));
+}
+
+#[test]
+fn test_sequence_diagram_multiple_peers() {
+    let events = vec![
+        make_msg_event(5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(10, "pong", false, 8, Some(Msg::Pong(Pong { value: 2 }))),
+    ];
+    let path = write_archive("seq-multi-peer.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--peer")
+        .arg("5")
+        .arg("--peer")
+        .arg("10")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("P5"));
+    assert!(stdout.contains("P10"));
+}
+
+#[test]
+fn test_sequence_diagram_no_messages() {
+    let path = write_archive("seq-empty.bin", &[]);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("no P2P messages found"));
+}
+
+#[test]
+fn test_sequence_diagram_peer_filter_no_match() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let path = write_archive("seq-no-match.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--peer")
+        .arg("999")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("no P2P messages found"));
+}
+
+#[test]
+fn test_sequence_diagram_indentation() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let path = write_archive("seq-indent.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for line in stdout.lines().skip(1) {
+        if !line.is_empty() {
+            assert!(line.starts_with("    "), "line not indented: {:?}", line);
+        }
+    }
+}
+
+// --- CLI edge cases ---
+
+#[test]
+fn test_no_files_error() {
+    let output = replayer().output().unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_bad_file_error() {
+    let path = std::env::temp_dir().join("replayer-integ-nonexistent.bin");
+    let output = replayer().arg(path).output().unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("error reading"));
+}
+
+#[test]
+fn test_peer_requires_sequence_diagram() {
+    let output = replayer()
+        .arg("--peer")
+        .arg("5")
+        .arg("/dev/null")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_zst_archive() {
+    let events = vec![make_msg_event(
+        1,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let path = write_archive_zst("compressed", &events);
+    let output = replayer().arg(path).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 1 events"));
+}
+
+#[test]
+fn test_sequence_diagram_rejects_multiple_files() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let p1 = write_archive("seq-multi-1.bin", &events);
+    let p2 = write_archive("seq-multi-2.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(&p1)
+        .arg(&p2)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("single archive file"));
+}
+
+// --- time filter ---
+
+#[test]
+fn test_from_filter() {
+    let events = vec![
+        make_msg_event_ts(1000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(2000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 2 }))),
+        make_msg_event_ts(3000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 3 }))),
+    ];
+    let path = write_archive("from-filter.bin", &events);
+    let output = replayer()
+        .arg("--from")
+        .arg("2000")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 2 events"));
+}
+
+#[test]
+fn test_to_filter() {
+    let events = vec![
+        make_msg_event_ts(1000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(2000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 2 }))),
+        make_msg_event_ts(3000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 3 }))),
+    ];
+    let path = write_archive("to-filter.bin", &events);
+    let output = replayer()
+        .arg("--to")
+        .arg("2000")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 2 events"));
+}
+
+#[test]
+fn test_from_to_filter() {
+    let events = vec![
+        make_msg_event_ts(1000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(2000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 2 }))),
+        make_msg_event_ts(3000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 3 }))),
+    ];
+    let path = write_archive("from-to-filter.bin", &events);
+    let output = replayer()
+        .arg("--from")
+        .arg("1500")
+        .arg("--to")
+        .arg("2500")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total: 1 events"));
+}
+
+#[test]
+fn test_from_to_filter_with_sequence_diagram() {
+    let events = vec![
+        make_msg_event_ts(1000, 5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            2000,
+            5,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+        make_msg_event_ts(
+            3000,
+            10,
+            "ping",
+            true,
+            8,
+            Some(Msg::Ping(Ping { value: 2 })),
+        ),
+    ];
+    let path = write_archive("from-to-seq.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--to")
+        .arg("2000")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("P5"));
+    assert!(!stdout.contains("P10"));
+}
+
+// --- list-peers ---
+
+#[test]
+fn test_list_peers() {
+    let events = vec![
+        make_msg_event(5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(5, "pong", false, 8, Some(Msg::Pong(Pong { value: 1 }))),
+        make_msg_event(10, "ping", true, 8, Some(Msg::Ping(Ping { value: 2 }))),
+    ];
+    let path = write_archive("list-peers.bin", &events);
+    let output = replayer().arg("--list-peers").arg(path).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Peer ID"));
+    assert!(stdout.contains("Address"));
+    assert!(stdout.contains("Messages"));
+    assert!(stdout.contains("5"));
+    assert!(stdout.contains("10"));
+    assert!(stdout.contains("127.0.0.5:8333"));
+    assert!(stdout.contains("127.0.0.10:8333"));
+}
+
+#[test]
+fn test_list_peers_empty() {
+    let path = write_archive("list-peers-empty.bin", &[]);
+    let output = replayer().arg("--list-peers").arg(path).output().unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("no peers found"));
+}
+
+#[test]
+fn test_list_peers_conflicts_with_sequence_diagram() {
+    let output = replayer()
+        .arg("--list-peers")
+        .arg("--sequence-diagram")
+        .arg("/dev/null")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_list_peers_message_count() {
+    let events = vec![
+        make_msg_event(5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event(5, "pong", false, 8, Some(Msg::Pong(Pong { value: 1 }))),
+        make_msg_event(5, "inv", true, 100, None),
+    ];
+    let path = write_archive("list-peers-count.bin", &events);
+    let output = replayer().arg("--list-peers").arg(path).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // peer 5 has 3 messages
+    let peer_line = stdout.lines().find(|l| l.contains("127.0.0.5")).unwrap();
+    assert!(peer_line.contains("3"));
+}
+
+// --- html output ---
+
+#[test]
+fn test_html_output() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let archive_path = write_archive("html-out.bin", &events);
+    let html_path = std::env::temp_dir().join("replayer-integ-html-out.html");
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--html")
+        .arg(&html_path)
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("wrote"));
+    let html = std::fs::read_to_string(&html_path).unwrap();
+    assert!(html.contains("<!DOCTYPE html>"));
+    assert!(html.contains("mermaid"));
+    assert!(html.contains("sequenceDiagram"));
+    assert!(html.contains("P5"));
+}
+
+#[test]
+fn test_html_no_stdout() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let archive_path = write_archive("html-no-stdout.bin", &events);
+    let html_path = std::env::temp_dir().join("replayer-integ-html-no-stdout.html");
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--html")
+        .arg(&html_path)
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.is_empty());
+}
+
+#[test]
+fn test_html_bad_path() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let archive_path = write_archive("html-bad-path.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg("--html")
+        .arg("/nonexistent/dir/out.html")
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("error writing"));
+}
+
+// --- csv ---
+
+#[test]
+fn test_csv_messages() {
+    let events = vec![
+        make_msg_event_ts(1000, 5, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            2000,
+            10,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+    ];
+    let archive_path = write_archive("csv-msgs.bin", &events);
+    let csv_path = std::env::temp_dir().join("replayer-integ-csv-msgs.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("wrote"));
+    let csv = std::fs::read_to_string(&csv_path).unwrap();
+    let lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(lines[0], "timestamp,peer_id,addr,command,direction,size");
+    assert_eq!(lines[1], "1000,5,127.0.0.5:8333,ping,in,8");
+    assert_eq!(lines[2], "2000,10,127.0.0.10:8333,pong,out,8");
+    assert_eq!(lines.len(), 3);
+}
+
+#[test]
+fn test_csv_empty() {
+    let archive_path = write_archive("csv-empty.bin", &[]);
+    let csv_path = std::env::temp_dir().join("replayer-integ-csv-empty.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let csv = std::fs::read_to_string(&csv_path).unwrap();
+    let lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(lines.len(), 1); // header only
+}
+
+#[test]
+fn test_csv_conflicts_with_sequence_diagram() {
+    let output = replayer()
+        .arg("--csv")
+        .arg("/dev/null")
+        .arg("--sequence-diagram")
+        .arg("/dev/null")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_csv_conflicts_with_list_peers() {
+    let output = replayer()
+        .arg("--csv")
+        .arg("/dev/null")
+        .arg("--list-peers")
+        .arg("/dev/null")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_csv_with_time_filter() {
+    let events = vec![
+        make_msg_event_ts(1000, 1, "ping", true, 8, Some(Msg::Ping(Ping { value: 1 }))),
+        make_msg_event_ts(
+            2000,
+            1,
+            "pong",
+            false,
+            8,
+            Some(Msg::Pong(Pong { value: 1 })),
+        ),
+        make_msg_event_ts(3000, 1, "inv", true, 100, None),
+    ];
+    let archive_path = write_archive("csv-time.bin", &events);
+    let csv_path = std::env::temp_dir().join("replayer-integ-csv-time.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg("--from")
+        .arg("1500")
+        .arg("--to")
+        .arg("2500")
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let csv = std::fs::read_to_string(&csv_path).unwrap();
+    let lines: Vec<&str> = csv.lines().collect();
+    assert_eq!(lines.len(), 2); // header + 1 row
+    assert!(lines[1].starts_with("2000,"));
+}
+
+#[test]
+fn test_csv_no_stdout() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let archive_path = write_archive("csv-no-stdout.bin", &events);
+    let csv_path = std::env::temp_dir().join("replayer-integ-csv-no-stdout.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.is_empty());
+}
+
+#[test]
+fn test_csv_bad_path() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let archive_path = write_archive("csv-bad-path.bin", &events);
+    let output = replayer()
+        .arg("--csv")
+        .arg("/nonexistent/dir/out.csv")
+        .arg(archive_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("error writing"));
+}
+
+#[test]
+fn test_csv_rejects_multiple_files() {
+    let events = vec![make_msg_event(
+        5,
+        "ping",
+        true,
+        8,
+        Some(Msg::Ping(Ping { value: 1 })),
+    )];
+    let p1 = write_archive("csv-multi-1.bin", &events);
+    let p2 = write_archive("csv-multi-2.bin", &events);
+    let csv_path = std::env::temp_dir().join("replayer-integ-csv-multi.csv");
+    let output = replayer()
+        .arg("--csv")
+        .arg(&csv_path)
+        .arg(&p1)
+        .arg(&p2)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("single archive file"));
+}
+
+// --- message label in diagram output ---
+
+#[test]
+fn test_diagram_message_with_size_no_detail() {
+    let events = vec![make_msg_event(5, "tx", true, 500, None)];
+    let path = write_archive("seq-size.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("tx (500B)"));
+}
+
+#[test]
+fn test_diagram_message_no_size_no_detail() {
+    let events = vec![make_msg_event(
+        5,
+        "verack",
+        true,
+        0,
+        Some(Msg::Verack(true)),
+    )];
+    let path = write_archive("seq-no-size.bin", &events);
+    let output = replayer()
+        .arg("--sequence-diagram")
+        .arg(path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("verack"));
+    assert!(!stdout.contains("(0B)"));
+}


### PR DESCRIPTION
Implements both approaches from #397.

  - `--sequence-diagram`: mermaid sequence diagram from archived P2P messages
  - `--html <path>`: self-contained HTML with client-side rendering
  - `--csv <path>`: export P2P messages as CSV for external tools
  - `--peer`: filter to specific peer IDs
  - `--list-peers`: peers sorted by message count
  - `--msg-type`: filter by message type (e.g. `--msg-type ping,inv,tx`)
  - `--from`/`--to`: timestamp filtering, works with all output modes

  Mermaid for diagram rendering, its open-source, well maintained,
  renders client-side (https://github.com/mermaid-js/mermaid).

  HTML output example: 
cargo run -p replayer -- /tmp/archiver-output/archive.20260520-171752-085.bin.zst --sequence-diagram --peer 56 --peer 92 --html /tmp/diagram.html
<img width="3244" height="7706" alt="image" src="https://github.com/user-attachments/assets/49a1e685-8723-451d-a1af-7465e9207f6d" />


  Questions:
  - What should diagrams show beyond message type and timestamp?
  - Should we cap the default number of peers shown? Currently shows all.
  - Worth exploring a web UI where you drop archive files and browse interactively?