### PR TITLE
Add metrics for IPC extractor

### DIFF
--- a/extractors/ipc/README.md
+++ b/extractors/ipc/README.md
@@ -40,6 +40,8 @@ Options:
           The log level the extractor should run with. Valid log levels are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html [default: DEBUG]
       --query-interval <QUERY_INTERVAL>
           Interval (in seconds) in which to query from the Bitcoin Core IPC interface [default: 10]
+      --prometheus-address <PROMETHEUS_ADDRESS>
+          Address to serve Prometheus metrics on [default: 127.0.0.1:8285]
   -h, --help
           Print help
   -V, --version

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -19,7 +19,10 @@ use shared::{
 use std::io;
 
 mod error;
+mod metrics;
+
 use error::RuntimeError;
+use metrics::Metrics;
 
 mod ipc;
 use ipc::IpcClient;
@@ -46,6 +49,10 @@ pub struct Args {
     /// Interval (in seconds) in which to query from the Bitcoin Core IPC interface.
     #[arg(long, default_value_t = 10)]
     pub query_interval: u64,
+
+    /// Address to serve Prometheus metrics on.
+    #[arg(long, default_value = "127.0.0.1:8285")]
+    pub prometheus_address: String,
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
@@ -69,6 +76,9 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
     let mut ipc_session = IpcClient::init(stream).await?;
 
+    let metrics = Metrics::new();
+    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);
     log::info!(
@@ -79,7 +89,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                if let Err(e) = fetch_and_publish_tip(&ipc_session, &nats_client).await {
+                if let Err(e) = fetch_and_publish_tip(&ipc_session, &nats_client, &metrics).await {
                     log::error!("Could not fetch and publish 'BlockTip': {}", e);
                 }
             }
@@ -115,11 +125,36 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     Ok(())
 }
 
+async fn measure_ipc_call<T, E, Fut>(method_name: &str, metrics: &Metrics, fut: Fut) -> Result<T, E>
+where
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let timer = metrics
+        .ipc_fetch_duration
+        .with_label_values(&[method_name])
+        .start_timer();
+    let res = fut.await;
+    match &res {
+        Ok(_) => {
+            timer.stop_and_record();
+        }
+        Err(_) => {
+            timer.stop_and_discard();
+            metrics
+                .ipc_fetch_errors
+                .with_label_values(&[method_name])
+                .inc();
+        }
+    }
+    res
+}
+
 async fn fetch_and_publish_tip(
     ipc_client: &IpcClient,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), RuntimeError> {
-    let tip = match ipc_client.get_tip().await? {
+    let tip = match measure_ipc_call("get_tip", metrics, ipc_client.get_tip()).await? {
         Some(t) => t,
         None => return Ok(()), // the node has no tip loaded yet, skip NATS publish
     };
@@ -129,6 +164,12 @@ async fn fetch_and_publish_tip(
     }))?;
     nats_client
         .publish(Subject::Ipc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["get_tip"])
+                .inc();
+        })?;
     Ok(())
 }

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -12,11 +12,12 @@ use shared::{
     tokio::{
         self,
         net::UnixStream,
-        sync::watch,
+        sync::{oneshot, watch},
         time::{self, Duration},
     },
 };
 use std::io;
+use std::net::SocketAddr;
 
 mod error;
 mod metrics;
@@ -55,7 +56,11 @@ pub struct Args {
     pub prometheus_address: String,
 }
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+) -> Result<(), RuntimeError> {
     let nats_client = nats_util::prepare_connection(&args.nats)?
         .connect(&args.nats.address)
         .await?;
@@ -77,7 +82,11 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let mut ipc_session = IpcClient::init(stream).await?;
 
     let metrics = Metrics::new();
-    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+    let local_addr =
+        shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);

