### PR TITLE
archiver: remove manifest.toml writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,10 +99,8 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "sha2",
  "shared",
  "time",
- "toml",
 ]
 
 [[package]]
@@ -2008,30 +2006,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.9",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.9",
@@ -2358,47 +2336,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2976,15 +2913,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "winnow"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/shared/src/testing/nats_publisher.rs
+++ b/shared/src/testing/nats_publisher.rs
@@ -14,6 +14,7 @@ impl NatsPublisherForTesting {
     }
 
     pub async fn publish(&self, subject: String, payload: Vec<u8>) {
+        log::trace!("publishing {} ({} bytes)", subject, payload.len());
         self.client
             .publish(subject, payload.into())
             .await

--- a/tools/archive/Cargo.toml
+++ b/tools/archive/Cargo.toml
@@ -6,12 +6,7 @@ edition = "2021"
 [dependencies]
 shared = { path = "../../shared" }
 time = { version = "0.3", features = ["formatting", "macros"] }
-toml = "0.8"
-sha2 = "0.10"
 
-[dev-dependencies]
-sha2 = "0.10"
-toml = "0.8"
 
 [features]
 # Treat warnings as a build error.

--- a/tools/archive/README.md
+++ b/tools/archive/README.md
@@ -25,12 +25,6 @@ from `prost`), preceded by a 16-byte header:
 The git commit hash in the header identifies the exact version of the protobuf definitions used
 to record the file, allowing future readers to check out that commit if needed.
 
-### Manifest
-
-Each archive file has a corresponding `<base-name>.<timestamp>.manifest.toml` with its metadata
-(version, NATS address, event count, uncompressed size, SHA-256 checksum, event types,
-first/last timestamps).
-
 ### Compression
 
 Archive files are compressed with zstd using streaming compression — the writer is wrapped in a

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -234,6 +234,7 @@ impl ArchiveFile {
 
     fn write_event(&mut self, event: &Event) -> std::io::Result<()> {
         let buf = event.encode_length_delimited_to_vec();
+        log::trace!("writing {:?} ({} bytes)", event, buf.len());
         self.writer.write_all(&buf)?;
         self.hasher.update(&buf);
         self.bytes_written += buf.len() as u64;

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -4,7 +4,6 @@ mod error;
 
 pub use error::RuntimeError;
 
-use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -12,9 +11,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use time::macros::format_description;
 use time::OffsetDateTime;
-
-use sha2::{Digest, Sha256};
-use shared::serde::Serialize;
 
 use shared::clap;
 use shared::clap::Parser;
@@ -60,34 +56,14 @@ impl ArchiveHeader {
     }
 }
 
-#[derive(Serialize)]
-#[serde(crate = "shared::serde")]
-struct FileEntry {
-    name: String,
-    version: u8,
-    nats_address: String,
-    size_bytes: u64,
-    events: u64,
-    first_timestamp: u64,
-    last_timestamp: u64,
-    event_types: Vec<String>,
-    checksum: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    compressed_size_bytes: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    compressed_checksum: Option<String>,
-}
-
 struct TrackingWriter {
     inner: BufWriter<File>,
-    hasher: Sha256,
     bytes_written: u64,
 }
 
 impl Write for TrackingWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let written = self.inner.write(buf)?;
-        self.hasher.update(&buf[..written]);
         self.bytes_written += written as u64;
         Ok(written)
     }
