### PR TITLE
fix: linter warnings

### DIFF
--- a/extractors/ebpf/src/lib.rs
+++ b/extractors/ebpf/src/lib.rs
@@ -457,8 +457,8 @@ pub async fn run(args: Args, shutdown_rx: watch::Receiver<bool>) -> Result<()> {
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
+    log::info!("Connected to NATS server at {}", args.nats.address);
 
     let mut obj_container = MaybeUninit::uninit();
     // Keeping _loaded_obj and _links alive is important. Dropping them triggers deleletion from the

--- a/extractors/ipc/src/lib.rs
+++ b/extractors/ipc/src/lib.rs
@@ -62,8 +62,8 @@ pub async fn run(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
+    log::info!("Connected to NATS server at {}", args.nats.address);
 
     let stream = UnixStream::connect(&args.ipc_socket_path)
         .await
@@ -73,7 +73,7 @@ pub async fn run(
                 args.ipc_socket_path
             )
         })?;
-    log::info!("Connected to IPC socket at {}", &args.ipc_socket_path);
+    log::info!("Connected to IPC socket at {}", args.ipc_socket_path);
 
     let mut ipc_session = IpcClient::init(stream)
         .await

--- a/extractors/log/src/lib.rs
+++ b/extractors/log/src/lib.rs
@@ -51,20 +51,20 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
+    log::info!("Connected to NATS server at {}", args.nats.address);
 
-    log::info!("Opening bitcoind log pipe at {}...", &args.bitcoind_pipe);
+    log::info!("Opening bitcoind log pipe at {}...", args.bitcoind_pipe);
     let file = open_pipe(&args.bitcoind_pipe, shutdown_rx.clone())
         .await
         .with_context(|| format!("opening pipe {}", args.bitcoind_pipe))?;
-    log::info!("Opened bitcoind log pipe at {}", &args.bitcoind_pipe);
+    log::info!("Opened bitcoind log pipe at {}", args.bitcoind_pipe);
     let reader = BufReader::new(file);
     let mut lines = reader.lines();
 
     log::info!(
         "Started reading lines from bitcoind log pipe at {}",
-        &args.bitcoind_pipe
+        args.bitcoind_pipe
     );
     loop {
         tokio::select! {

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -101,7 +101,7 @@ fn spawn_pipe(log_path: String, pipe_path: String) {
         .arg(&pipe_path)
         .status()
         .expect("Failed to create named pipe");
-    info!("Created named pipe at {}", &pipe_path);
+    info!("Created named pipe at {}", pipe_path);
 
     // Start tail -f from debug.log to the pipe
     info!("Running: bash -c 'tail -f {} > {}'", log_path, pipe_path);

--- a/extractors/p2p/src/lib.rs
+++ b/extractors/p2p/src/lib.rs
@@ -149,8 +149,8 @@ pub async fn run(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
+    log::info!("Connected to NATS server at {}", args.nats.address);
 
     log::debug!("Starting TCP listener on {}..", args.p2p_address);
     let listener = TcpListener::bind(args.p2p_address.as_str())

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -141,8 +141,8 @@ pub async fn run(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
-    log::info!("Connected to NATS server at {}", &args.nats.address);
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
+    log::info!("Connected to NATS server at {}", args.nats.address);
 
     // Start the metric server with our custom registry. This happens after
     // the RPC client and NATS connection are set up so that any startup

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -549,8 +549,8 @@ async fn test_integration_rpc_getrawaddrman() {
                 if let Some(ref e) = r.rpc_event {
                     match e {
                         Addrman(addrman) => {
-                            for (_, bucket) in addrman.new.iter() {
-                                for (_, entry) in bucket.entries.iter() {
+                            for bucket in addrman.new.values() {
+                                for entry in bucket.entries.values() {
                                     assert_eq!(entry.address, "1.2.3.4");
                                     assert_eq!(entry.port, 1234);
                                 }

--- a/tools/alerts/src/lib.rs
+++ b/tools/alerts/src/lib.rs
@@ -183,7 +183,7 @@ pub async fn run<A: Alerter>(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
 
     let netmsg_sub = nc
         .subscribe(Subject::NetMsg.to_string())

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -264,7 +264,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
 
     let mut sub = nc
         .subscribe("*")

--- a/tools/connectivity-check/src/main.rs
+++ b/tools/connectivity-check/src/main.rs
@@ -30,6 +30,8 @@ use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+// allow the constants to be "dead" code, which looks like a false positive
+#[allow(dead_code)]
 mod metrics;
 
 const WORKERS: usize = 50;
@@ -326,7 +328,7 @@ async fn main() {
     let (output_sender, output_receiver) = unbounded();
 
     metricserver::start(&args.metrics_address, None).unwrap();
-    log::info!("metrics-server started on {}", &args.metrics_address);
+    log::info!("metrics-server started on {}", args.metrics_address);
 
     let nc = nats_util::prepare_connection(&args.nats)
         .expect("should be able to open a password file")

--- a/tools/logger/src/lib.rs
+++ b/tools/logger/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> anyhow::
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
 
     let mut sub = nc
         .subscribe("*")

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -116,7 +116,7 @@ pub async fn run(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
     info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc
         .subscribe("*")
@@ -812,8 +812,8 @@ fn handle_rpc_event(e: &rpc::RpcEvent, state_arc: Arc<Mutex<State>>, metrics: me
                     let mut sources: BTreeSet<String> = BTreeSet::new();
                     let mut source_asn: BTreeSet<u32> = BTreeSet::new();
 
-                    for (_, bucket) in table.iter() {
-                        for (_, entry) in bucket.entries.iter() {
+                    for bucket in table.values() {
+                        for entry in bucket.entries.values() {
                             table_stats
                                 .port_count
                                 .entry(entry.port as u16)

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -89,7 +89,7 @@ pub async fn run(
         .context("preparing NATS connection")?
         .connect(&args.nats.address)
         .await
-        .with_context(|| format!("connecting to NATS at {}", &args.nats.address))?;
+        .with_context(|| format!("connecting to NATS at {}", args.nats.address))?;
     log::info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc
         .subscribe("*")


### PR DESCRIPTION
For some reason, a newer linter now warns about the connectivity-check metrics.rs constants now being unused. Allow dead code there.

Additionally, remove the redundant `&` from a few places the linter complains about now.