--- a/extractors/ipc/src/main.rs
+++ b/extractors/ipc/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
     LocalSet::new()
         .run_until(async move {
             let (shutdown_tx, shutdown_rx) = watch::channel(false);
-            let run_future = ipc_extractor::run(args, shutdown_rx);
+            let run_future = ipc_extractor::run(args, shutdown_rx, None);
             tokio::pin!(run_future);
 
             tokio::select! {

--- a/extractors/ipc/src/metrics.rs
+++ b/extractors/ipc/src/metrics.rs
@@ -1,0 +1,76 @@
+use shared::prometheus::{
+    HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+};
+
+const NAMESPACE: &str = "ipcextractor";
+
+pub const LABEL_IPC_METHOD: &str = "ipc_method";
+
+const IPC_DURATION_BUCKETS: [f64; 12] = [
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// Metrics for the ipc-extractor.
+/// Each instance has its own registry.
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub registry: Registry,
+    /// Time it took to fetch data from the IPC interface.
+    pub ipc_fetch_duration: HistogramVec,
+    /// Number of errors while fetching data from the IPC interface.
+    pub ipc_fetch_errors: IntCounterVec,
+    /// Number of errors while publishing events to NATS.
+    pub nats_publish_errors: IntCounterVec,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new_custom(Some(NAMESPACE.to_string()), None)
+            .expect("Could not create prometheus registry");
+
+        let ipc_fetch_duration = register_histogram_vec_with_registry!(
+            HistogramOpts::new(
+                "ipc_fetch_duration_seconds",
+                "Time it took to fetch data from the IPC interface."
+            )
+            .buckets(IPC_DURATION_BUCKETS.to_vec()),
+            &[LABEL_IPC_METHOD],
+            registry
+        )
+        .expect("Could not create ipc_fetch_duration_seconds metric");
+
+        let ipc_fetch_errors = register_int_counter_vec_with_registry!(
+            Opts::new(
+                "ipc_fetch_errors_total",
+                "Number of errors while fetching data from the IPC interface."
+            ),
+            &[LABEL_IPC_METHOD],
+            registry
+        )
+        .expect("Could not create ipc_fetch_errors_total metric");
+
+        let nats_publish_errors = register_int_counter_vec_with_registry!(
+            Opts::new(
+                "nats_publish_errors_total",
+                "Number of errors while publishing events to NATS."
+            ),
+            &[LABEL_IPC_METHOD],
+            registry
+        )
+        .expect("Could not create nats_publish_errors_total metric");
+
+        Self {
+            registry,
+            ipc_fetch_duration,
+            ipc_fetch_errors,
+            nats_publish_errors,
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/extractors/ipc/tests/common/mod.rs
+++ b/extractors/ipc/tests/common/mod.rs
@@ -1,0 +1,84 @@
+use shared::{
+    bitcoind,
+    log::{self, info},
+    nats_util::NatsArgs,
+    simple_logger::SimpleLogger,
+};
+
+use std::sync::Once;
+
+use ipc_extractor::Args;
+
+static INIT: Once = Once::new();
+
+// 1 second query interval for fast tests
+pub const QUERY_INTERVAL_SECONDS: u64 = 1;
+
+pub fn setup() {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+    });
+}
+
+pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
+    Args {
+        nats: NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        log_level: log::Level::Trace,
+        ipc_socket_path,
+        query_interval: QUERY_INTERVAL_SECONDS,
+        prometheus_address: "127.0.0.1:0".to_string(),
+    }
+}
+
+fn bitcoin_node_exe_path() -> String {
+    if let Ok(p) = std::env::var("BITCOIN_NODE_EXE") {
+        return p;
+    }
+    let bitcoind_path =
+        std::path::PathBuf::from(bitcoind::downloaded_exe_path().expect("downloaded_exe_path"));
+    bitcoind_path
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("unexpected bitcoind path layout")
+        .join("libexec")
+        .join("bitcoin-node")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
+    let exe_path = bitcoin_node_exe_path();
+    info!("Using bitcoin-node at '{}'", exe_path);
+    bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap()
+}
+
+pub fn configure_node() -> bitcoind::BitcoinD {
+    let mut node_conf = bitcoind::Conf::default();
+    node_conf.args = vec!["-regtest", "-ipcbind=unix"];
+    // enabling this is useful for debugging, but enabling this by default will
+    // be quite spammy.
+    node_conf.view_stdout = false;
+    // node_conf.wallet is `true` by default, but since `bitcoin-node` binary doesn't
+    // have wallet capabilities we disable it
+    node_conf.wallet = None;
+
+    setup_node(node_conf)
+}
+
+pub fn ipc_socket_path(node: &bitcoind::BitcoinD) -> String {
+    node.workdir()
+        .as_path()
+        .join("regtest")
+        .join("node.sock")
+        .to_str()
+        .unwrap()
+        .into()
+}

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -37,6 +37,7 @@ pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
         log_level: log::Level::Trace,
         ipc_socket_path,
         query_interval: QUERY_INTERVAL_SECONDS,
+        prometheus_address: "127.0.0.1:0".to_string(),
     }
 }
 

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -1,114 +1,40 @@
 #![cfg(feature = "nats_integration_tests")]
 #![cfg(feature = "node_integration_tests")]
 
