### PR TITLE
update: CI Nix channel to version 26.05

### DIFF
--- a/.github/actions/setup-nix-action/action.yml
+++ b/.github/actions/setup-nix-action/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-25.11
+        nix_path: nixpkgs=channel:nixos-26.05
 
     - name: Restore and save Nix store
       uses: nix-community/cache-nix-action@main


### PR DESCRIPTION
We want to build and test against the lastest version of NixOS in CI.