### PR TITLE
refactor(replayer): use clap and log, return errors instead of unwrap

### DIFF
--- a/tools/archive/README.md
+++ b/tools/archive/README.md
@@ -104,7 +104,7 @@ Options:
 
 ## replayer
 
-Reads peer-observer archive files and prints decoded events to stdout.
+Reads peer-observer archive files and logs decoded events at info level.
 
 Supports:
 - `.bin`
@@ -119,13 +119,13 @@ Supports:
   
 ```
 
-### Example output
+### Example log output
 
 ```text
-header: ArchiveHeader(created=1780140481)
-[1] ts=1234567890 ebpf: ...
-[2] ts=1234567891 ebpf: ...
-total: 2 events
+INFO [replayer] header: ArchiveHeader(created=1780140481)
+INFO [replayer] [1] ts=1234567890 ebpf: ...
+INFO [replayer] [2] ts=1234567891 ebpf: ...
+INFO [replayer] total: 2 events
 ```
 
 ### Help
@@ -133,5 +133,13 @@ total: 2 events
 ```
 Read and display peer-observer archive files
 
-Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]
+Usage: replayer [OPTIONS] <FILE>...
+
+Arguments:
+  <FILE>...  Archive files to read
+
+Options:
+  -l, --log-level <LOG_LEVEL>  The log level the tool should run on [default: INFO]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```

--- a/tools/archive/src/bin/replayer.rs
+++ b/tools/archive/src/bin/replayer.rs
@@ -1,50 +1,116 @@
 use archive::read::ArchiveReader;
-use shared::protobuf::event::event::PeerObserverEvent;
-use std::env;
-use std::path::Path;
+use shared::clap;
+use shared::clap::Parser;
+use shared::protobuf::event::{event::PeerObserverEvent, Event};
+use shared::{log, simple_logger};
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process::ExitCode;
 
-fn main() {
-    let files: Vec<String> = env::args().skip(1).collect();
-    if files.is_empty() || files.iter().any(|f| f == "--help" || f == "-h") {
-        println!("Read and display peer-observer archive files");
-        println!();
-        println!("Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]");
-        return;
+#[derive(Parser, Debug)]
+#[command(version, about = "Read and display peer-observer archive files")]
+struct Args {
+    /// Archive files to read.
+    #[arg(value_name = "FILE", required = true)]
+    files: Vec<PathBuf>,
+
+    /// The log level the tool should run on.
+    #[arg(short, long, default_value_t = log::Level::Info)]
+    log_level: log::Level,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("replayer tool error: {}", e);
     }
 
-    for path in &files {
-        if files.len() > 1 {
-            println!("=== {} ===", path);
+    let mut had_error = false;
+
+    for path in &args.files {
+        if args.files.len() > 1 {
+            log::info!("=== {} ===", path.display());
         }
 
-        let archive = ArchiveReader::open(Path::new(path)).unwrap();
-        println!("header: {}", archive.header);
+        let archive = match ArchiveReader::open(path) {
+            Ok(archive) => archive,
+            Err(e) => {
+                log::error!("failed to read archive {}: {e}", path.display());
+                had_error = true;
+                continue;
+            }
+        };
+
+        log::info!("header: {}", archive.header);
 
         let mut events_count = 0;
-        for (n, event) in archive.enumerate() {
-            let event = event.unwrap();
-            let ts = event.timestamp;
-            match &event.peer_observer_event {
-                Some(PeerObserverEvent::EbpfExtractor(e)) => {
-                    println!("[{n}] ts={ts} ebpf: {}", e.ebpf_event.as_ref().unwrap())
+        for (idx, event) in archive.enumerate() {
+            let n = idx + 1;
+            let event = match event {
+                Ok(event) => event,
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                    log::error!(
+                        "archive {} ended unexpectedly while reading event {n}: {e}",
+                        path.display()
+                    );
+                    had_error = true;
+                    break;
                 }
-                Some(PeerObserverEvent::RpcExtractor(r)) => {
-                    println!("[{n}] ts={ts} rpc: {}", r.rpc_event.as_ref().unwrap())
+                Err(e) => {
+                    log::error!(
+                        "failed to read archive {} at event {n}: {e}",
+                        path.display()
+                    );
+                    had_error = true;
+                    break;
                 }
-                Some(PeerObserverEvent::P2pExtractor(p)) => {
-                    println!("[{n}] ts={ts} p2p: {}", p.p2p_event.as_ref().unwrap())
-                }
-                Some(PeerObserverEvent::LogExtractor(l)) => {
-                    println!("[{n}] ts={ts} log: {}", l.log_event.as_ref().unwrap())
-                }
-                Some(PeerObserverEvent::IpcExtractor(i)) => {
-                    println!("[{n}] ts={ts} ipc: {}", i.ipc_event.as_ref().unwrap())
-                }
-                None => println!("[{n}] ts={ts} <unknown>"),
+            };
+
+            if let Err(e) = display_event(n, &event) {
+                log::warn!(
+                    "failed to display archive {} event {n}: {e}",
+                    path.display()
+                );
             }
-            events_count = n + 1;
+            events_count = n;
         }
 
-        println!("total: {} events", events_count);
+        log::info!("total: {} events", events_count);
     }
+
+    if had_error {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn display_event(n: usize, event: &Event) -> Result<(), &'static str> {
+    let ts = event.timestamp;
+    match &event.peer_observer_event {
+        Some(PeerObserverEvent::EbpfExtractor(e)) => {
+            let ebpf_event = e.ebpf_event.as_ref().ok_or("missing ebpf event")?;
+            log::info!("[{n}] ts={ts} ebpf: {ebpf_event}");
+        }
+        Some(PeerObserverEvent::RpcExtractor(r)) => {
+            let rpc_event = r.rpc_event.as_ref().ok_or("missing rpc event")?;
+            log::info!("[{n}] ts={ts} rpc: {rpc_event}");
+        }
+        Some(PeerObserverEvent::P2pExtractor(p)) => {
+            let p2p_event = p.p2p_event.as_ref().ok_or("missing p2p event")?;
+            log::info!("[{n}] ts={ts} p2p: {p2p_event}");
+        }
+        Some(PeerObserverEvent::LogExtractor(l)) => {
+            let log_event = l.log_event.as_ref().ok_or("missing log event")?;
+            log::info!("[{n}] ts={ts} log: {log_event}");
+        }
+        Some(PeerObserverEvent::IpcExtractor(i)) => {
+            let ipc_event = i.ipc_event.as_ref().ok_or("missing ipc event")?;
+            log::info!("[{n}] ts={ts} ipc: {ipc_event}");
+        }
+        None => log::info!("[{n}] ts={ts} <unknown>"),
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Follow-up from the https://github.com/peer-observer/peer-observer/pull/373 review comments.
- Use clap for replayer arguments and add --log-level
- Log decoded replay output at info level
- Log read/display errors instead of unwrapping
- Treat failures before a valid archive header as errors and exit 1
- Treat `UnexpectedEof` while reading events as a truncated archive error and exit 1
- Update the archive README with the generated replayer help