-use ipc_extractor::{self, Args};
+mod common;
+
+use common::{configure_node, ipc_socket_path, make_test_args, setup};
+
 use shared::{
     async_nats,
     bitcoin::{self, hashes::Hash},
-    bitcoind,
     futures::StreamExt,
-    log::{self, info},
-    nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
         ipc_extractor::ipc::IpcEvent::BlockTip,
     },
-    simple_logger::SimpleLogger,
     testing::nats_server::NatsServerForTesting,
     tokio::{self, sync::watch, task::LocalSet, time::sleep},
 };
-use std::sync::Once;
 use std::time::Duration;
-
-pub const QUERY_INTERVAL_SECONDS: u64 = 1;
 
 // 5 second check() timeout.
 const TEST_TIMEOUT_SECONDS: u64 = 5;
-
-pub fn make_test_args(nats_port: u16, ipc_socket_path: String) -> Args {
-    Args {
-        nats: NatsArgs {
-            address: format!("127.0.0.1:{}", nats_port),
-            username: None,
-            password: None,
-            password_file: None,
-        },
-        log_level: log::Level::Trace,
-        ipc_socket_path,
-        query_interval: QUERY_INTERVAL_SECONDS,
-        prometheus_address: "127.0.0.1:0".to_string(),
-    }
-}
-
-static INIT: Once = Once::new();
-
-pub fn setup() {
-    INIT.call_once(|| {
-        SimpleLogger::new()
-            .with_level(log::LevelFilter::Trace)
-            .init()
-            .unwrap();
-    });
-}
-
-fn bitcoin_node_exe_path() -> String {
-    if let Ok(p) = std::env::var("BITCOIN_NODE_EXE") {
-        return p;
-    }
-    let bitcoind_path =
-        std::path::PathBuf::from(bitcoind::downloaded_exe_path().expect("downloaded_exe_path"));
-    bitcoind_path
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("unexpected bitcoind path layout")
-        .join("libexec")
-        .join("bitcoin-node")
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
-    let exe_path = bitcoin_node_exe_path();
-    info!("Using bitcoin-node at '{}'", exe_path);
-    bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap()
-}
-
-fn configure_node() -> bitcoind::BitcoinD {
-    let mut node_conf = bitcoind::Conf::default();
-    node_conf.args = vec!["-regtest", "-ipcbind=unix"];
-    // enabling this is useful for debugging, but enabling this by default will
-    // be quite spammy.
-    node_conf.view_stdout = false;
-    // node_conf.wallet is `true` by default, but since `bitcoin-node` binary doesn't
-    // have wallet capabilities we disable it
-    node_conf.wallet = None;
-
-    setup_node(node_conf)
-}
 
 async fn check(check_expected: fn(PeerObserverEvent) -> ()) {
     setup();
     let node = configure_node();
     let nats_server = NatsServerForTesting::new(&[]).await;
 
-    let ipc_socket_path = node
-        .workdir()
-        .as_path()
-        .join("regtest")
-        .join("node.sock")
-        .to_str()
-        .unwrap()
-        .into();
-
-    let args = make_test_args(nats_server.port, ipc_socket_path);
+    let args = make_test_args(nats_server.port, ipc_socket_path(&node));
 
     let local = LocalSet::new();
     local
         .run_until(async move {
             let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone());
+            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone(), None);
             tokio::pin!(ipc_extractor_future);
 
             let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
@@ -190,7 +116,7 @@ async fn test_integration_ipc_node_shutdown() {
         .run_until(async move {
             let (_shutdown_tx, shutdown_rx) = watch::channel(false);
 
-            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone());
+            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone(), None);
             tokio::pin!(ipc_extractor_future);
 
             let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))

