### PR TITLE
Improve disconnection handling in ipc-extractor

### DIFF
--- a/extractors/ipc/src/ipc.rs
+++ b/extractors/ipc/src/ipc.rs
@@ -12,7 +12,7 @@ use init_capnp::init::Client as InitClient;
 use mining_capnp::mining::Client as MiningClient;
 use proxy_capnp::thread::Client as ThreadClient;
 
-use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
+use capnp_rpc::{Disconnector, RpcSystem, rpc_twoparty_capnp, twoparty};
 use shared::{
     futures::AsyncReadExt,
     protobuf::ipc_extractor::BlockTip,
@@ -26,6 +26,7 @@ pub struct IpcClient {
     pub mining: MiningClient,
     pub thread: ThreadClient,
     pub rpc_task: JoinHandle<Result<(), capnp::Error>>,
+    pub disconnector: Disconnector<rpc_twoparty_capnp::Side>,
 }
 
 impl IpcClient {
@@ -40,6 +41,7 @@ impl IpcClient {
 
         let mut rpc_system = RpcSystem::new(network, None);
         let init: InitClient = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+        let disconnector = rpc_system.get_disconnector();
         let rpc_task = tokio::task::spawn_local(rpc_system);
 
         let response = init.construct_request().send().promise.await?;
@@ -58,6 +60,7 @@ impl IpcClient {
             rpc_task,
             thread,
             mining,
+            disconnector,
         })
     }
 

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -93,20 +93,22 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                     Ok(_) => {
                         if *shutdown_rx.borrow() {
                             log::info!("ipc_extractor received shutdown signal.");
-                            ipc_session.rpc_task.abort();
                             break;
                         }
                     }
                     Err(_) => {
                         // all senders dropped -> treat as shutdown
                         log::warn!("The shutdown notification sender was dropped. Shutting down.");
-                        ipc_session.rpc_task.abort();
                         break;
                     }
                 }
             }
         }
     }
+    if let Err(e) = ipc_session.disconnector.await {
+        log::error!("could not run disconnector during shutdown: {}", e);
+    }
+    let _ = ipc_session.rpc_task.await;
     Ok(())
 }
 

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -67,7 +67,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         })?;
     log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
 
-    let ipc_session = IpcClient::init(stream).await?;
+    let mut ipc_session = IpcClient::init(stream).await?;
 
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);
@@ -79,40 +79,43 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                 if ipc_session.rpc_task.is_finished() {
-                    log::error!("Lost connection to IPC socket. Exiting.");
-                    break;
+                if let Err(e) = fetch_and_publish_tip(&ipc_session, &nats_client).await {
+                    log::error!("Could not fetch and publish 'BlockTip': {}", e);
                 }
-
-                if let Err(e) = get_tip(&ipc_session, &nats_client).await {
-                        log::error!("Could not fetch and publish 'BlockTip': {}", e)
+            }
+            res = &mut ipc_session.rpc_task => {
+                match res {
+                    Ok(Ok(())) => log::warn!("Lost IPC connection to bitcoin-node."),
+                    Ok(Err(e)) => log::error!("Lost IPC connection to bitcoin-node: {e}"),
+                    Err(e) => log::error!("IPC task panicked or was cancelled: {e}"),
                 }
+                break;
             }
             res = shutdown_rx.changed() => {
                 match res {
-                    Ok(_) => {
-                        if *shutdown_rx.borrow() {
-                            log::info!("ipc_extractor received shutdown signal.");
-                            break;
-                        }
+                    Ok(_) if *shutdown_rx.borrow() => {
+                        log::info!("ipc_extractor received shutdown signal.");
                     }
-                    Err(_) => {
+                    _ => {
                         // all senders dropped -> treat as shutdown
                         log::warn!("The shutdown notification sender was dropped. Shutting down.");
-                        break;
                     }
                 }
+                break;
             }
         }
     }
+
     if let Err(e) = ipc_session.disconnector.await {
         log::error!("could not run disconnector during shutdown: {}", e);
     }
-    let _ = ipc_session.rpc_task.await;
+    if !ipc_session.rpc_task.is_finished() {
+        let _ = ipc_session.rpc_task.await;
+    }
     Ok(())
 }
 
-async fn get_tip(
+async fn fetch_and_publish_tip(
     ipc_client: &IpcClient,
     nats_client: &async_nats::Client,
 ) -> Result<(), RuntimeError> {
@@ -124,7 +127,6 @@ async fn get_tip(
     let proto = Event::new(PeerObserverEvent::IpcExtractor(ipc_extractor::Ipc {
         ipc_event: Some(ipc_extractor::ipc::IpcEvent::BlockTip(tip)),
     }))?;
-
     nats_client
         .publish(Subject::Ipc.to_string(), proto.encode_to_vec().into())
         .await?;

--- a/extractors/ipc/tests/integration.rs
+++ b/extractors/ipc/tests/integration.rs
@@ -164,3 +164,61 @@ async fn test_integration_ipc() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn test_integration_ipc_node_shutdown() {
+    println!("test that the ipc-extractor shuts down when the node is stopped");
+
+    setup();
+    let mut node = configure_node();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+
+    let ipc_socket_path = node
+        .workdir()
+        .as_path()
+        .join("regtest")
+        .join("node.sock")
+        .to_str()
+        .unwrap()
+        .into();
+
+    let args = make_test_args(nats_server.port, ipc_socket_path);
+
+    let local = LocalSet::new();
+    local
+        .run_until(async move {
+            let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+            let ipc_extractor_future = ipc_extractor::run(args, shutdown_rx.clone());
+            tokio::pin!(ipc_extractor_future);
+
+            let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
+                .await
+                .unwrap();
+            let mut sub = nc.subscribe("*").await.unwrap();
+
+            tokio::select! {
+                _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
+                    panic!("timed out waiting for check() to complete");
+                }
+                msg = sub.next() => {
+                    if let Some(msg) = msg {
+                        let unwrapped = Event::decode(msg.payload).unwrap();
+                        if unwrapped.peer_observer_event.is_some() {
+                            // After we received the first message from the ipc-extractor,
+                            // we shut down the node.
+                            node.stop().unwrap();
+                        }
+                    } else {
+                        panic!("subscription ended");
+                    }
+                }
+                result = &mut ipc_extractor_future => {
+                    panic!("ipc_extractor stopped unexpectedly: {:?}", result);
+                }
+            }
+
+            assert_eq!(ipc_extractor_future.await.unwrap(), ());
+        })
+        .await;
+}


### PR DESCRIPTION
This PR cherry-picks 2 commits from #441.

Instead of detecting IPC connection loss via polling, this could be improved by watching the RPC task and using capnp's Disconnector object for clean shutdown.