### PR TITLE
refactor(archive): split replayer into library module and use anyhow

### DIFF
--- a/tools/archive/src/bin/replayer.rs
+++ b/tools/archive/src/bin/replayer.rs
@@ -1,18 +1,16 @@
 use archive::replayer::{self, Args};
+use shared::anyhow::{Context, Result};
 use shared::clap::Parser;
 use shared::simple_logger;
-use std::process::ExitCode;
 
-fn main() -> ExitCode {
+fn main() -> Result<()> {
     let args = Args::parse();
 
-    if let Err(e) = simple_logger::init_with_level(args.log_level) {
-        eprintln!("replayer tool error: {}", e);
-    }
+    simple_logger::init_with_level(args.log_level).context("could not initialize logger")?;
 
     if replayer::run(&args) {
-        ExitCode::FAILURE
-    } else {
-        ExitCode::SUCCESS
+        std::process::exit(1);
     }
+
+    Ok(())
 }

--- a/tools/archive/src/bin/replayer.rs
+++ b/tools/archive/src/bin/replayer.rs
@@ -1,23 +1,7 @@
-use archive::read::ArchiveReader;
-use shared::clap;
+use archive::replayer::{self, Args};
 use shared::clap::Parser;
-use shared::protobuf::event::{event::PeerObserverEvent, Event};
-use shared::{log, simple_logger};
-use std::io::ErrorKind;
-use std::path::PathBuf;
+use shared::simple_logger;
 use std::process::ExitCode;
-
-#[derive(Parser, Debug)]
-#[command(version, about = "Read and display peer-observer archive files")]
-struct Args {
-    /// Archive files to read.
-    #[arg(value_name = "FILE", required = true)]
-    files: Vec<PathBuf>,
-
-    /// The log level the tool should run on.
-    #[arg(short, long, default_value_t = log::Level::Info)]
-    log_level: log::Level,
-}
 
 fn main() -> ExitCode {
     let args = Args::parse();
@@ -26,91 +10,9 @@ fn main() -> ExitCode {
         eprintln!("replayer tool error: {}", e);
     }
 
-    let mut had_error = false;
-
-    for path in &args.files {
-        if args.files.len() > 1 {
-            log::info!("=== {} ===", path.display());
-        }
-
-        let archive = match ArchiveReader::open(path) {
-            Ok(archive) => archive,
-            Err(e) => {
-                log::error!("failed to read archive {}: {e}", path.display());
-                had_error = true;
-                continue;
-            }
-        };
-
-        log::info!("header: {}", archive.header);
-
-        let mut events_count = 0;
-        for (idx, event) in archive.enumerate() {
-            let n = idx + 1;
-            let event = match event {
-                Ok(event) => event,
-                Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-                    log::error!(
-                        "archive {} ended unexpectedly while reading event {n}: {e}",
-                        path.display()
-                    );
-                    had_error = true;
-                    break;
-                }
-                Err(e) => {
-                    log::error!(
-                        "failed to read archive {} at event {n}: {e}",
-                        path.display()
-                    );
-                    had_error = true;
-                    break;
-                }
-            };
-
-            if let Err(e) = display_event(n, &event) {
-                log::warn!(
-                    "failed to display archive {} event {n}: {e}",
-                    path.display()
-                );
-            }
-            events_count = n;
-        }
-
-        log::info!("total: {} events", events_count);
-    }
-
-    if had_error {
+    if replayer::run(&args) {
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
     }
-}
-
-fn display_event(n: usize, event: &Event) -> Result<(), &'static str> {
-    let ts = event.timestamp;
-    match &event.peer_observer_event {
-        Some(PeerObserverEvent::EbpfExtractor(e)) => {
-            let ebpf_event = e.ebpf_event.as_ref().ok_or("missing ebpf event")?;
-            log::info!("[{n}] ts={ts} ebpf: {ebpf_event}");
-        }
-        Some(PeerObserverEvent::RpcExtractor(r)) => {
-            let rpc_event = r.rpc_event.as_ref().ok_or("missing rpc event")?;
-            log::info!("[{n}] ts={ts} rpc: {rpc_event}");
-        }
-        Some(PeerObserverEvent::P2pExtractor(p)) => {
-            let p2p_event = p.p2p_event.as_ref().ok_or("missing p2p event")?;
-            log::info!("[{n}] ts={ts} p2p: {p2p_event}");
-        }
-        Some(PeerObserverEvent::LogExtractor(l)) => {
-            let log_event = l.log_event.as_ref().ok_or("missing log event")?;
-            log::info!("[{n}] ts={ts} log: {log_event}");
-        }
-        Some(PeerObserverEvent::IpcExtractor(i)) => {
-            let ipc_event = i.ipc_event.as_ref().ok_or("missing ipc event")?;
-            log::info!("[{n}] ts={ts} ipc: {ipc_event}");
-        }
-        None => log::info!("[{n}] ts={ts} <unknown>"),
-    }
-
-    Ok(())
 }