--- a/extractors/ipc/tests/metrics_integration.rs
+++ b/extractors/ipc/tests/metrics_integration.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+mod common;
+
+use common::{QUERY_INTERVAL_SECONDS, configure_node, ipc_socket_path, make_test_args, setup};
+
+use shared::{
+    testing::{
+        metrics_fetcher::{fetch_metrics, get_metric_value},
+        nats_server::NatsServerForTesting,
+    },
+    tokio::{
+        self, select,
+        sync::{oneshot, watch},
+        task::LocalSet,
+        time::{Duration, sleep},
+    },
+};
+
+/// Verifies the Prometheus metrics server starts and responds to HTTP requests.
+#[tokio::test]
+async fn test_integration_metrics_server_basic() {
+    setup();
+    let node = configure_node();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let args = make_test_args(nats_server.port, ipc_socket_path(&node));
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            let (addr_tx, addr_rx) = oneshot::channel();
+
+            let mut handle = tokio::task::spawn_local(async move {
+                ipc_extractor::run(args, shutdown_rx, Some(addr_tx))
+                    .await
+                    .expect("ipc extractor failed");
+            });
+
+            let metrics_port = select! {
+                addr = addr_rx => addr.expect("ipc-extractor should send bound address").port(),
+                result = &mut handle => {
+                    result.unwrap();
+                    unreachable!("ipc-extractor task exited before sending bound address");
+                }
+            };
+
+            let metrics = fetch_metrics(metrics_port, "/metrics");
+            assert!(
+                metrics.is_ok(),
+                "Metrics server should respond: {:?}",
+                metrics
+            );
+
+            shutdown_tx.send(true).unwrap();
+            handle.await.unwrap();
+        })
+        .await;
+}
+
+/// Verifies that a successful IPC call records its duration in the histogram.
+#[tokio::test]
+async fn test_integration_metrics_ipc_fetch_duration() {
+    setup();
+    let node = configure_node();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let args = make_test_args(nats_server.port, ipc_socket_path(&node));
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            let (addr_tx, addr_rx) = oneshot::channel();
+
+            let mut handle = tokio::task::spawn_local(async move {
+                ipc_extractor::run(args, shutdown_rx, Some(addr_tx))
+                    .await
+                    .expect("ipc extractor failed");
+            });
+
+            let metrics_port = select! {
+                addr = addr_rx => addr.expect("ipc-extractor should send bound address").port(),
+                result = &mut handle => {
+                    result.unwrap();
+                    unreachable!("ipc-extractor task exited before sending bound address");
+                }
+            };
+
+            // Wait for at least one query cycle.
+            sleep(Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
+
+            let metrics = fetch_metrics(metrics_port, "/metrics").expect("Should fetch metrics");
+
+            let count = get_metric_value(
+                &metrics,
+                "ipcextractor_ipc_fetch_duration_seconds_count",
+                "ipc_method",
+                "get_tip",
+            );
+            assert!(
+                count >= 1,
+                "Should have recorded at least one get_tip call, got: {}",
+                count
+            );
+
+            shutdown_tx.send(true).unwrap();
+            handle.await.unwrap();
+        })
+        .await;
+}


### PR DESCRIPTION
Partially addresses #436, based on @ViniciusCestarii 's suggestion in https://github.com/peer-observer/peer-observer/pull/379#pullrequestreview-4154925468.

This PR introduces Prometheus metrics for the newly added ipc-extractor, as well as its corresponding integration test. Mostly mirroring the rpc-extractor code, as this is the reference.

Exposing:
  - `ipcextractor_ipc_fetch_duration_seconds`
  - `ipcextractor_ipc_fetch_errors_total`
  - `nats_publish_errors_total`

Thanks @ViniciusCestarii for the suggestion!