@@ -95,11 +71,6 @@ impl Write for TrackingWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }
-}
-
-struct CompressedStats {
-    checksum: String,
-    size_bytes: u64,
 }
 
 enum ArchiveWriter {
@@ -112,7 +83,6 @@ impl ArchiveWriter {
         if compression_level > 0 {
             let tracker = TrackingWriter {
                 inner: BufWriter::new(file),
-                hasher: Sha256::new(),
                 bytes_written: 0,
             };
             let encoder = zstd::Encoder::new(tracker, compression_level as i32)?;
@@ -129,19 +99,16 @@ impl ArchiveWriter {
         }
     }
 
-    fn finish(self) -> std::io::Result<Option<CompressedStats>> {
+    fn finish(self) -> std::io::Result<()> {
         match self {
             Self::Plain(mut writer) => {
                 writer.flush()?;
-                Ok(None)
+                Ok(())
             }
             Self::Zstd(encoder) => {
                 let mut tracker = encoder.finish()?;
                 tracker.flush()?;
-                Ok(Some(CompressedStats {
-                    size_bytes: tracker.bytes_written,
-                    checksum: format!("{:x}", tracker.hasher.finalize()),
-                }))
+                Ok(())
             }
         }
     }
@@ -164,19 +131,11 @@ impl Write for ArchiveWriter {
 }
 
 /// Holds all mutable state for the currently open archive file.
-/// Tracks bytes written, event counts, timestamps, and event types
-/// so that the main event loop only needs to call write_event() and
-/// check needs_rotation().
+/// Tracks (compressed) bytes written so that we know when to rotate the file.
 struct ArchiveFile {
     path: PathBuf,
-    formatted_timestamp: String,
     writer: ArchiveWriter,
-    hasher: Sha256,
     bytes_written: u64,
-    events: u64,
-    first_timestamp: u64,
-    last_timestamp: u64,
-    event_types: HashSet<&'static str>,
 }
 
 impl ArchiveFile {
@@ -187,7 +146,7 @@ impl ArchiveFile {
             "bin"
         };
         // Retry on rare timestamp collisions (e.g. fast rotations in tests)
-        let (path, formatted_timestamp, file) = loop {
+        let (path, file) = loop {
             let formatted_timestamp = format_utc_timestamp(
                 SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -200,7 +159,7 @@ impl ArchiveFile {
                 .create_new(true)
                 .open(&path)
             {
-                Ok(file) => break (path, formatted_timestamp, file),
+                Ok(file) => break (path, file),
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                     std::thread::sleep(std::time::Duration::from_millis(1));
                 }
@@ -213,22 +172,17 @@ impl ArchiveFile {
             }
         };
         let mut writer = ArchiveWriter::new(file, compression_level)?;
-        let mut hasher = Sha256::new();
         // header: 16 bytes = MAGIC "PA" (2B) + VERSION (1B) + GIT_HASH (4B) + reserved (9B)
         let header_bytes = ArchiveHeader::new(GIT_HASH).to_bytes();
         writer.write_all(&header_bytes)?;
-        hasher.update(header_bytes);
         writer.flush()?;
+
+        log::info!("Created archive file: {}", path.display());
+
         Ok(Self {
             path,
-            formatted_timestamp,
             writer,
-            hasher,
             bytes_written: HEADER_SIZE as u64,
-            events: 0,
-            first_timestamp: 0,
-            last_timestamp: 0,
-            event_types: HashSet::new(),
         })
     }
 
@@ -236,16 +190,7 @@ impl ArchiveFile {
         let buf = event.encode_length_delimited_to_vec();
         log::trace!("writing {:?} ({} bytes)", event, buf.len());
         self.writer.write_all(&buf)?;
-        self.hasher.update(&buf);
         self.bytes_written += buf.len() as u64;
-        self.events += 1;
-        if self.first_timestamp == 0 {
-            self.first_timestamp = event.timestamp;
-        }
-        self.last_timestamp = event.timestamp;
-        if let Some(name) = event_type_name(event) {
-            self.event_types.insert(name);
-        }
         Ok(())
     }
 
@@ -256,26 +201,8 @@ impl ArchiveFile {
         }
     }
 
-    fn finalize(self, name: String, nats_address: &str) -> std::io::Result<FileEntry> {
-        let compressed_stats = self.writer.finish()?;
-        let checksum = format!("{:x}", self.hasher.finalize());
-        let mut sorted_types: Vec<String> =
-            self.event_types.into_iter().map(String::from).collect();
-        sorted_types.sort();
-        let entry = FileEntry {
-            name,
-            version: VERSION,
-            nats_address: nats_address.to_string(),
-            size_bytes: self.bytes_written,
-            events: self.events,
-            first_timestamp: self.first_timestamp,
-            last_timestamp: self.last_timestamp,
-            event_types: sorted_types,
-            checksum,
-            compressed_size_bytes: compressed_stats.as_ref().map(|s| s.size_bytes),
-            compressed_checksum: compressed_stats.map(|s| s.checksum),
-        };
-        Ok(entry)
+    fn finalize(self) -> std::io::Result<()> {
+        self.writer.finish()
     }
 }
 
@@ -378,14 +305,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     fs::create_dir_all(&args.output_dir)?;
     let mut current_file =
         ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
-    log::info!("Created archive file: {}", current_file.path.display());
 
-<<<<<<< HEAD
-    let mut total_events: u64 = 0;
     let mut total_files: u64 = 0;
-=======
-    let mut total_files: u64 = 1;
->>>>>>> 90d1986 (fixup! fix: finalize the current file when shutting down)
 
     loop {
         shared::tokio::select! {
@@ -406,8 +327,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
                         if current_file.needs_rotation(args.max_file_size) {
                             match rotate(current_file, &args) {
-                                Ok((file_events, new_file)) => {
-                                    total_events += file_events;
+                                Ok(new_file) => {
                                     total_files += 1;
                                     current_file = new_file;
                                 }
@@ -440,44 +360,19 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         }
     }
 
-    total_events += close_file(current_file, &args)?;
     total_files += 1;
     current_file.finalize()?;
 
-    log::info!(
-        "shutting down. total events archived: {}, files: {}",
-        total_events,
-        total_files
-    );
+    log::info!("shutting down. total files: {}", total_files);
     Ok(())
 }
 
-/// Finalizes the current archive file, adds its FileEntry to the manifest,
-/// and writes the manifest to disk.
-fn close_file(current_file: ArchiveFile, args: &Args) -> std::io::Result<u64> {
-    let name = current_file
-        .path
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string();
-
-    let manifest_path = args.output_dir.join(format!(
-        "{}.{}.manifest.toml",
-        args.base_name, current_file.formatted_timestamp
-    ));
-    let entry = current_file.finalize(name, &args.nats.address)?;
-
-    write_manifest(&entry, &manifest_path)?;
-    Ok(entry.events)
-}
-
 /// Closes the current archive file and opens the next one.
-fn rotate(current_file: ArchiveFile, args: &Args) -> std::io::Result<(u64, ArchiveFile)> {
-    let total_events = close_file(current_file, args)?;
+fn rotate(current_file: ArchiveFile, args: &Args) -> std::io::Result<ArchiveFile> {
+    log::trace!("rotating {:?}", current_file.path);
+    current_file.finalize()?;
     let new_file = ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
-    Ok((total_events, new_file))
+    Ok(new_file)
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
@@ -511,13 +406,6 @@ fn event_type_name(event: &Event) -> Option<&'static str> {
         PeerObserverEvent::IpcExtractor(_) => "ipc_extractor",
     };
     Some(name)
-}
-
-fn write_manifest(entry: &FileEntry, path: &Path) -> std::io::Result<()> {
-    let toml_str = toml::to_string_pretty(entry).map_err(std::io::Error::other)?;
-    fs::write(path, &toml_str)?;
-    log::info!("wrote manifest: {}", path.display());
-    Ok(())
 }
 
 fn format_utc_timestamp(epoch_ms: u64) -> String {

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -380,8 +380,12 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
     log::info!("Created archive file: {}", current_file.path.display());
 
+<<<<<<< HEAD
     let mut total_events: u64 = 0;
     let mut total_files: u64 = 0;
+=======
+    let mut total_files: u64 = 1;
+>>>>>>> 90d1986 (fixup! fix: finalize the current file when shutting down)
 
     loop {
         shared::tokio::select! {
@@ -438,6 +442,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
     total_events += close_file(current_file, &args)?;
     total_files += 1;
+    current_file.finalize()?;
 
     log::info!(
         "shutting down. total events archived: {}, files: {}",

--- a/tools/archive/tests/integration.rs
+++ b/tools/archive/tests/integration.rs
@@ -44,7 +44,7 @@ fn find_files(dir: &std::path::Path, suffix: &str) -> Vec<std::path::PathBuf> {
 fn setup() {
     INIT.call_once(|| {
         simple_logger::SimpleLogger::new()
-            .with_level(log::LevelFilter::Info)
+            .with_level(log::LevelFilter::Trace)
             .init()
             .unwrap();
     });

--- a/tools/archive/tests/integration.rs
+++ b/tools/archive/tests/integration.rs
@@ -3,7 +3,6 @@
 use archive::archiver::{run, Args};
 use archive::replayer::read_archive;
 
-use sha2::Digest;
 use shared::{
     log,
     nats_subjects::Subject,
@@ -373,25 +372,11 @@ async fn test_file_rotation_with_compression() {
         zst_files.len()
     );
 
-    let manifest_files = find_files(&tmp_dir, ".manifest.toml");
     let mut archive_names: Vec<_> = zst_files
         .iter()
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
-    let mut manifest_names: Vec<_> = manifest_files
-        .iter()
-        .map(|p| {
-            let manifest_str = std::fs::read_to_string(p).unwrap();
-            let manifest: toml::Value = manifest_str.parse().unwrap();
-            manifest["name"].as_str().unwrap().to_string()
-        })
-        .collect();
     archive_names.sort();
-    manifest_names.sort();
-    assert_eq!(
-        archive_names, manifest_names,
-        "each manifest must reference exactly one unique archive file"
-    );
 
     // decompress and count total events
     let mut total_events = 0;
@@ -524,89 +509,6 @@ async fn test_replayer_roundtrip_uncompressed() {
 }
 
 #[tokio::test]
-async fn test_compression_integrity() {
-    setup();
-
-    let tmp_dir = std::env::temp_dir().join("archiver_test_compression");
-    let _ = std::fs::remove_dir_all(&tmp_dir);
-
-    let nats_server = NatsServerForTesting::new(&[]).await;
-    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
-    let dir = tmp_dir.clone();
-    let archiver_handle = tokio::spawn(async move {
-        let mut args = make_test_args(nats_server.port, &dir);
-        args.max_file_size = 100;
-        args.compression_level = 3;
-        run(args, shutdown_rx).await.unwrap();
-    });
-
-    sleep(Duration::from_secs(1)).await;
-
-    let all_events = make_all_event_types();
-    for (event, _) in &all_events {
-        nats_publisher
-            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
-            .await;
-    }
-
-    sleep(Duration::from_millis(500)).await;
-    shutdown_tx.send(true).unwrap();
-    archiver_handle.await.unwrap();
-
-    let manifest_path = find_files(&tmp_dir, ".manifest.toml")
-        .into_iter()
-        .next()
-        .expect("expected a manifest file");
-    let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
-    let manifest: toml::Value = manifest_str.parse().unwrap();
-    let zst_name = manifest["name"].as_str().unwrap();
-    let expected_checksum = manifest["checksum"].as_str().unwrap();
-
-    let zst_path = tmp_dir.join(zst_name);
-    let bin_path = tmp_dir.join(zst_name.strip_suffix(".zst").unwrap());
-
-    assert!(zst_path.exists(), "{} should exist", zst_name);
-    assert!(
-        !bin_path.exists(),
-        "{} should have been deleted",
-        bin_path.display()
-    );
-
-    let file = File::open(&zst_path).unwrap();
-    let mut decoder = zstd::Decoder::new(file).unwrap();
-    let mut decompressed = Vec::new();
-    decoder.read_to_end(&mut decompressed).unwrap();
-
-    let actual_checksum = format!("{:x}", sha2::Sha256::digest(&decompressed));
-
-    assert_eq!(
-        actual_checksum, expected_checksum,
-        "decompressed SHA-256 of {} must match manifest checksum",
-        zst_name
-    );
-
-    let compressed_checksum = manifest["compressed_checksum"].as_str().unwrap();
-    let compressed_size = manifest["compressed_size_bytes"].as_integer().unwrap() as u64;
-
-    let raw_zst = std::fs::read(&zst_path).unwrap();
-    let actual_compressed_checksum = format!("{:x}", sha2::Sha256::digest(&raw_zst));
-    assert_eq!(
-        actual_compressed_checksum, compressed_checksum,
-        "SHA-256 of raw .zst must match manifest compressed_checksum"
-    );
-
-    let file_size = std::fs::metadata(&zst_path).unwrap().len();
-    assert_eq!(
-        compressed_size, file_size,
-        "compressed_size_bytes must match file size on disk"
-    );
-
-    let _ = std::fs::remove_dir_all(&tmp_dir);
-}
-
-#[tokio::test]
 async fn test_no_compression() {
     setup();
 
@@ -642,33 +544,6 @@ async fn test_no_compression() {
     assert!(!bin_files.is_empty(), ".0.bin file should exist");
     let zst_files = find_files(&tmp_dir, ".bin.zst");
     assert!(zst_files.is_empty(), ".0.bin.zst file should not exist");
-
-    // manifest should reference .bin
-    let manifest_path = find_files(&tmp_dir, ".manifest.toml")
-        .into_iter()
-        .next()
-        .expect("expected a manifest file");
-    let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
-    let manifest: toml::Value = manifest_str.parse().unwrap();
-    assert!(manifest["name"].as_str().unwrap().ends_with(".bin"));
-
-    // checksum should match raw file content
-    let raw = std::fs::read(&bin_files[0]).unwrap();
-    let actual_checksum = format!("{:x}", sha2::Sha256::digest(&raw));
-    let expected_checksum = manifest["checksum"].as_str().unwrap();
-    assert_eq!(
-        actual_checksum, expected_checksum,
-        "SHA-256 of raw .bin must match manifest checksum"
-    );
-
-    assert!(
-        manifest.get("compressed_checksum").is_none(),
-        "compressed_checksum should not be present without compression"
-    );
-    assert!(
-        manifest.get("compressed_size_bytes").is_none(),
-        "compressed_size_bytes should not be present without compression"
-    );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }


### PR DESCRIPTION
This removes the manifest writing from the archiver for now as mentioned in https://github.com/peer-observer/peer-observer/pull/373#pullrequestreview-4269844782 and https://github.com/peer-observer/peer-observer/issues/439#issuecomment-4537190823. The idea is to add a binary that allows us to extract archive information, similar to a manifest, soon.

I've also went ahead and added some trace logging to the archiver which is now shown in failing tests. Additionally, I'm also making sure that the archiver finalizes/flushes the files to disk before shutting down, as not doing this broke some tests for me.

closes https://github.com/peer-observer/peer-observer/pull/431
closes https://github.com/peer-observer/peer-observer/pull/434