### PR TITLE
remove: drop duplicate dev dependencies from archiver

### DIFF
--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -10,8 +10,6 @@ toml = "0.8"
 sha2 = "0.10"
 
 [dev-dependencies]
-sha2 = "0.10"
-toml = "0.8"
 replayer = { path = "../replayer" }
 
 [features]


### PR DESCRIPTION
This is a followup to #373 and resolves a part of #439.

In Rust, dev-dependencies inherit from normal dependencies. No need to have them here twice.