### PR TITLE
ci: free disk space on ubuntu runners

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,86 @@
+name: Free disk space on Ubuntu runners
+description: >
+  Remove preinstalled SDKs, large apt packages, and Docker images that
+  the peer-observer CI jobs don't use, freeing headroom on ubuntu-latest
+  for the cargo cache restore and subsequent build.
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        set -eo pipefail
+
+        avail_bytes() {
+          df --output=avail -B1 / | tail -1 | tr -dc '0-9'
+        }
+        to_mib() { echo $(( $1 / 1024 / 1024 )); }
+        to_gib() { echo $(( $1 / 1024 / 1024 / 1024 )); }
+
+        banner() {
+          echo
+          echo "===================================================================="
+          echo ">>> $1"
+          echo "===================================================================="
+        }
+
+        report_delta() {
+          local label="$1" pre="$2"
+          local post delta_bytes
+          post=$(avail_bytes)
+          delta_bytes=$(( post - pre ))
+          echo
+          df -h /
+          printf -- "--> %s reclaimed: +%d MiB (avail now: %d MiB / %d GiB)\n" \
+            "$label" "$(to_mib "$delta_bytes")" "$(to_mib "$post")" "$(to_gib "$post")"
+        }
+
+        PRE_TOTAL=$(avail_bytes)
+
+        banner "Initial disk usage"
+        df -h /
+
+        banner "Remove preinstalled SDKs"
+        PRE=$(avail_bytes)
+        for d in \
+          /usr/local/lib/android \
+          /opt/hostedtoolcache/CodeQL \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /usr/share/dotnet \
+          /usr/share/swift \
+          /usr/share/miniconda \
+          /usr/local/share/powershell \
+          /usr/local/share/chromium ; do
+          sudo rm -rf "$d" || true
+        done
+        sudo rm -rf /opt/hostedtoolcache/Java_*_x64 || true
+        report_delta "SDK removal" "$PRE"
+
+        banner "Purge large apt packages"
+        PRE=$(avail_bytes)
+        # Drop apt's noisy "Package 'X' is not installed, so not removed" lines:
+        # apt expands quoted globs (e.g. 'mysql-*') against its full package DB,
+        # printing one line per known-but-uninstalled match.
+        sudo apt-get purge -y --auto-remove \
+          azure-cli google-cloud-cli google-cloud-sdk \
+          microsoft-edge-stable firefox google-chrome-stable \
+          'mysql-*' 'postgresql-*' 'mongodb-*' \
+          'temurin-*-jdk' 2>&1 \
+          | grep -v 'is not installed, so not removed' || true
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        report_delta "Apt purge" "$PRE"
+
+        banner "Docker prune"
+        PRE=$(avail_bytes)
+        sudo docker image prune --all --force || true
+        sudo docker builder prune -a --force || true
+        report_delta "Docker prune" "$PRE"
+
+        banner "Cleanup summary"
+        POST_TOTAL=$(avail_bytes)
+        DELTA_TOTAL_GIB=$(( (POST_TOTAL - PRE_TOTAL) / 1024 / 1024 / 1024 ))
+        df -h /
+        printf -- "==> Total reclaimed: +%d GiB (avail now: %d GiB)\n" \
+          "$DELTA_TOTAL_GIB" "$(to_gib "$POST_TOTAL")"

--- a/.github/actions/setup-ubuntu-action/action.yml
+++ b/.github/actions/setup-ubuntu-action/action.yml
@@ -4,6 +4,9 @@ description: Install dependencies and setup Rust cache
 runs:
   using: composite
   steps:
+    - name: Free disk space
+      uses: ./.github/actions/free-disk-space
+
     - name: Install build dependecies
       shell: bash
       run: |
@@ -19,8 +22,12 @@ runs:
           elfutils \
           gcc-multilib \
           libcapnp-dev \
-          capnproto 
-    
+          capnproto \
+          pkg-config \
+          make \
+          git \
+          jq
+
     - name: Cache cargo
       uses: actions/cache@v3
       with:
@@ -31,3 +38,24 @@ runs:
         key: ${{ runner.os }}-ubuntu-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-ubuntu-cargo-
+
+    - name: Report disk usage after cargo cache restore
+      shell: bash
+      run: |
+        set -eo pipefail
+
+        avail_bytes() {
+          df --output=avail -B1 / | tail -1 | tr -dc '0-9'
+        }
+        to_gib() { echo $(( $1 / 1024 / 1024 / 1024 )); }
+
+        echo
+        echo "===================================================================="
+        echo ">>> Disk usage after cargo cache restore"
+        echo "===================================================================="
+        df -h /
+        echo
+        du -sh ~/.cargo/registry ~/.cargo/git target 2>/dev/null || true
+        du -sh target/debug/deps target/debug/incremental target/debug/build 2>/dev/null || true
+        AVAIL=$(avail_bytes)
+        printf -- "==> Avail after cache restore: %d GiB\n" "$(to_gib "$AVAIL")"


### PR DESCRIPTION
## Summary

`ubuntu-test` has been failing intermittently with `rustc-LLVM ERROR: IO failure on output stream: No space left on device` during the link step (see #446). On the constrained `ubuntu-latest` SKU (with 72 GiB) the runner has only ~5 GiB free after the 14 GB cargo cache is restored, leaving cargo's linker with nowhere to land its object files. 

This PR adds a new `.github/actions/free-disk-space` composite that removes preinstalled SDKs and large apt packages the project doesn't use (Android, CodeQL, GHC/GHCup, .NET, Swift, Miniconda, PowerShell, Chromium, JDKs, Azure/Google CLIs, browsers, MySQL/Postgres/Mongo, Temurin JDKs) plus the preinstalled Docker images. Estimated reclaim is ~25-30 GiB. The composite is wired as the first nested step in `setup-ubuntu-action` so every Ubuntu job runs the cleanup before apt install and before the cargo cache restore.

The composite logs `df -h /` and a per-group delta after each operation, so the impact is visible in every CI run. A matching `Report disk usage after cargo cache restore` step is added at the end of `setup-ubuntu-action` to show `df -h /` plus `du -sh` of the cargo cache directories and `target/` after the cache lands.

`pkg-config`, `make`, `git`, and `jq` are added to the apt install list. The cleanup runs `apt-get autoremove`, which could plausibly cascade-remove any of them; making them explicit removes that footgun.

## Testing

End-to-end validation is this PR's CI pass. The pre/post `df` logs in the cleanup composite and the post-cache report will surface the actual reclaim and the post-cache headroom in every run.

Closes #446