### PR TITLE
Add addr-entries spammer detection to the alerts tool

### DIFF
--- a/tools/alerts/README.md
+++ b/tools/alerts/README.md
@@ -53,10 +53,8 @@ or by being evicted after `--peer-stale-secs` of inactivity), the same `Alerter`
 emits a `PeerDisconnected` alert with the duration of the spamming episode:
 
 ```
-PeerDisconnected | peer_id=<id> addr=<addr> | active=<duration>s
+PeerDisconnected | peer_id=<id> addr=<addr> | active=<duration>s | flags=[<reason>, ...]
 ```
-
-Non-flagged peers disconnect silently (no alert is emitted).
 
 ## Usage
 
@@ -126,5 +124,5 @@ Example output:
 INFO  [alerts::alerter] PingSpammer | peer_id=42 addr=1.2.3.4:8333 | 4 pings in last 30s (threshold: 3)
 INFO  [alerts::alerter] AddrSpammer | peer_id=7 addr=5.6.7.8:8333 | 3 addr/addrv2 messages in last 60s (threshold: 2)
 INFO  [alerts::alerter] AddrEntriesSpammer | peer_id=9 addr=8.8.8.8:8333 | 15 addr/addrv2 entries rate-limited (threshold: 5, bucket: 5, rate: 0.1/s, getaddr_sent: 0)
-INFO  [alerts::alerter] PeerDisconnected | peer_id=42 addr=1.2.3.4:8333 | active=47s
+INFO  [alerts::alerter] PeerDisconnected | peer_id=42 addr=1.2.3.4:8333 | active=47s | flags=[PingSpammer]
 ```

--- a/tools/alerts/README.md
+++ b/tools/alerts/README.md
@@ -26,6 +26,24 @@ Alert format (as rendered by `LoggingAlerter`):
 AddrSpammer | peer_id=<id> addr=<addr> | <count> addr/addrv2 messages in last <secs>s (threshold: <threshold>)
 ```
 
