### PR TITLE
test(shared): add post-IBD tip wait helper

### DIFF
--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -17,7 +17,7 @@ use shared::{
         },
     },
     simple_logger::SimpleLogger,
-    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting, node::mine_and_wait_for_tip},
     tokio::{
         self, select,
         sync::{oneshot, watch},
@@ -236,18 +236,8 @@ async fn test_integration_p2pextractor_addr_annoucement() {
             ..Default::default()
         },
         |node| {
-            // To self-announce our address, we need to be out ouf initial block download
-            // Mine a block to get out of initial block download
-            node.client
-                .generate_to_address(1, &REGTEST_ADDRESS)
-                .unwrap();
-            assert!(
-                !node
-                    .client
-                    .get_blockchain_info()
-                    .unwrap()
-                    .initial_block_download
-            );
+            // To self-announce our address, we need to be out of initial block download.
+            mine_and_wait_for_tip(&node.client);
 
             // Connects to the Bitcoin node, announces one address to it, and disconnect.
             // The node will then relay that address to the p2p-extractor eventually.

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -24,7 +24,7 @@ use shared::{
             },
         },
     },
-    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
+    testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting, node::mine_and_wait_for_tip},
     tokio::{
         self, select,
         sync::{oneshot, watch},
@@ -480,10 +480,7 @@ async fn test_integration_rpc_getorphantxs() {
                 .collect();
 
             // The receiving node needs to be out of IBD to start accepting transactions.
-            node1
-                .client
-                .generate_to_address(1, &REGTEST_ADDRESS)
-                .expect("failed to generate to address");
+            mine_and_wait_for_tip(&node1.client);
 
             // node1 is peer=0 of node2
             const PEER_ID: u64 = 0;

--- a/shared/src/testing/mod.rs
+++ b/shared/src/testing/mod.rs
@@ -17,3 +17,5 @@ pub mod metrics_fetcher;
 pub mod nats_publisher;
 /// A NATS server runnner to be used in integration tests.
 pub mod nats_server;
+/// Utilities for driving Bitcoin Core nodes in integration tests.
+pub mod node;

--- a/shared/src/testing/node.rs
+++ b/shared/src/testing/node.rs
@@ -1,0 +1,51 @@
+use crate::{bitcoin::BlockHash, bitcoind, testing::REGTEST_ADDRESS};
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+const POST_IBD_TIP_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn wait_for_tip_post_ibd(node: &bitcoind::Client, expected_tip: BlockHash) {
+    let start = Instant::now();
+
+    loop {
+        let info = node
+            .get_blockchain_info()
+            .expect("failed to get blockchain info while waiting for post-IBD tip")
+            .into_model()
+            .expect("failed to parse blockchain info while waiting for post-IBD tip");
+
+        if info.best_block_hash == expected_tip && !info.initial_block_download {
+            node.sync_with_validation_interface_queue()
+                .expect("failed to sync validation interface queue after post-IBD tip");
+            return;
+        }
+
+        if start.elapsed() >= POST_IBD_TIP_TIMEOUT {
+            panic!(
+                "timed out waiting for node tip {expected_tip} post-IBD; \
+                 last tip={}, blocks={}, headers={}, ibd={}",
+                info.best_block_hash, info.blocks, info.headers, info.initial_block_download
+            );
+        }
+
+        sleep(Duration::from_millis(50));
+    }
+}
+
+/// Mines one block on `node` and waits until that block is its active post-IBD tip.
+pub fn mine_and_wait_for_tip(node: &bitcoind::Client) {
+    let generated = node
+        .generate_to_address(1, &REGTEST_ADDRESS)
+        .expect("failed to generate block while waiting for post-IBD tip");
+    let block_hash = generated
+        .into_model()
+        .expect("failed to parse generated block hash")
+        .0
+        .into_iter()
+        .next()
+        .expect("generatetoaddress returned no block hashes");
+
+    wait_for_tip_post_ibd(node, block_hash);
+}


### PR DESCRIPTION
## Summary

This came out of reviewing the compact block reconstruction integration tests in #420. Those tests need a deterministic way to know that a regtest node has connected a mined block and left IBD before the next step tries to trigger post-IBD behaviour.

This adds `shared::testing::node::mine_and_wait_for_tip`, which mines one block on the given node, polls until that block is the active tip, verifies `initial_block_download` is false, and then drains the validation interface queue.

The existing `p2p-extractor` `address-announcement` and `rpc-extractor` `getorphantxs` tests both utilise the helper instead of generating a block and immediately asserting on IBD state. That should make the tests less sensitive to slow hardware (e.g. the hardware I actually use for testing, a VM on a 10yr old server!!) where bitcoind has not yet advanced all relevant state by the next line of test code.

UPDATE: The helper currently takes a single client because both call sites here are single-node. When the cross-node case lands (PR #420's `test_integration_logextractor_saw_new_header` is the obvious next caller, where `node2` mines and `node1` observes), the signature can grow to `(miner, observer)` or split into a dedicated `mine_and_wait_for_tip_observed_by` helper without disturbing the current callers.

## Testing

My usual stress: 50 consecutive runs of the integration suite on older hardware, all green.