### PR TITLE
fix: CI workflow permissions can be reduced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
This was noted in GH code scanning: https://github.com/peer-observer/peer-observer/security/code-scanning/12