+### AddrEntriesSpammer
+
+Counts the address *entries* inside `addr`/`addrv2` messages, catching peers that stay under `AddrSpammer`
+by sending a few oversized messages.
+Uses a per-peer token bucket modeled on Bitcoin Core's addr rate limiting: the bucket starts at
+`--addr-entries-initial-tokens` (default `1`) and refills at `--addr-entries-rate-per-sec` entries/s up to
+`--addr-entries-bucket-capacity` (default `1000`, Core's `MAX_ADDR_PROCESSING_TOKEN_BUCKET`).
+Each entry spends a token and entries hitting an empty bucket count as *rate-limited*.
+Both message types share one bucket, and the alert fires once the cumulative rate-limited count exceeds `--addr-entries-threshold`.
+Each outbound `GETADDR` adds one capacity-sized allowance to cover the expected response, matching Core's bypass for requested address bursts.
+
+The metric is the count of entries that *exceed Core's rate limit*.
+
+Alert format (as rendered by `LoggingAlerter`):
+```
+AddrEntriesSpammer | peer_id=<id> addr=<addr> | <count> addr/addrv2 entries rate-limited (threshold: <threshold>, bucket: <capacity>, rate: <rate>/s, getaddr_sent: <count>)
+```
+
 Each peer/kind combination fires at most one alert per session (one-shot).
 
 ## Peer lifecycle
@@ -70,6 +88,14 @@ Options:
           Number of addr/addrv2 messages in the window before alerting [default: 6]
       --addr-window-secs <ADDR_WINDOW_SECS>
           Sliding window size for addr detection (seconds) [default: 60]
+      --addr-entries-initial-tokens <ADDR_ENTRIES_INITIAL_TOKENS>
+          Initial token seed for a peer's addr/addrv2 entry bucket. Mirrors Core's per-peer starting bucket (1.0, "permit self-announcement") [default: 1]
+      --addr-entries-bucket-capacity <ADDR_ENTRIES_BUCKET_CAPACITY>
+          Token bucket capacity: the refill ceiling for addr/addrv2 entries. Mirrors Core's MAX_ADDR_PROCESSING_TOKEN_BUCKET (1000); the bucket refills up to this [default: 1000]
+      --addr-entries-rate-per-sec <ADDR_ENTRIES_RATE_PER_SEC>
+          Token refill rate for addr/addrv2 entries (entries per second). Mirrors Core's MAX_ADDR_RATE_PER_SECOND (0.1, i.e. one entry every 10 seconds) [default: 0.1]
+      --addr-entries-threshold <ADDR_ENTRIES_THRESHOLD>
+          Number of rate-limited addr/addrv2 entries before alerting [default: 20]
   -l, --log-level <LOG_LEVEL>
           [default: DEBUG]
       --peer-stale-secs <PEER_STALE_SECS>
@@ -89,12 +115,16 @@ cargo run -p alerts -- \
   --ping-threshold 3 \
   --ping-window-secs 30 \
   --addr-threshold 2 \
-  --addr-window-secs 60
+  --addr-window-secs 60 \
+  --addr-entries-initial-tokens 5 \
+  --addr-entries-bucket-capacity 5 \
+  --addr-entries-threshold 5
 ```
 
 Example output:
 ```
 INFO  [alerts::alerter] PingSpammer | peer_id=42 addr=1.2.3.4:8333 | 4 pings in last 30s (threshold: 3)
 INFO  [alerts::alerter] AddrSpammer | peer_id=7 addr=5.6.7.8:8333 | 3 addr/addrv2 messages in last 60s (threshold: 2)
+INFO  [alerts::alerter] AddrEntriesSpammer | peer_id=9 addr=8.8.8.8:8333 | 15 addr/addrv2 entries rate-limited (threshold: 5, bucket: 5, rate: 0.1/s, getaddr_sent: 0)
 INFO  [alerts::alerter] PeerDisconnected | peer_id=42 addr=1.2.3.4:8333 | active=47s
 ```

--- a/tools/alerts/src/alerter.rs
+++ b/tools/alerts/src/alerter.rs
@@ -8,8 +8,10 @@ pub enum SpammerKind {
 
 /// Every observation the alerts tool publishes flows through this enum
 /// `Spammer` is emitted when a peer crosses a configured threshold once
+/// `AddrEntriesSpammer` is emitted when a peer's addr/addrv2 entries exhaust a
+/// token bucket modeled on Bitcoin Core's addr rate limiting
 /// `PeerDisconnected` is emitted when a previously-flagged peer disconnects
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Alert {
     Spammer {
         kind: SpammerKind,
@@ -18,6 +20,20 @@ pub enum Alert {
         count: usize,
         window_secs: u64,
         threshold: usize,
+    },
+    AddrEntriesSpammer {
+        peer_id: u64,
+        addr: String,
+        /// Cumulative number of addr/addrv2 entries dropped by the token bucket
+        rate_limited: u64,
+        /// `rate_limited` value that triggered the alert
+        threshold: u64,
+        /// Token bucket capacity / refill ceiling (entries)
+        bucket_capacity: u64,
+        /// Token refill rate (entries per second)
+        rate_per_sec: f64,
+        /// Number of outbound GETADDR requests observed for this peer
+        getaddr_requests_sent: u64,
     },
     PeerDisconnected {
         peer_id: u64,
@@ -47,6 +63,19 @@ impl std::fmt::Display for Alert {
                     name, peer_id, addr, count, unit, window_secs, threshold
                 )
             }
+            Alert::AddrEntriesSpammer {
+                peer_id,
+                addr,
+                rate_limited,
+                threshold,
+                bucket_capacity,
+                rate_per_sec,
+                getaddr_requests_sent,
+            } => write!(
+                f,
+                "AddrEntriesSpammer | peer_id={} addr={} | {} addr/addrv2 entries rate-limited (threshold: {}, bucket: {}, rate: {}/s, getaddr_sent: {})",
+                peer_id, addr, rate_limited, threshold, bucket_capacity, rate_per_sec, getaddr_requests_sent
+            ),
             Alert::PeerDisconnected {
                 peer_id,
                 addr,
@@ -97,5 +126,28 @@ impl IntegrationTestAlerter {
 impl Alerter for IntegrationTestAlerter {
     fn emit(&self, alert: Alert) {
         let _ = self.tx.send(alert);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn addr_entries_spammer_display_includes_bucket_rate_and_getaddr_count() {
+        let alert = Alert::AddrEntriesSpammer {
+            peer_id: 42,
+            addr: "203.0.113.5:8333".to_string(),
+            rate_limited: 1234,
+            threshold: 77,
+            bucket_capacity: 1000,
+            rate_per_sec: 0.25,
+            getaddr_requests_sent: 3,
+        };
+
+        assert_eq!(
+            alert.to_string(),
+            "AddrEntriesSpammer | peer_id=42 addr=203.0.113.5:8333 | 1234 addr/addrv2 entries rate-limited (threshold: 77, bucket: 1000, rate: 0.25/s, getaddr_sent: 3)"
+        );
     }
 }

--- a/tools/alerts/src/alerter.rs
+++ b/tools/alerts/src/alerter.rs
@@ -6,6 +6,24 @@ pub enum SpammerKind {
     Addr,
 }
 
+/// Reason a peer was flagged and kept in state until it disconnected
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PeerFlag {
+    PingSpammer,
+    AddrSpammer,
+    AddrEntriesSpammer,
+}
+
+impl std::fmt::Display for PeerFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PeerFlag::PingSpammer => f.write_str("PingSpammer"),
+            PeerFlag::AddrSpammer => f.write_str("AddrSpammer"),
+            PeerFlag::AddrEntriesSpammer => f.write_str("AddrEntriesSpammer"),
+        }
+    }
+}
+
 /// Every observation the alerts tool publishes flows through this enum
 /// `Spammer` is emitted when a peer crosses a configured threshold once
 /// `AddrEntriesSpammer` is emitted when a peer's addr/addrv2 entries exhaust a
@@ -39,6 +57,8 @@ pub enum Alert {
         peer_id: u64,
         addr: String,
         active_secs: u64,
+        /// Heuristics that caused this peer to be tracked until disconnect
+        flags: Vec<PeerFlag>,
     },
 }
 
@@ -80,11 +100,21 @@ impl std::fmt::Display for Alert {
                 peer_id,
                 addr,
                 active_secs,
-            } => write!(
-                f,
-                "PeerDisconnected | peer_id={} addr={} | active={}s",
-                peer_id, addr, active_secs
-            ),
+                flags,
+            } => {
+                write!(
+                    f,
+                    "PeerDisconnected | peer_id={} addr={} | active={}s | flags=[",
+                    peer_id, addr, active_secs
+                )?;
+                for (index, flag) in flags.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{flag}")?;
+                }
+                f.write_str("]")
+            }
         }
     }
 }
@@ -148,6 +178,40 @@ mod tests {
         assert_eq!(
             alert.to_string(),
             "AddrEntriesSpammer | peer_id=42 addr=203.0.113.5:8333 | 1234 addr/addrv2 entries rate-limited (threshold: 77, bucket: 1000, rate: 0.25/s, getaddr_sent: 3)"
+        );
+    }
+
+    #[test]
+    fn peer_disconnected_display_includes_all_flags() {
+        let alert = Alert::PeerDisconnected {
+            peer_id: 42,
+            addr: "203.0.113.5:8333".to_string(),
+            active_secs: 105,
+            flags: vec![
+                PeerFlag::PingSpammer,
+                PeerFlag::AddrSpammer,
+                PeerFlag::AddrEntriesSpammer,
+            ],
+        };
+
+        assert_eq!(
+            alert.to_string(),
+            "PeerDisconnected | peer_id=42 addr=203.0.113.5:8333 | active=105s | flags=[PingSpammer, AddrSpammer, AddrEntriesSpammer]"
+        );
+    }
+
+    #[test]
+    fn peer_disconnected_display_includes_single_flag() {
+        let alert = Alert::PeerDisconnected {
+            peer_id: 7,
+            addr: "198.51.100.9:8333".to_string(),
+            active_secs: 12,
+            flags: vec![PeerFlag::AddrEntriesSpammer],
+        };
+
+        assert_eq!(
+            alert.to_string(),
+            "PeerDisconnected | peer_id=7 addr=198.51.100.9:8333 | active=12s | flags=[AddrEntriesSpammer]"
         );
     }
 }

--- a/tools/alerts/src/lib.rs
+++ b/tools/alerts/src/lib.rs
@@ -44,6 +44,26 @@ pub struct Args {
     #[arg(long, default_value_t = 60)]
     pub addr_window_secs: u64,
 
+    /// Initial token seed for a peer's addr/addrv2 entry bucket. Mirrors Core's
+    /// per-peer starting bucket (1.0, "permit self-announcement")
+    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u64).range(1..))]
+    pub addr_entries_initial_tokens: u64,
+
+    /// Token bucket capacity: the refill ceiling for addr/addrv2 entries. Mirrors
+    /// Core's MAX_ADDR_PROCESSING_TOKEN_BUCKET (1000); the bucket refills up to
+    /// this
+    #[arg(long, default_value_t = 1000, value_parser = clap::value_parser!(u64).range(1..))]
+    pub addr_entries_bucket_capacity: u64,
+
+    /// Token refill rate for addr/addrv2 entries (entries per second). Mirrors
+    /// Core's MAX_ADDR_RATE_PER_SECOND (0.1, i.e. one entry every 10 seconds)
+    #[arg(long, default_value_t = 0.1, value_parser = parse_non_negative_finite)]
+    pub addr_entries_rate_per_sec: f64,
+
+    /// Number of rate-limited addr/addrv2 entries before alerting
+    #[arg(long, default_value_t = 20)]
+    pub addr_entries_threshold: u64,
+
     #[arg(short, long, default_value_t = shared::log::Level::Debug)]
     pub log_level: shared::log::Level,
 
@@ -52,24 +72,53 @@ pub struct Args {
     pub peer_stale_secs: u64,
 }
 
+/// Clap value parser: accepts a finite float greater than or equal to 0
+fn parse_non_negative_finite(s: &str) -> Result<f64, String> {
+    let v: f64 = s.parse().map_err(|e| format!("{e}"))?;
+    if v.is_finite() && v >= 0.0 {
+        Ok(v)
+    } else {
+        Err(format!("must be a finite number >= 0, got {v}"))
+    }
+}
+
 #[derive(Default)]
 struct AlertTypeState {
     timestamps: VecDeque<Instant>,
     alerted_at: Option<Instant>,
 }
 
+/// Token bucket tracking addr/addrv2 entries, modeled on addr rate limiting
+/// The bucket starts at the configured seed and refills over time up to the
+/// capacity; entries that exceed the available tokens are counted as `rate_limited`
+struct AddrEntriesState {
+    tokens: f64,
+    last_update: Instant,
+    rate_limited: u64,
+    getaddr_requests_sent: u64,
+    alerted_at: Option<Instant>,
+}
+
 struct PeerState {
     ping: AlertTypeState,
     addr: AlertTypeState,
+    addr_entries: AddrEntriesState,
     last_seen: Instant,
     peer_addr: String,
 }
 
 impl PeerState {
-    fn new(peer_addr: String, now: Instant) -> Self {
+    fn new(peer_addr: String, now: Instant, addr_entries_initial_tokens: u64) -> Self {
         PeerState {
             ping: AlertTypeState::default(),
             addr: AlertTypeState::default(),
+            addr_entries: AddrEntriesState {
+                tokens: addr_entries_initial_tokens as f64,
+                last_update: now,
+                rate_limited: 0,
+                getaddr_requests_sent: 0,
+                alerted_at: None,
+            },
             last_seen: now,
             peer_addr,
         }
@@ -118,6 +167,64 @@ impl PeerState {
             threshold,
         })
     }
+
+    /// Models Core's response allowance for an outbound GETADDR: accept an
+    /// additional MAX_ADDR_TO_SEND-style burst beyond the regular refill cap
+    fn record_getaddr_sent(&mut self, args: &Args) {
+        self.addr_entries.tokens += args.addr_entries_bucket_capacity as f64;
+        self.addr_entries.getaddr_requests_sent =
+            self.addr_entries.getaddr_requests_sent.saturating_add(1);
+    }
+
+    /// Feeds `entries` (the number of addresses in an addr/addrv2 message) into
+    /// the per-peer token bucket. Refills the bucket for elapsed time, consumes
+    /// one token per entry, and counts any entry beyond the bucket as
+    /// rate-limited. Returns an `Alert` the first time the cumulative
+    /// rate-limited count exceeds the threshold; one-shot afterwards
+    fn check_addr_entries(
+        &mut self,
+        peer_id: u64,
+        entries: usize,
+        now: Instant,
+        args: &Args,
+    ) -> Option<Alert> {
+        let state = &mut self.addr_entries;
+        if state.alerted_at.is_some() {
+            return None;
+        }
+
+        let capacity = args.addr_entries_bucket_capacity as f64;
+        if state.tokens < capacity {
+            let elapsed = now.duration_since(state.last_update).as_secs_f64();
+            state.tokens = (state.tokens + elapsed * args.addr_entries_rate_per_sec).min(capacity);
+        }
+        state.last_update = now;
+
+        // Consume one token per entry: process as many entries as
+        // whole tokens allow, count the rest as rate-limited, and keep the
+        // fractional token remainder for the next message
+        let entries = entries as f64;
+        let processed = entries.min(state.tokens.floor());
+        state.rate_limited = state
+            .rate_limited
+            .saturating_add((entries - processed) as u64);
+        state.tokens -= processed;
+
+        if state.rate_limited <= args.addr_entries_threshold {
+            return None;
+        }
+        state.alerted_at = Some(now);
+
+        Some(Alert::AddrEntriesSpammer {
+            peer_id,
+            addr: self.peer_addr.clone(),
+            rate_limited: state.rate_limited,
+            threshold: args.addr_entries_threshold,
+            bucket_capacity: args.addr_entries_bucket_capacity,
+            rate_per_sec: args.addr_entries_rate_per_sec,
+            getaddr_requests_sent: state.getaddr_requests_sent,
+        })
+    }
 }
 
 struct AlertState {
@@ -136,10 +243,14 @@ impl AlertState {
 /// spammers, including how long they were active. Returns `None` for peers
 /// that were never flagged so non-flagged disconnects stay silent
 fn disconnect_alert(peer_id: u64, peer: &PeerState, now: Instant) -> Option<Alert> {
-    let first_alerted = [peer.ping.alerted_at, peer.addr.alerted_at]
-        .into_iter()
-        .flatten()
-        .min()?;
+    let first_alerted = [
+        peer.ping.alerted_at,
+        peer.addr.alerted_at,
+        peer.addr_entries.alerted_at,
+    ]
+    .into_iter()
+    .flatten()
+    .min()?;
     Some(Alert::PeerDisconnected {
         peer_id,
         addr: peer.peer_addr.clone(),
@@ -249,8 +360,8 @@ fn handle_event(event: Event, state: &mut AlertState, args: &Args, alerter: &imp
     }
 }
 
-/// Processes an inbound P2P message. Drops outbound messages and dispatches
-/// to ping or addr spammer detection based on the message type
+/// Processes P2P messages relevant to alerts. Outbound GETADDR messages add
+/// Core-style response allowance; other outbound messages are ignored.
 fn handle_message(
     msg: shared::protobuf::ebpf_extractor::message::MessageEvent,
     state: &mut AlertState,
@@ -258,27 +369,42 @@ fn handle_message(
     alerter: &impl Alerter,
     now: Instant,
 ) {
-    if !msg.meta.inbound {
-        return;
-    }
-
     let peer_id = msg.meta.peer_id;
     let addr = &msg.meta.addr;
+
+    if !msg.meta.inbound {
+        if matches!(&msg.msg, Some(Msg::Getaddr(_))) {
+            let peer = state.peers.entry(peer_id).or_insert_with(|| {
+                PeerState::new(addr.clone(), now, args.addr_entries_initial_tokens)
+            });
+            peer.last_seen = now;
+            peer.record_getaddr_sent(args);
+        }
+        return;
+    }
 
     let peer = state
         .peers
         .entry(peer_id)
-        .or_insert_with(|| PeerState::new(addr.clone(), now));
+        .or_insert_with(|| PeerState::new(addr.clone(), now, args.addr_entries_initial_tokens));
     peer.last_seen = now;
 
-    let kind = match msg.msg {
-        Some(Msg::Ping(_)) => SpammerKind::Ping,
-        Some(Msg::Addr(_)) | Some(Msg::Addrv2(_)) => SpammerKind::Addr,
+    // addr/addrv2 feed two distinct heuristics: the message-count sliding window
+    // (`check`) and the entry-count token bucket (`check_addr_entries`)
+    let (kind, addr_entries) = match &msg.msg {
+        Some(Msg::Ping(_)) => (SpammerKind::Ping, None),
+        Some(Msg::Addr(a)) => (SpammerKind::Addr, Some(a.addresses.len())),
+        Some(Msg::Addrv2(a)) => (SpammerKind::Addr, Some(a.addresses.len())),
         _ => return,
     };
 
     if let Some(alert) = peer.check(kind, peer_id, now, args) {
         alerter.emit(alert);
+    }
+    if let Some(entries) = addr_entries {
+        if let Some(alert) = peer.check_addr_entries(peer_id, entries, now, args) {
+            alerter.emit(alert);
+        }
     }
 }
 
@@ -316,13 +442,52 @@ mod tests {
             ping_window_secs: window_secs,
             addr_threshold,
             addr_window_secs: window_secs,
+            addr_entries_initial_tokens: 1000,
+            addr_entries_bucket_capacity: 1000,
+            addr_entries_rate_per_sec: 0.1,
+            addr_entries_threshold: 1000,
             log_level: shared::log::Level::Trace,
             peer_stale_secs: 300,
         }
     }
 
+    /// Like test_args but pins the token-bucket knobs for addr-entries tests.
+    /// Capacity is pinned equal to the seed so these focused tests exercise a
+    /// bucket that starts full; the seed-below-capacity behavior has its own test
+    fn entries_args(initial_tokens: u64, rate_per_sec: f64, threshold: u64) -> Args {
+        Args {
+            addr_entries_initial_tokens: initial_tokens,
+            addr_entries_bucket_capacity: initial_tokens,
+            addr_entries_rate_per_sec: rate_per_sec,
+            addr_entries_threshold: threshold,
+            ..test_args(100, 100, 60)
+        }
+    }
+
     fn make_peer(now: Instant) -> PeerState {
-        PeerState::new("1.2.3.4:8333".to_string(), now)
+        PeerState::new("1.2.3.4:8333".to_string(), now, 1000)
+    }
+
+    /// Builds a peer whose entry bucket starts at exactly `initial_tokens`,
+    /// allowing fractional runtime states (e.g. a partially drained bucket) that
+    /// the integer CLI capacity can't express directly
+    fn make_peer_with_tokens(now: Instant, initial_tokens: f64) -> PeerState {
+        let mut peer = PeerState::new("1.2.3.4:8333".to_string(), now, 0);
+        peer.addr_entries.tokens = initial_tokens;
+        peer
+    }
+
+    fn unwrap_addr_entries(alert: Alert) -> (u64, u64, u64, u64) {
+        match alert {
+            Alert::AddrEntriesSpammer {
+                peer_id,
+                rate_limited,
+                threshold,
+                getaddr_requests_sent,
+                ..
+            } => (peer_id, rate_limited, threshold, getaddr_requests_sent),
+            other => panic!("expected Alert::AddrEntriesSpammer, got {other:?}"),
+        }
     }
 
     fn unwrap_spammer(alert: Alert) -> (SpammerKind, u64, usize, u64, usize) {
@@ -472,5 +637,253 @@ mod tests {
         assert_eq!(window_secs, args.addr_window_secs);
         assert_eq!(threshold, args.addr_threshold);
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn addr_entries_burst_within_capacity_no_alert() {
+        // seed=10, no refill, threshold=5: a single 10-entry message fills but
+        // does not exceed the bucket, so nothing is rate-limited
+        let args = entries_args(10, 0.0, 5);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 10.0);
+
+        assert!(peer.check_addr_entries(1, 10, t0, &args).is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 0);
+        assert_eq!(peer.addr_entries.tokens, 0.0);
+    }
+
+    #[test]
+    fn addr_entries_sustained_flood_alerts() {
+        // seed=10, no refill, threshold=5: entries beyond the bucket accumulate
+        // as rate-limited and fire once the cumulative count passes the threshold
+        let args = entries_args(10, 0.0, 5);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 10.0);
+
+        // Drain the bucket (rate_limited still 0)
+        assert!(peer.check_addr_entries(1, 10, t0, &args).is_none());
+        // 4 over-rate entries: rate_limited=4, still <= threshold
+        assert!(peer
+            .check_addr_entries(1, 4, t0 + Duration::from_millis(1), &args)
+            .is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 4);
+        // 4 more: rate_limited=8 > 5 -> alert
+        let alert = peer
+            .check_addr_entries(1, 4, t0 + Duration::from_millis(2), &args)
+            .expect("cumulative rate-limited entries over threshold must alert");
+        let (peer_id, rate_limited, threshold, getaddr_requests_sent) = unwrap_addr_entries(alert);
+        assert_eq!(peer_id, 1);
+        assert_eq!(rate_limited, 8);
+        assert_eq!(threshold, 5);
+        assert_eq!(getaddr_requests_sent, 0);
+    }
+
+    #[test]
+    fn addr_entries_refill_replenishes_tokens() {
+        // seed=10, refill 1 entry/s, threshold=0 (alert on first rate-limited
+        // entry). Draining then waiting refills the bucket so a later message of
+        // the same size is fully covered and never rate-limited
+        let args = entries_args(10, 1.0, 0);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 10.0);
+
+        // Drain to 0 (threshold=0 but rate_limited is still 0 -> no alert)
+        assert!(peer.check_addr_entries(1, 10, t0, &args).is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 0);
+
+        // 5s later: +5 tokens; a 5-entry message is fully covered
+        assert!(peer
+            .check_addr_entries(1, 5, t0 + Duration::from_secs(5), &args)
+            .is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 0);
+
+        // Refill is capped at the seed: after a long gap tokens never exceed capacity
+        assert!(peer
+            .check_addr_entries(1, 0, t0 + Duration::from_secs(10_000), &args)
+            .is_none());
+        assert_eq!(peer.addr_entries.tokens, 10.0);
+    }
+
+    #[test]
+    fn addr_entries_one_shot_no_retrigger() {
+        // seed=1 (the smallest CLI-reachable capacity), no refill, threshold=0:
+        // the first 3-entry message processes 1 and rate-limits 2 (> threshold),
+        // firing once; subsequent messages are dropped without changing rate_limited
+        let args = entries_args(1, 0.0, 0);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1.0);
+
+        let alert = peer
+            .check_addr_entries(9, 3, t0, &args)
+            .expect("3 entries against a 1-token bucket and threshold 0 must alert");
+        let (_, rate_limited, _, getaddr_requests_sent) = unwrap_addr_entries(alert);
+        assert_eq!(rate_limited, 2);
+        assert_eq!(getaddr_requests_sent, 0);
+
+        // Further messages must not re-alert, and rate_limited must stay frozen
+        for i in 1..5 {
+            assert!(peer
+                .check_addr_entries(9, 5, t0 + Duration::from_millis(i), &args)
+                .is_none());
+        }
+        assert_eq!(peer.addr_entries.rate_limited, 2);
+    }
+
+    #[test]
+    fn addr_entries_preserves_fractional_remainder() {
+        // bucket seeded at 1.9 tokens (a drained/partially-refilled runtime
+        // state), capacity 2, no refill: 2 entries process one whole token (1)
+        // and rate-limit one, keeping the 0.9 fractional remainder (Core-style),
+        // instead of zeroing the bucket
+        let args = entries_args(2, 0.0, 100);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1.9);
+
+        assert!(peer.check_addr_entries(1, 2, t0, &args).is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 1);
+        assert!(
+            (peer.addr_entries.tokens - 0.9).abs() < 1e-9,
+            "expected ~0.9 tokens left, got {}",
+            peer.addr_entries.tokens
+        );
+    }
+
+    #[test]
+    fn addr_entries_single_oversized_message_alerts() {
+        // Core-faithful seed: the bucket starts at 1 even though its capacity is
+        // 1000 (the MAX_ADDR_TO_SEND burst Core only grants after an outbound
+        // GETADDR). A single 1000-entry addr processes 1 and rate-limits 999
+        // (> threshold), so one oversized message alerts — the case a bucket
+        // seeded at its full capacity would have missed
+        let args = Args {
+            addr_entries_initial_tokens: 1,
+            addr_entries_bucket_capacity: 1000,
+            addr_entries_rate_per_sec: 0.0,
+            addr_entries_threshold: 20,
+            ..test_args(100, 100, 60)
+        };
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1.0);
+
+        let alert = peer
+            .check_addr_entries(1, 1000, t0, &args)
+            .expect("a single 1000-entry addr against a seed-1 bucket must alert");
+        let (_, rate_limited, threshold, getaddr_requests_sent) = unwrap_addr_entries(alert);
+        assert_eq!(rate_limited, 999);
+        assert_eq!(threshold, 20);
+        assert_eq!(getaddr_requests_sent, 0);
+    }
+
+    #[test]
+    fn addr_entries_getaddr_allows_expected_response() {
+        let args = Args {
+            addr_entries_initial_tokens: 1,
+            addr_entries_bucket_capacity: 1000,
+            addr_entries_rate_per_sec: 0.0,
+            addr_entries_threshold: 20,
+            ..test_args(100, 100, 60)
+        };
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1.0);
+
+        peer.record_getaddr_sent(&args);
+        assert_eq!(peer.addr_entries.getaddr_requests_sent, 1);
+        assert_eq!(peer.addr_entries.tokens, 1001.0);
+
+        assert!(peer
+            .check_addr_entries(1, 1000, t0 + Duration::from_millis(1), &args)
+            .is_none());
+        assert_eq!(peer.addr_entries.rate_limited, 0);
+        assert_eq!(peer.addr_entries.tokens, 1.0);
+    }
+
+    #[test]
+    fn addr_entries_getaddr_tokens_can_exceed_capacity_without_clamping() {
+        let args = entries_args(1000, 1.0, 1000);
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1000.0);
+
+        peer.record_getaddr_sent(&args);
+        assert_eq!(peer.addr_entries.tokens, 2000.0);
+
+        assert!(peer
+            .check_addr_entries(1, 0, t0 + Duration::from_secs(60), &args)
+            .is_none());
+        assert_eq!(peer.addr_entries.tokens, 2000.0);
+    }
+
+    #[test]
+    fn addr_entries_alerts_after_getaddr_response_excess() {
+        let args = Args {
+            addr_entries_initial_tokens: 1,
+            addr_entries_bucket_capacity: 1000,
+            addr_entries_rate_per_sec: 0.0,
+            addr_entries_threshold: 20,
+            ..test_args(100, 100, 60)
+        };
+        let t0 = Instant::now();
+        let mut peer = make_peer_with_tokens(t0, 1.0);
+
+        peer.record_getaddr_sent(&args);
+        assert!(peer
+            .check_addr_entries(1, 1000, t0 + Duration::from_millis(1), &args)
+            .is_none());
+
+        let alert = peer
+            .check_addr_entries(1, 30, t0 + Duration::from_millis(2), &args)
+            .expect("entries beyond the GETADDR allowance must still alert");
+        let (_, rate_limited, threshold, getaddr_requests_sent) = unwrap_addr_entries(alert);
+        assert_eq!(rate_limited, 29);
+        assert_eq!(threshold, 20);
+        assert_eq!(getaddr_requests_sent, 1);
+    }
+
+    #[test]
+    fn rejects_invalid_entry_counts() {
+        // The seed and the capacity are both entry counts (u64 >= 1): negatives,
+        // zero, fractions and non-numbers must be rejected so the bucket can't be
+        // configured into a state that silently rate-limits every entry
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-initial-tokens", "-1"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-initial-tokens", "0"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-initial-tokens", "0.5"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-initial-tokens", "nan"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-initial-tokens", "inf"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-bucket-capacity", "0"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-bucket-capacity", "-1"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-bucket-capacity", "0.5"]).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_entry_rates() {
+        // Exercise the custom f64 parser directly so failures come from
+        // parse_non_negative_finite rather than clap's argument splitting.
+        assert!(parse_non_negative_finite("-0.1").is_err());
+        assert!(parse_non_negative_finite("nan").is_err());
+        assert!(parse_non_negative_finite("inf").is_err());
+        assert!(parse_non_negative_finite("-inf").is_err());
+
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-rate-per-sec=-0.1"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-rate-per-sec=nan"]).is_err());
+        assert!(Args::try_parse_from(["alerts", "--addr-entries-rate-per-sec=inf"]).is_err());
+    }
+
+    #[test]
+    fn parses_valid_entry_args() {
+        assert_eq!(parse_non_negative_finite("0").expect("zero is valid"), 0.0);
+        assert_eq!(
+            parse_non_negative_finite("0.1").expect("fractional rate is valid"),
+            0.1
+        );
+
+        assert!(Args::try_parse_from([
+            "alerts",
+            "--addr-entries-initial-tokens",
+            "1",
+            "--addr-entries-bucket-capacity",
+            "2000",
+            "--addr-entries-rate-per-sec",
+            "0"
+        ])
+        .is_ok());
     }
 }

--- a/tools/alerts/src/lib.rs
+++ b/tools/alerts/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 
 pub mod alerter;
 
-pub use crate::alerter::{Alert, Alerter, LoggingAlerter, SpammerKind};
+pub use crate::alerter::{Alert, Alerter, LoggingAlerter, PeerFlag, SpammerKind};
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -243,18 +243,28 @@ impl AlertState {
 /// spammers, including how long they were active. Returns `None` for peers
 /// that were never flagged so non-flagged disconnects stay silent
 fn disconnect_alert(peer_id: u64, peer: &PeerState, now: Instant) -> Option<Alert> {
-    let first_alerted = [
-        peer.ping.alerted_at,
-        peer.addr.alerted_at,
-        peer.addr_entries.alerted_at,
-    ]
-    .into_iter()
-    .flatten()
-    .min()?;
+    // Keep this list in the canonical display order. Using the same source for
+    // both the duration and flags prevents the two from drifting apart as new
+    // peer heuristics are added.
+    let flags_and_times = [
+        (PeerFlag::PingSpammer, peer.ping.alerted_at),
+        (PeerFlag::AddrSpammer, peer.addr.alerted_at),
+        (PeerFlag::AddrEntriesSpammer, peer.addr_entries.alerted_at),
+    ];
+    let first_alerted = flags_and_times
+        .iter()
+        .filter_map(|(_, alerted_at)| *alerted_at)
+        .min()?;
+    let flags = flags_and_times
+        .into_iter()
+        .filter_map(|(flag, alerted_at)| alerted_at.map(|_| flag))
+        .collect();
+
     Some(Alert::PeerDisconnected {
         peer_id,
         addr: peer.peer_addr.clone(),
         active_secs: now.duration_since(first_alerted).as_secs(),
+        flags,
     })
 }
 
@@ -475,6 +485,37 @@ mod tests {
         let mut peer = PeerState::new("1.2.3.4:8333".to_string(), now, 0);
         peer.addr_entries.tokens = initial_tokens;
         peer
+    }
+
+    #[test]
+    fn disconnect_alert_is_none_for_unflagged_peer() {
+        let now = Instant::now();
+        let peer = make_peer(now);
+
+        assert!(disconnect_alert(1, &peer, now + Duration::from_secs(10)).is_none());
+    }
+
+    #[test]
+    fn disconnect_alert_includes_all_flags_and_uses_first_alert_time() {
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+        peer.ping.alerted_at = Some(t0 + Duration::from_secs(2));
+        peer.addr.alerted_at = Some(t0 + Duration::from_secs(4));
+        peer.addr_entries.alerted_at = Some(t0 + Duration::from_secs(6));
+
+        assert_eq!(
+            disconnect_alert(7, &peer, t0 + Duration::from_secs(10)),
+            Some(Alert::PeerDisconnected {
+                peer_id: 7,
+                addr: "1.2.3.4:8333".to_string(),
+                active_secs: 8,
+                flags: vec![
+                    PeerFlag::PingSpammer,
+                    PeerFlag::AddrSpammer,
+                    PeerFlag::AddrEntriesSpammer,
+                ],
+            })
+        );
     }
 
     fn unwrap_addr_entries(alert: Alert) -> (u64, u64, u64, u64) {

--- a/tools/alerts/tests/integration.rs
+++ b/tools/alerts/tests/integration.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nats_integration_tests")]
 
-use alerts::{alerter::IntegrationTestAlerter, Alert, Args, SpammerKind};
+use alerts::{alerter::IntegrationTestAlerter, Alert, Args, PeerFlag, SpammerKind};
 
 use shared::{
     anyhow,
@@ -545,7 +545,89 @@ async fn test_flagged_peer_disconnect_emits_disconnect_alert() {
     // Flagged peer's Close emits a `PeerDisconnected` alert through the same channel
     let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
     match disconnect {
-        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 50),
+        Alert::PeerDisconnected { peer_id, flags, .. } => {
+            assert_eq!(peer_id, 50);
+            assert_eq!(flags, vec![PeerFlag::PingSpammer]);
+        }
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a peer which triggers every current peer heuristic reports all
+/// reasons in canonical order when it disconnects
+#[tokio::test]
+async fn test_disconnect_includes_all_triggered_flags() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                ping_threshold: 1,
+                addr_threshold: 0,
+                addr_entries_initial_tokens: 1,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 0,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    let peer_id = 51;
+    let addr = "51.52.53.54:8333";
+    publish_n(
+        &harness.publisher,
+        &Subject::NetMsg.to_string(),
+        &make_ping_event(peer_id, addr, true),
+        2,
+    )
+    .await;
+    let (kind, alert_peer_id, _, _) =
+        unwrap_spammer(recv_alert(&mut harness.rx, Duration::from_secs(2)).await);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(alert_peer_id, peer_id);
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addr_event(peer_id, addr, 3).encode_to_vec(),
+        )
+        .await;
+    let (kind, alert_peer_id, _, _) =
+        unwrap_spammer(recv_alert(&mut harness.rx, Duration::from_secs(2)).await);
+    assert_eq!(kind, SpammerKind::Addr);
+    assert_eq!(alert_peer_id, peer_id);
+    let (alert_peer_id, _, _, _) =
+        unwrap_addr_entries_spammer(recv_alert(&mut harness.rx, Duration::from_secs(2)).await);
+    assert_eq!(alert_peer_id, peer_id);
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(peer_id, addr).encode_to_vec(),
+        )
+        .await;
+
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    match disconnect {
+        Alert::PeerDisconnected {
+            peer_id: disconnected_peer_id,
+            flags,
+            ..
+        } => {
+            assert_eq!(disconnected_peer_id, peer_id);
+            assert_eq!(
+                flags,
+                vec![
+                    PeerFlag::PingSpammer,
+                    PeerFlag::AddrSpammer,
+                    PeerFlag::AddrEntriesSpammer,
+                ]
+            );
+        }
         other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
     }
 
@@ -588,7 +670,10 @@ async fn test_stale_peer_cleanup_emits_disconnect_alert() {
     // Wait for the cleanup interval to evict peer 60 (interval = peer_stale_secs = 1s)
     let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(5)).await;
     match disconnect {
-        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 60),
+        Alert::PeerDisconnected { peer_id, flags, .. } => {
+            assert_eq!(peer_id, 60);
+            assert_eq!(flags, vec![PeerFlag::PingSpammer]);
+        }
         other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
     }
 
@@ -795,7 +880,10 @@ async fn test_addr_entries_flagged_peer_disconnect_emits_disconnect_alert() {
     // The flagged peer's Close must emit a `PeerDisconnected` through the channel
     let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
     match disconnect {
-        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 90),
+        Alert::PeerDisconnected { peer_id, flags, .. } => {
+            assert_eq!(peer_id, 90);
+            assert_eq!(flags, vec![PeerFlag::AddrEntriesSpammer]);
+        }
         other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
     }
 

--- a/tools/alerts/tests/integration.rs
+++ b/tools/alerts/tests/integration.rs
@@ -10,6 +10,7 @@ use shared::{
     nats_util,
     prost::Message,
     protobuf::{
+        bitcoin_primitives::Address,
         ebpf_extractor::{
             connection::{self, ClosedConnection, Connection, ConnectionEvent},
             ebpf,
@@ -33,6 +34,10 @@ struct AlertSettingsInTest {
     ping_window_secs: u64,
     addr_threshold: usize,
     addr_window_secs: u64,
+    addr_entries_initial_tokens: u64,
+    addr_entries_bucket_capacity: u64,
+    addr_entries_rate_per_sec: f64,
+    addr_entries_threshold: u64,
     peer_stale_secs: u64,
 }
 
@@ -43,6 +48,12 @@ impl Default for AlertSettingsInTest {
             ping_window_secs: 60,
             addr_threshold: 5,
             addr_window_secs: 60,
+            // Token bucket large enough that the message-count tests (which send
+            // zero-entry messages) never trip the entry heuristic
+            addr_entries_initial_tokens: 1000,
+            addr_entries_bucket_capacity: 1000,
+            addr_entries_rate_per_sec: 0.1,
+            addr_entries_threshold: 1000,
             peer_stale_secs: 3600,
         }
     }
@@ -61,6 +72,10 @@ fn make_test_args(nats_port: u16, settings: AlertSettingsInTest) -> Args {
         ping_window_secs: settings.ping_window_secs,
         addr_threshold: settings.addr_threshold,
         addr_window_secs: settings.addr_window_secs,
+        addr_entries_initial_tokens: settings.addr_entries_initial_tokens,
+        addr_entries_bucket_capacity: settings.addr_entries_bucket_capacity,
+        addr_entries_rate_per_sec: settings.addr_entries_rate_per_sec,
+        addr_entries_threshold: settings.addr_entries_threshold,
         log_level: log::Level::Trace,
         peer_stale_secs: settings.peer_stale_secs,
     }
@@ -122,8 +137,8 @@ fn make_ping_event(peer_id: u64, addr: &str, inbound: bool) -> Event {
     .unwrap()
 }
 
-/// Constructs an inbound `Addr` message event for the given peer
-fn make_addr_event(peer_id: u64, addr: &str) -> Event {
+/// Constructs an inbound `Addr` message event carrying `entries` addresses
+fn make_addr_event(peer_id: u64, addr: &str, entries: usize) -> Event {
     Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
         ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
             meta: Metadata {
@@ -134,14 +149,16 @@ fn make_addr_event(peer_id: u64, addr: &str) -> Event {
                 inbound: true,
                 size: 30,
             },
-            msg: Some(Msg::Addr(Addr { addresses: vec![] })),
+            msg: Some(Msg::Addr(Addr {
+                addresses: vec![Address::default(); entries],
+            })),
         })),
     }))
     .unwrap()
 }
 
-/// Constructs an inbound `AddrV2` message event for the given peer
-fn make_addrv2_event(peer_id: u64, addr: &str) -> Event {
+/// Constructs an inbound `AddrV2` message event carrying `entries` addresses
+fn make_addrv2_event(peer_id: u64, addr: &str, entries: usize) -> Event {
     Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
         ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
             meta: Metadata {
@@ -152,10 +169,44 @@ fn make_addrv2_event(peer_id: u64, addr: &str) -> Event {
                 inbound: true,
                 size: 30,
             },
-            msg: Some(Msg::Addrv2(AddrV2 { addresses: vec![] })),
+            msg: Some(Msg::Addrv2(AddrV2 {
+                addresses: vec![Address::default(); entries],
+            })),
         })),
     }))
     .unwrap()
+}
+
+/// Constructs an outbound `GETADDR` message event for the given peer
+fn make_getaddr_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "getaddr".to_string(),
+                inbound: false,
+                size: 0,
+            },
+            msg: Some(Msg::Getaddr(true)),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Destructures `Alert::AddrEntriesSpammer` for assertions; panics on any other variant
+fn unwrap_addr_entries_spammer(alert: Alert) -> (u64, u64, u64, u64) {
+    match alert {
+        Alert::AddrEntriesSpammer {
+            peer_id,
+            rate_limited,
+            threshold,
+            getaddr_requests_sent,
+            ..
+        } => (peer_id, rate_limited, threshold, getaddr_requests_sent),
+        other => panic!("expected Alert::AddrEntriesSpammer, got {other:?}"),
+    }
 }
 
 /// Builds a ClosedConnection event for the given peer/addr
@@ -267,7 +318,7 @@ async fn test_addr_spammer() {
     })
     .await;
 
-    let event = make_addr_event(2, "5.6.7.8:8333");
+    let event = make_addr_event(2, "5.6.7.8:8333", 0);
     let subject = Subject::NetMsg.to_string();
 
     publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
@@ -303,7 +354,7 @@ async fn test_addrv2_spammer() {
     })
     .await;
 
-    let event = make_addrv2_event(3, "9.10.11.12:8333");
+    let event = make_addrv2_event(3, "9.10.11.12:8333", 0);
     let subject = Subject::NetMsg.to_string();
 
     publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
@@ -577,6 +628,279 @@ async fn test_undecodable_payload_does_not_kill_tool() {
     let (kind, peer_id, _, _) = unwrap_spammer(alert);
     assert_eq!(kind, SpammerKind::Ping);
     assert_eq!(peer_id, 77);
+
+    harness.shutdown().await;
+}
+
+/// With the defaults (seed 1, capacity 1000) a single oversized
+/// addr message trips the limiter end-to-end: the bucket starts at 1, not at its
+/// 1000 capacity, so 25 entries leave 24 rate-limited (> threshold 20)
+#[tokio::test]
+async fn test_addr_entries_single_message_core_seed() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                // keep the message-count threshold high so only the entry heuristic fires
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 1,
+                addr_entries_bucket_capacity: 1000,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 20,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    // 25 entries against a seed-1 bucket: 1 processed, 24 rate-limited (> 20)
+    let event = make_addr_event(82, "8.8.8.8:8333", 25);
+    harness
+        .publisher
+        .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+        .await;
+
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (peer_id, rate_limited, threshold, getaddr_requests_sent) =
+        unwrap_addr_entries_spammer(alert);
+    assert_eq!(peer_id, 82);
+    assert_eq!(rate_limited, 24);
+    assert_eq!(threshold, 20);
+    assert_eq!(getaddr_requests_sent, 0);
+
+    harness.shutdown().await;
+}
+
+/// addrv2 entries feed the same token bucket and can fire the alert on their own
+#[tokio::test]
+async fn test_addrv2_entries_spammer() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 5,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 5,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    let event = make_addrv2_event(81, "8.8.4.4:8333", 20);
+    harness
+        .publisher
+        .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+        .await;
+
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (peer_id, _, threshold, getaddr_requests_sent) = unwrap_addr_entries_spammer(alert);
+    assert_eq!(peer_id, 81);
+    assert_eq!(threshold, 5);
+    assert_eq!(getaddr_requests_sent, 0);
+
+    harness.shutdown().await;
+}
+
+/// addr and addrv2 entries accumulate in one shared per-peer bucket
+#[tokio::test]
+async fn test_addr_and_addrv2_share_entries_bucket() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 10,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 5,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    // First an addr with 8 entries: bucket 10 -> 2 left, nothing rate-limited
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addr_event(83, "1.1.1.1:8333", 8).encode_to_vec(),
+        )
+        .await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "8 entries against a 10-token bucket must not alert"
+    );
+
+    // Then an addrv2 with 8 entries: only 2 tokens remain, 6 rate-limited (> 5)
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addrv2_event(83, "1.1.1.1:8333", 8).encode_to_vec(),
+        )
+        .await;
+
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (peer_id, rate_limited, _, getaddr_requests_sent) = unwrap_addr_entries_spammer(alert);
+    assert_eq!(peer_id, 83);
+    assert_eq!(rate_limited, 6);
+    assert_eq!(getaddr_requests_sent, 0);
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a peer flagged only via the entry token bucket (never the
+/// ping/message-count heuristics) still emits a `PeerDisconnected` alert when
+/// its conection closes, covering the `addr_entries.alerted_at` branch of
+/// `disconnect_alert`
+#[tokio::test]
+async fn test_addr_entries_flagged_peer_disconnect_emits_disconnect_alert() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                // keep the message-count threshold high so only the entry heuristic fires
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 5,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 5,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    // 20 entries against a 5-token bucket: 15 rate-limited (> threshold 5) -> flag
+    let event = make_addr_event(90, "9.9.9.9:8333", 20);
+    harness
+        .publisher
+        .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+        .await;
+
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (peer_id, _, _, getaddr_requests_sent) = unwrap_addr_entries_spammer(alert);
+    assert_eq!(peer_id, 90);
+    assert_eq!(getaddr_requests_sent, 0);
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(90, "9.9.9.9:8333").encode_to_vec(),
+        )
+        .await;
+
+    // The flagged peer's Close must emit a `PeerDisconnected` through the channel
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    match disconnect {
+        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 90),
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// An outbound GETADDR grants a Core-style response allowance: a following
+/// 1000-entry addr message is covered by the bucket and does not alert
+#[tokio::test]
+async fn test_addr_entries_getaddr_allows_response() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 1,
+                addr_entries_bucket_capacity: 1000,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 20,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_getaddr_event(84, "8.8.8.8:8333").encode_to_vec(),
+        )
+        .await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(200)).await,
+        "outbound GETADDR must not alert"
+    );
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addr_event(84, "8.8.8.8:8333", 1000).encode_to_vec(),
+        )
+        .await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "1000-entry response to our GETADDR should be covered by the allowance"
+    );
+
+    harness.shutdown().await;
+}
+
+/// The GETADDR allowance only covers the expected response burst; entries beyond
+/// the remaining bucket still become rate-limited and can trigger an alert
+#[tokio::test]
+async fn test_addr_entries_getaddr_response_excess_alerts() {
+    let mut harness = TestHarness::new(|port| {
+        make_test_args(
+            port,
+            AlertSettingsInTest {
+                addr_threshold: 100,
+                addr_entries_initial_tokens: 1,
+                addr_entries_bucket_capacity: 1000,
+                addr_entries_rate_per_sec: 0.0,
+                addr_entries_threshold: 20,
+                ..Default::default()
+            },
+        )
+    })
+    .await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_getaddr_event(85, "8.8.4.4:8333").encode_to_vec(),
+        )
+        .await;
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addr_event(85, "8.8.4.4:8333", 1000).encode_to_vec(),
+        )
+        .await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "the first 1000 entries should be covered by the GETADDR allowance"
+    );
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_addr_event(85, "8.8.4.4:8333", 30).encode_to_vec(),
+        )
+        .await;
+
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (peer_id, rate_limited, threshold, getaddr_requests_sent) =
+        unwrap_addr_entries_spammer(alert);
+    assert_eq!(peer_id, 85);
+    assert_eq!(rate_limited, 29);
+    assert_eq!(threshold, 20);
+    assert_eq!(getaddr_requests_sent, 1);
 
     harness.shutdown().await;
 }


### PR DESCRIPTION
Adds an `AddrEntriesSpammer` heuristic that flags peers whose `addr`/`addrv2` messages carry too many entries - catching peers that stay under the message-count threshold by sending a few oversized messages.

Detection uses a per-peer token bucket modeled on Core's addr rate limiting.

Part of #185 (the addr-spammer / addr-entries item).

**Note:** overlaps with anyhow refactor, happy to rebase on top of whichever lands first.