--- a/tools/archive/src/lib.rs
+++ b/tools/archive/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod archiver;
 
 pub mod read;
+
+pub mod replayer;

--- a/tools/archive/src/replayer.rs
+++ b/tools/archive/src/replayer.rs
@@ -1,10 +1,9 @@
 use crate::read::ArchiveReader;
+use shared::anyhow::{Context, Result};
 use shared::clap;
 use shared::clap::Parser;
 use shared::log;
 use shared::protobuf::event::{event::PeerObserverEvent, Event};
-use std::io;
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
@@ -19,29 +18,6 @@ pub struct Args {
     pub log_level: log::Level,
 }
 
-#[derive(Debug)]
-pub enum ReplayFileError {
-    OpenArchive(io::Error),
-    UnexpectedEof {
-        event_number: usize,
-        source: io::Error,
-    },
-    ReadEvent {
-        event_number: usize,
-        source: io::Error,
-    },
-}
-
-impl ReplayFileError {
-    fn events_count(&self) -> Option<usize> {
-        match self {
-            ReplayFileError::OpenArchive(_) => None,
-            ReplayFileError::UnexpectedEof { event_number, .. }
-            | ReplayFileError::ReadEvent { event_number, .. } => Some(event_number - 1),
-        }
-    }
-}
-
 pub fn run(args: &Args) -> bool {
     let mut had_error = false;
 
@@ -53,10 +29,7 @@ pub fn run(args: &Args) -> bool {
         match replay_file(path) {
             Ok(events_count) => log::info!("total: {} events", events_count),
             Err(error) => {
-                log_replay_error(path, &error);
-                if let Some(events_count) = error.events_count() {
-                    log::info!("total: {} events", events_count);
-                }
+                log::error!("{:#}", error);
                 had_error = true;
             }
         }
@@ -65,37 +38,23 @@ pub fn run(args: &Args) -> bool {
     had_error
 }
 
-pub fn replay_file(path: &Path) -> Result<usize, ReplayFileError> {
-    let archive = match ArchiveReader::open(path) {
-        Ok(archive) => archive,
-        Err(e) => return Err(ReplayFileError::OpenArchive(e)),
-    };
+pub fn replay_file(path: &Path) -> Result<usize> {
+    let archive =
+        ArchiveReader::open(path).with_context(|| format!("reading archive {}", path.display()))?;
 
     log::info!("header: {}", archive.header);
 
     let mut events_count = 0;
     for (idx, event) in archive.enumerate() {
         let n = idx + 1;
-        let event = match event {
-            Ok(event) => event,
-            Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-                return Err(ReplayFileError::UnexpectedEof {
-                    event_number: n,
-                    source: e,
-                });
-            }
-            Err(e) => {
-                return Err(ReplayFileError::ReadEvent {
-                    event_number: n,
-                    source: e,
-                });
-            }
-        };
+        let event =
+            event.with_context(|| format!("error at event {n} in archive {}", path.display()))?;
 
         if let Err(e) = display_event(n, &event) {
             log::warn!(
-                "failed to display archive {} event {n}: {e}",
-                path.display()
+                "failed to display archive {} event {n}: {:#}",
+                path.display(),
+                e
             );
         }
         events_count = n;
@@ -104,53 +63,27 @@ pub fn replay_file(path: &Path) -> Result<usize, ReplayFileError> {
     Ok(events_count)
 }
 
-fn log_replay_error(path: &Path, error: &ReplayFileError) {
-    match error {
-        ReplayFileError::OpenArchive(e) => {
-            log::error!("failed to read archive {}: {e}", path.display());
-        }
-        ReplayFileError::UnexpectedEof {
-            event_number,
-            source,
-        } => {
-            log::error!(
-                "archive {} ended unexpectedly while reading event {event_number}: {source}",
-                path.display()
-            );
-        }
-        ReplayFileError::ReadEvent {
-            event_number,
-            source,
-        } => {
-            log::error!(
-                "failed to read archive {} at event {event_number}: {source}",
-                path.display()
-            );
-        }
-    }
-}
-
-fn display_event(n: usize, event: &Event) -> Result<(), &'static str> {
+fn display_event(n: usize, event: &Event) -> Result<()> {
     let ts = event.timestamp;
     match &event.peer_observer_event {
         Some(PeerObserverEvent::EbpfExtractor(e)) => {
-            let ebpf_event = e.ebpf_event.as_ref().ok_or("missing ebpf event")?;
+            let ebpf_event = e.ebpf_event.as_ref().context("missing ebpf event")?;
             log::info!("[{n}] ts={ts} ebpf: {ebpf_event}");
         }
         Some(PeerObserverEvent::RpcExtractor(r)) => {
-            let rpc_event = r.rpc_event.as_ref().ok_or("missing rpc event")?;
+            let rpc_event = r.rpc_event.as_ref().context("missing rpc event")?;
             log::info!("[{n}] ts={ts} rpc: {rpc_event}");
         }
         Some(PeerObserverEvent::P2pExtractor(p)) => {
-            let p2p_event = p.p2p_event.as_ref().ok_or("missing p2p event")?;
+            let p2p_event = p.p2p_event.as_ref().context("missing p2p event")?;
             log::info!("[{n}] ts={ts} p2p: {p2p_event}");
         }
         Some(PeerObserverEvent::LogExtractor(l)) => {
-            let log_event = l.log_event.as_ref().ok_or("missing log event")?;
+            let log_event = l.log_event.as_ref().context("missing log event")?;
             log::info!("[{n}] ts={ts} log: {log_event}");
         }
         Some(PeerObserverEvent::IpcExtractor(i)) => {
-            let ipc_event = i.ipc_event.as_ref().ok_or("missing ipc event")?;
+            let ipc_event = i.ipc_event.as_ref().context("missing ipc event")?;
             log::info!("[{n}] ts={ts} ipc: {ipc_event}");
         }
         None => log::info!("[{n}] ts={ts} <unknown>"),

--- a/tools/archive/src/replayer.rs
+++ b/tools/archive/src/replayer.rs
@@ -1,0 +1,160 @@
+use crate::read::ArchiveReader;
+use shared::clap;
+use shared::clap::Parser;
+use shared::log;
+use shared::protobuf::event::{event::PeerObserverEvent, Event};
+use std::io;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+#[command(version, about = "Read and display peer-observer archive files")]
+pub struct Args {
+    /// Archive files to read.
+    #[arg(value_name = "FILE", required = true)]
+    pub files: Vec<PathBuf>,
+
+    /// The log level the tool should run on.
+    #[arg(short, long, default_value_t = log::Level::Info)]
+    pub log_level: log::Level,
+}
+
+#[derive(Debug)]
+pub enum ReplayFileError {
+    OpenArchive(io::Error),
+    UnexpectedEof {
+        event_number: usize,
+        source: io::Error,
+    },
+    ReadEvent {
+        event_number: usize,
+        source: io::Error,
+    },
+}
+
+impl ReplayFileError {
+    fn events_count(&self) -> Option<usize> {
+        match self {
+            ReplayFileError::OpenArchive(_) => None,
+            ReplayFileError::UnexpectedEof { event_number, .. }
+            | ReplayFileError::ReadEvent { event_number, .. } => Some(event_number - 1),
+        }
+    }
+}
+
+pub fn run(args: &Args) -> bool {
+    let mut had_error = false;
+
+    for path in &args.files {
+        if args.files.len() > 1 {
+            log::info!("=== {} ===", path.display());
+        }
+
+        match replay_file(path) {
+            Ok(events_count) => log::info!("total: {} events", events_count),
+            Err(error) => {
+                log_replay_error(path, &error);
+                if let Some(events_count) = error.events_count() {
+                    log::info!("total: {} events", events_count);
+                }
+                had_error = true;
+            }
+        }
+    }
+
+    had_error
+}
+
+pub fn replay_file(path: &Path) -> Result<usize, ReplayFileError> {
+    let archive = match ArchiveReader::open(path) {
+        Ok(archive) => archive,
+        Err(e) => return Err(ReplayFileError::OpenArchive(e)),
+    };
+
+    log::info!("header: {}", archive.header);
+
+    let mut events_count = 0;
+    for (idx, event) in archive.enumerate() {
+        let n = idx + 1;
+        let event = match event {
+            Ok(event) => event,
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                return Err(ReplayFileError::UnexpectedEof {
+                    event_number: n,
+                    source: e,
+                });
+            }
+            Err(e) => {
+                return Err(ReplayFileError::ReadEvent {
+                    event_number: n,
+                    source: e,
+                });
+            }
+        };
+
+        if let Err(e) = display_event(n, &event) {
+            log::warn!(
+                "failed to display archive {} event {n}: {e}",
+                path.display()
+            );
+        }
+        events_count = n;
+    }
+
+    Ok(events_count)
+}
+
+fn log_replay_error(path: &Path, error: &ReplayFileError) {
+    match error {
+        ReplayFileError::OpenArchive(e) => {
+            log::error!("failed to read archive {}: {e}", path.display());
+        }
+        ReplayFileError::UnexpectedEof {
+            event_number,
+            source,
+        } => {
+            log::error!(
+                "archive {} ended unexpectedly while reading event {event_number}: {source}",
+                path.display()
+            );
+        }
+        ReplayFileError::ReadEvent {
+            event_number,
+            source,
+        } => {
+            log::error!(
+                "failed to read archive {} at event {event_number}: {source}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn display_event(n: usize, event: &Event) -> Result<(), &'static str> {
+    let ts = event.timestamp;
+    match &event.peer_observer_event {
+        Some(PeerObserverEvent::EbpfExtractor(e)) => {
+            let ebpf_event = e.ebpf_event.as_ref().ok_or("missing ebpf event")?;
+            log::info!("[{n}] ts={ts} ebpf: {ebpf_event}");
+        }
+        Some(PeerObserverEvent::RpcExtractor(r)) => {
+            let rpc_event = r.rpc_event.as_ref().ok_or("missing rpc event")?;
+            log::info!("[{n}] ts={ts} rpc: {rpc_event}");
+        }
+        Some(PeerObserverEvent::P2pExtractor(p)) => {
+            let p2p_event = p.p2p_event.as_ref().ok_or("missing p2p event")?;
+            log::info!("[{n}] ts={ts} p2p: {p2p_event}");
+        }
+        Some(PeerObserverEvent::LogExtractor(l)) => {
+            let log_event = l.log_event.as_ref().ok_or("missing log event")?;
+            log::info!("[{n}] ts={ts} log: {log_event}");
+        }
+        Some(PeerObserverEvent::IpcExtractor(i)) => {
+            let ipc_event = i.ipc_event.as_ref().ok_or("missing ipc event")?;
+            log::info!("[{n}] ts={ts} ipc: {ipc_event}");
+        }
+        None => log::info!("[{n}] ts={ts} <unknown>"),
+    }
+
+    Ok(())
+}

--- a/tools/archive/tests/replayer.rs
+++ b/tools/archive/tests/replayer.rs
@@ -1,4 +1,4 @@
-use archive::replayer::{self, Args, ReplayFileError};
+use archive::replayer::{self, Args};
 use shared::{
     log,
     prost::Message,
@@ -9,7 +9,7 @@ use shared::{
     },
 };
 use std::fs;
-use std::io::ErrorKind;
+use std::io::{self, ErrorKind};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -46,6 +46,10 @@ fn write_temp_archive(test_name: &str, bytes: Vec<u8>) -> PathBuf {
     path
 }
 
+fn assert_io_error_kind(error: &shared::anyhow::Error, kind: ErrorKind) {
+    assert_eq!(error.downcast_ref::<io::Error>().unwrap().kind(), kind);
+}
+
 #[test]
 fn replays_valid_archive() {
     let path = write_temp_archive("valid", archive_bytes(&[test_event()]));
@@ -65,13 +69,11 @@ fn replays_valid_archive() {
 fn missing_header_is_an_archive_error() {
     let path = write_temp_archive("missing_header", Vec::new());
 
-    match replayer::replay_file(&path).unwrap_err() {
-        ReplayFileError::OpenArchive(source) => {
-            assert_eq!(source.kind(), ErrorKind::Other);
-            assert!(source.to_string().contains("missing header"));
-        }
-        other => panic!("expected OpenArchive error, got {other:?}"),
-    }
+    let error = replayer::replay_file(&path).unwrap_err();
+    assert_io_error_kind(&error, ErrorKind::Other);
+    let error = format!("{error:#}");
+    assert!(error.contains("reading archive"));
+    assert!(error.contains("missing header"));
 
     let _ = fs::remove_file(path);
 }
@@ -84,16 +86,9 @@ fn truncated_event_is_an_unexpected_eof() {
     bytes.extend(event_bytes);
     let path = write_temp_archive("truncated_event", bytes);
 
-    match replayer::replay_file(&path).unwrap_err() {
-        ReplayFileError::UnexpectedEof {
-            event_number,
-            source,
-        } => {
-            assert_eq!(event_number, 1);
-            assert_eq!(source.kind(), ErrorKind::UnexpectedEof);
-        }
-        other => panic!("expected UnexpectedEof error, got {other:?}"),
-    }
+    let error = replayer::replay_file(&path).unwrap_err();
+    assert_io_error_kind(&error, ErrorKind::UnexpectedEof);
+    assert!(format!("{error:#}").contains("error at event 1"));
 
     let _ = fs::remove_file(path);
 }
@@ -105,16 +100,9 @@ fn malformed_event_is_a_read_error() {
     bytes.push(0xff);
     let path = write_temp_archive("malformed_event", bytes);
 
-    match replayer::replay_file(&path).unwrap_err() {
-        ReplayFileError::ReadEvent {
-            event_number,
-            source,
-        } => {
-            assert_eq!(event_number, 1);
-            assert_eq!(source.kind(), ErrorKind::Other);
-        }
-        other => panic!("expected ReadEvent error, got {other:?}"),
-    }
+    let error = replayer::replay_file(&path).unwrap_err();
+    assert_io_error_kind(&error, ErrorKind::Other);
+    assert!(format!("{error:#}").contains("error at event 1"));
 
     let _ = fs::remove_file(path);
 }

--- a/tools/archive/tests/replayer.rs
+++ b/tools/archive/tests/replayer.rs
@@ -1,0 +1,144 @@
+use archive::replayer::{self, Args, ReplayFileError};
+use shared::{
+    log,
+    prost::Message,
+    protobuf::{
+        archive::ArchiveHeader,
+        event::{event::PeerObserverEvent, Event},
+        rpc_extractor::{self, rpc},
+    },
+};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn test_event() -> Event {
+    Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+        rpc_event: Some(rpc::RpcEvent::Uptime(12345)),
+    }))
+    .unwrap()
+}
+
+fn archive_bytes(events: &[Event]) -> Vec<u8> {
+    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    for event in events {
+        bytes.extend(event.encode_length_delimited_to_vec());
+    }
+    bytes
+}
+
+fn temp_path(test_name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "archive_replayer_{test_name}_{}_{}.bin",
+        std::process::id(),
+        nonce
+    ))
+}
+
+fn write_temp_archive(test_name: &str, bytes: Vec<u8>) -> PathBuf {
+    let path = temp_path(test_name);
+    fs::write(&path, bytes).unwrap();
+    path
+}
+
+#[test]
+fn replays_valid_archive() {
+    let path = write_temp_archive("valid", archive_bytes(&[test_event()]));
+
+    assert_eq!(replayer::replay_file(&path).unwrap(), 1);
+
+    let args = Args {
+        files: vec![path.clone()],
+        log_level: log::Level::Info,
+    };
+    assert!(!replayer::run(&args));
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn missing_header_is_an_archive_error() {
+    let path = write_temp_archive("missing_header", Vec::new());
+
+    match replayer::replay_file(&path).unwrap_err() {
+        ReplayFileError::OpenArchive(source) => {
+            assert_eq!(source.kind(), ErrorKind::Other);
+            assert!(source.to_string().contains("missing header"));
+        }
+        other => panic!("expected OpenArchive error, got {other:?}"),
+    }
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn truncated_event_is_an_unexpected_eof() {
+    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    let mut event_bytes = test_event().encode_length_delimited_to_vec();
+    event_bytes.pop();
+    bytes.extend(event_bytes);
+    let path = write_temp_archive("truncated_event", bytes);
+
+    match replayer::replay_file(&path).unwrap_err() {
+        ReplayFileError::UnexpectedEof {
+            event_number,
+            source,
+        } => {
+            assert_eq!(event_number, 1);
+            assert_eq!(source.kind(), ErrorKind::UnexpectedEof);
+        }
+        other => panic!("expected UnexpectedEof error, got {other:?}"),
+    }
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn malformed_event_is_a_read_error() {
+    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    bytes.push(1);
+    bytes.push(0xff);
+    let path = write_temp_archive("malformed_event", bytes);
+
+    match replayer::replay_file(&path).unwrap_err() {
+        ReplayFileError::ReadEvent {
+            event_number,
+            source,
+        } => {
+            assert_eq!(event_number, 1);
+            assert_eq!(source.kind(), ErrorKind::Other);
+        }
+        other => panic!("expected ReadEvent error, got {other:?}"),
+    }
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn display_error_is_not_fatal() {
+    let event = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+        rpc_event: None,
+    }))
+    .unwrap();
+    let path = write_temp_archive("display_error", archive_bytes(&[event]));
+
+    assert_eq!(replayer::replay_file(&path).unwrap(), 1);
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn run_reports_archive_error() {
+    let missing_path = temp_path("missing_file");
+    let args = Args {
+        files: vec![missing_path],
+        log_level: log::Level::Info,
+    };
+
+    assert!(replayer::run(&args));
+}


### PR DESCRIPTION
Follow-up from #455.

This splits the archive replayer logic out of `tools/archive/src/bin/replayer.rs` and into `archive::replayer`. This makes the replay behavior testable without spawning the binary.

Changes:
- move replayer args and replay logic into `tools/archive/src/replayer.rs`
- expose the new module from `tools/archive/src/lib.rs`
- add focused tests for valid archives, missing headers, truncated events, malformed events, display-only errors, and run-level error reporting
- update the new replayer code to use `anyhow` with archive/event context, following #418

The replayer still preserves the existing run-level behavior of processing all requested files and returning a failing exit status if any replay fails.